### PR TITLE
Fix a test case for Mac OS X.

### DIFF
--- a/windgate-project/asakusa-windgate-bootstrap/src/test/java/com/asakusafw/windgate/bootstrap/CommandLineUtilTest.java
+++ b/windgate-project/asakusa-windgate-bootstrap/src/test/java/com/asakusafw/windgate/bootstrap/CommandLineUtilTest.java
@@ -115,7 +115,7 @@ public class CommandLineUtilTest {
         buf.append(File.pathSeparatorChar);
         buf.append(c);
         List<File> result = canonicalize(CommandLineUtil.parseFileList(buf.toString()));
-        assertThat(result, is(Arrays.asList(a, b, c)));
+        assertThat(result, is(canonicalize(a, b, c)));
     }
 
     /**
@@ -124,7 +124,7 @@ public class CommandLineUtilTest {
     @Test
     public void parseFileList_null() {
         List<File> result = canonicalize(CommandLineUtil.parseFileList(null));
-        assertThat(result, is(Arrays.<File>asList()));
+        assertThat(result, is(canonicalize()));
     }
 
     /**
@@ -133,7 +133,11 @@ public class CommandLineUtilTest {
     @Test
     public void parseFileList_empty() {
         List<File> result = canonicalize(CommandLineUtil.parseFileList(""));
-        assertThat(result, is(Arrays.<File>asList()));
+        assertThat(result, is(canonicalize()));
+    }
+
+    private List<File> canonicalize(File... files) {
+        return canonicalize(Arrays.asList(files));
     }
 
     private List<File> canonicalize(List<File> list) {


### PR DESCRIPTION
On Mac OS X, the temporary directory location is in `/var/folders/..`,
but its canonical path is `/private/var/folders/..`.