### PR TITLE
an ambiguous message

### DIFF
--- a/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/session/SessionException.java
+++ b/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/session/SessionException.java
@@ -99,9 +99,9 @@ public class SessionException extends IOException {
         NOT_EXIST("The specified session does not exist yet"),
 
         /**
-         * The specified session was already acquired yet.
+         * The specified session was already acquired.
          */
-        ACQUIRED("The specified session was already acquired yet"),
+        ACQUIRED("The specified session was already acquired"),
 
         /**
          * The specified session was broken.


### PR DESCRIPTION
A word "already" contradicts a word "yet".
After the name of Reason enum instance "AQUIRED", I dropped the word "yet".
