### PR TITLE
better example for local file name pattern

### DIFF
--- a/docs/ja/source/application/administrator-guide.rst
+++ b/docs/ja/source/application/administrator-guide.rst
@@ -638,6 +638,6 @@ Asakusa Frameworkにはローカルファイル、及び分散ファイルシス
     # Directory for cleaning (required)
     clean.local-dir.0=/home/asakusa/asakusa/log
     # Cleaning Pattern (required)
-    clean.local-pattern.0=.*\.log\..*
+    clean.local-pattern.0=.*\.log.*
     # Preservation period date of file (optional)
     clean.local-keep-date=10


### PR DESCRIPTION
...an-localfs-conf.properties.

Since a value of clean.local-pattern.[n] is treated as a regular expression string of java.util.regexp.Pattern, an old value ".*\.log\.*" matches strings like "some.log" or "some.log......". The latter one is not a practical log file name. A new value ".*\.log.*" matches strings like "some.log" or "some.log.2011-12-06", which are practical as a log file name.
