### PR TITLE
Make methods in Report.Delegate public.

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/Report.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/Report.java
@@ -250,7 +250,7 @@ hadoop jar ... -D com.asakusafw.runtime.core.Report.Delegate=com.example.MockRep
     /**
      * {@link Report}クラスの実体。
      * @since 0.1.0
-     * @version 0.5.1
+     * @version 0.7.4
      */
     public abstract static class Delegate implements RuntimeResource {
 
@@ -270,7 +270,7 @@ hadoop jar ... -D com.asakusafw.runtime.core.Report.Delegate=com.example.MockRep
          * @param message メッセージ
          * @throws IOException レポートの通知に失敗した場合
          */
-        protected abstract void report(Level level, String message) throws IOException;
+        public abstract void report(Level level, String message) throws IOException;
 
         /**
          * Notifies a report.
@@ -280,7 +280,7 @@ hadoop jar ... -D com.asakusafw.runtime.core.Report.Delegate=com.example.MockRep
          * @throws IOException if failed to notify this report by I/O error
          * @since 0.5.1
          */
-        protected void report(Level level, String message, Throwable throwable) throws IOException {
+        public void report(Level level, String message, Throwable throwable) throws IOException {
             report(level, message);
         }
     }
@@ -349,7 +349,7 @@ hadoop jar ... -D com.asakusafw.runtime.core.Report.Delegate=com.example.MockRep
     public static class Default extends Delegate {
 
         @Override
-        protected void report(Level level, String message) {
+        public void report(Level level, String message) {
             switch (level) {
             case INFO:
                 System.out.println(message);
@@ -371,7 +371,7 @@ hadoop jar ... -D com.asakusafw.runtime.core.Report.Delegate=com.example.MockRep
         }
 
         @Override
-        protected void report(Level level, String message, Throwable throwable) {
+        public void report(Level level, String message, Throwable throwable) {
             switch (level) {
             case INFO:
                 System.out.println(message);

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/report/CommonsLoggingReport.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/report/CommonsLoggingReport.java
@@ -34,7 +34,7 @@ public class CommonsLoggingReport extends Report.Delegate {
     static final Log LOG = LogFactory.getLog(CommonsLoggingReport.class);
 
     @Override
-    protected void report(Level level, String message) {
+    public void report(Level level, String message) {
         if (level == Level.ERROR) {
             if (LOG.isErrorEnabled()) {
                 LOG.error(message, new Exception("error"));
@@ -51,7 +51,7 @@ public class CommonsLoggingReport extends Report.Delegate {
     }
 
     @Override
-    protected void report(Level level, String message, Throwable throwable) throws IOException {
+    public void report(Level level, String message, Throwable throwable) throws IOException {
         if (level == Level.ERROR) {
             LOG.error(message, throwable);
         } else if (level == Level.WARN) {

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/core/ReportTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/core/ReportTest.java
@@ -70,7 +70,7 @@ public class ReportTest {
     public void info_error() {
         Report.setDelegate(new Report.Delegate() {
             @Override
-            protected void report(Level level, String message) throws IOException {
+            public void report(Level level, String message) throws IOException {
                 throw new IOException();
             }
         });
@@ -95,7 +95,7 @@ public class ReportTest {
     public void warn_error() {
         Report.setDelegate(new Report.Delegate() {
             @Override
-            protected void report(Level level, String message) throws IOException {
+            public void report(Level level, String message) throws IOException {
                 throw new IOException();
             }
         });
@@ -120,7 +120,7 @@ public class ReportTest {
     public void error_error() {
         Report.setDelegate(new Report.Delegate() {
             @Override
-            protected void report(Level level, String message) throws IOException {
+            public void report(Level level, String message) throws IOException {
                 throw new IOException();
             }
         });
@@ -157,7 +157,7 @@ public class ReportTest {
         static final List<String> messages = new ArrayList<String>();
 
         @Override
-        protected void report(Level level, String message) throws IOException {
+        public void report(Level level, String message) throws IOException {
             levels.add(level);
             messages.add(message);
         }

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/OperatorTestEnvironmentTest.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/OperatorTestEnvironmentTest.java
@@ -149,7 +149,7 @@ public class OperatorTestEnvironmentTest {
         static volatile String lastMessage;
 
         @Override
-        protected void report(Level level, String message) throws IOException {
+        public void report(Level level, String message) throws IOException {
             lastLevel = level;
             lastMessage = message;
         }


### PR DESCRIPTION
The Report API is also used in other execution environments, like as [Asakusa on Spark](https://github.com/asakusafw/asakusafw-spark). This improvement will simplify to use the API from such environments.

Note that this breaks source compatibility of Report API **implementations** (not application code).