### PR TITLE
YAESS extensions should be passed via environment vars instead.

### DIFF
--- a/yaess-project/asakusa-yaess-core/src/main/java/com/asakusafw/yaess/basic/ProcessUtil.java
+++ b/yaess-project/asakusa-yaess-core/src/main/java/com/asakusafw/yaess/basic/ProcessUtil.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -42,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import com.asakusafw.yaess.core.Blob;
 import com.asakusafw.yaess.core.ExecutionContext;
+import com.asakusafw.yaess.core.ExecutionScriptHandler;
 import com.asakusafw.yaess.core.VariableResolver;
 import com.asakusafw.yaess.core.util.PropertiesUtil;
 import com.asakusafw.yaess.core.util.StreamRedirectTask;
@@ -241,14 +243,15 @@ final class ProcessUtil {
             Map<String, String> env,
             Map<String, Blob> extensions,
             OutputStream output) throws InterruptedException, IOException {
-        List<String> newCommand = new ArrayList<>();
-        newCommand.addAll(command);
+        Map<String, String> newEnv = new LinkedHashMap<>();
+        newEnv.putAll(env);
         try (TemporaryFiles temporaries = new TemporaryFiles()) {
             for (Map.Entry<String, Blob> entry : extensions.entrySet()) {
+                String name = entry.getKey();
                 String token = resolve(entry.getKey(), entry.getValue(), temporaries);
-                newCommand.add(token);
+                newEnv.put(ExecutionScriptHandler.ENV_EXTENSION_PREFIX + name, token);
             }
-            return execute(context, newCommand, env, output);
+            return execute(context, command, newEnv, output);
         }
     }
 

--- a/yaess-project/asakusa-yaess-core/src/main/java/com/asakusafw/yaess/core/ExecutionScriptHandler.java
+++ b/yaess-project/asakusa-yaess-core/src/main/java/com/asakusafw/yaess/core/ExecutionScriptHandler.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * implement {@link HadoopScriptHandler} or {@link CommandScriptHandler} instead.
  * @param <T> the type of script
  * @since 0.2.3
- * @version 0.2.6
+ * @version 0.8.0
  */
 public interface ExecutionScriptHandler<T extends ExecutionScript> extends Service {
 
@@ -55,6 +55,12 @@ public interface ExecutionScriptHandler<T extends ExecutionScript> extends Servi
      * The default value of {@link #getResourceId(ExecutionContext, ExecutionScript) resource ID}.
      */
     String DEFAULT_RESOURCE_ID = "default";
+
+    /**
+     * The prefix of environment variable names for each extension {@link Blob}s.
+     * @since 0.8.0
+     */
+    String ENV_EXTENSION_PREFIX = "ASAKUSA_EXTENSION_";
 
     /**
      * Returns the ID of this handler.

--- a/yaess-project/asakusa-yaess-core/src/test/resources/com/asakusafw/yaess/basic/arguments.sh
+++ b/yaess-project/asakusa-yaess-core/src/test/resources/com/asakusafw/yaess/basic/arguments.sh
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-
 _OUTPUT="$0.out"
 touch "$_OUTPUT"
 
@@ -25,3 +24,5 @@ do
 done
 
 cat "$_OUTPUT"
+
+exit 0

--- a/yaess-project/asakusa-yaess-core/src/test/resources/com/asakusafw/yaess/basic/blob.sh
+++ b/yaess-project/asakusa-yaess-core/src/test/resources/com/asakusafw/yaess/basic/blob.sh
@@ -15,23 +15,19 @@
 # limitations under the License.
 #
 
-if [ $# -ne 2 ]
-then
-    echo "invalid arguments"
-    exit 1
-fi
-
 _OUTPUT="$0.out"
-_MAIN="$1"
-_BLOB="$2"
+touch "$_OUTPUT"
 
-echo "$_MAIN" >> "$_OUTPUT"
+for line in "$@"
+do
+    echo "$line" >> "$_OUTPUT"
+done
 
-if [ -e "$_BLOB" ]
+if [ -e "$ASAKUSA_EXTENSION_testing" ]
 then
-    cat "$_BLOB" >> "$_OUTPUT"
-else
-    echo "MISSING FILE: $_BLOB" >> "$_OUTPUT"
+    cat "$ASAKUSA_EXTENSION_testing" >> "$_OUTPUT"
 fi
+
+cat "$_OUTPUT"
 
 exit 0

--- a/yaess-project/asakusa-yaess-jsch/src/test/resources/com/asakusafw/yaess/jsch/arguments.sh
+++ b/yaess-project/asakusa-yaess-jsch/src/test/resources/com/asakusafw/yaess/jsch/arguments.sh
@@ -15,7 +15,6 @@
 # limitations under the License.
 #
 
-
 _OUTPUT="$0.out"
 touch "$_OUTPUT"
 
@@ -25,3 +24,5 @@ do
 done
 
 cat "$_OUTPUT"
+
+exit 0

--- a/yaess-project/asakusa-yaess-jsch/src/test/resources/com/asakusafw/yaess/jsch/blob.sh
+++ b/yaess-project/asakusa-yaess-jsch/src/test/resources/com/asakusafw/yaess/jsch/blob.sh
@@ -15,23 +15,19 @@
 # limitations under the License.
 #
 
-if [ $# -ne 2 ]
-then
-    echo "invalid arguments"
-    exit 1
-fi
-
 _OUTPUT="$0.out"
-_MAIN="$1"
-_BLOB="$2"
+touch "$_OUTPUT"
 
-echo "$_MAIN" >> "$_OUTPUT"
+for line in "$@"
+do
+    echo "$line" >> "$_OUTPUT"
+done
 
-if [ -e "$_BLOB" ]
+if [ -e "$ASAKUSA_EXTENSION_testing" ]
 then
-    cat "$_BLOB" >> "$_OUTPUT"
-else
-    echo "MISSING FILE: $_BLOB" >> "$_OUTPUT"
+    cat "$ASAKUSA_EXTENSION_testing" >> "$_OUTPUT"
 fi
+
+cat "$_OUTPUT"
 
 exit 0


### PR DESCRIPTION
In #546, YAESS passes extensions via extra command arguments.
From this commit, YAESS will pass it via environment variables
named `ASAKUSA_EXTENSION_<name>`, and no extra arguments will be
passed.

For example, `yaess-batch.sh ... -E hoge=/path/to/extension` will
pass the extension file contents via `ASAKUSA_EXTENSION_hoge`
(only if each task accepts the `hoge` extension).