### PR TITLE
Wrong index of the transaction parameter

### DIFF
--- a/dsl-project/ashigel-compiler/src/main/java/com/asakusafw/compiler/operator/processor/MasterKindOperatorAnalyzer.java
+++ b/dsl-project/ashigel-compiler/src/main/java/com/asakusafw/compiler/operator/processor/MasterKindOperatorAnalyzer.java
@@ -88,7 +88,7 @@ public final class MasterKindOperatorAnalyzer {
         DataModelMirror selectorTx = environment.loadDataModel(selectorParams.get(1).asType());
         if (isValidTx(operatorTx, selectorTx) == false) {
             throw new ResolveException(MessageFormat.format(
-                    "マスタ選択を行うメソッド{0}の1つめの引数は、{1}のスーパータイプでなければなりません",
+                    "マスタ選択を行うメソッド{0}の2つめの引数は、{1}のスーパータイプでなければなりません",
                     selectorMethod.getSimpleName(),
                     operatorTx));
         }


### PR DESCRIPTION
A transaction parameter in a MasterSelection operator method is the second parameter, not the first parameter.
