### PR TITLE
Add workaround for old snappy-java on Mac.

### DIFF
--- a/core-project/asakusa-runtime-all/pom.xml
+++ b/core-project/asakusa-runtime-all/pom.xml
@@ -52,6 +52,11 @@
       <artifactId>asakusa-runtime-inprocess</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>asakusa-runtime-workaround</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/core-project/asakusa-runtime-workaround/.gitignore
+++ b/core-project/asakusa-runtime-workaround/.gitignore
@@ -1,0 +1,5 @@
+/.settings
+/target
+/.classpath
+/.project
+/bin

--- a/core-project/asakusa-runtime-workaround/pom.xml
+++ b/core-project/asakusa-runtime-workaround/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <name>Workaround for Asakusa Runtime Libraries</name>
+  <artifactId>asakusa-runtime-workaround</artifactId>
+  <parent>
+    <artifactId>asakusa-core-project</artifactId>
+    <groupId>com.asakusafw</groupId>
+    <version>0.8.0-SNAPSHOT</version>
+  </parent>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>asakusa-runtime</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>${hadoop.artifact.id}</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/core-project/asakusa-runtime-workaround/src/main/java/com/asakusafw/runtime/workaround/RuntimeWorkaround.java
+++ b/core-project/asakusa-runtime-workaround/src/main/java/com/asakusafw/runtime/workaround/RuntimeWorkaround.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2011-2015 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.workaround;
+
+/**
+ * Constants about workaround settings.
+ * @since 0.8.0
+ */
+public final class RuntimeWorkaround {
+
+    /**
+     * The common Hadoop property key prefix of workaround settings.
+     */
+    public static final String KEY_PREFIX = "com.asakusafw.workaround."; //$NON-NLS-1$
+
+    private RuntimeWorkaround() {
+        return;
+    }
+}

--- a/core-project/asakusa-runtime-workaround/src/main/java/com/asakusafw/runtime/workaround/package-info.java
+++ b/core-project/asakusa-runtime-workaround/src/main/java/com/asakusafw/runtime/workaround/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2015 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Workaround for Asakusa runtime libraries.
+ */
+package com.asakusafw.runtime.workaround;

--- a/core-project/asakusa-runtime-workaround/src/main/java/com/asakusafw/runtime/workaround/snappyjava/MacSnappyJavaWorkaround.java
+++ b/core-project/asakusa-runtime-workaround/src/main/java/com/asakusafw/runtime/workaround/snappyjava/MacSnappyJavaWorkaround.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2011-2015 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.workaround.snappyjava;
+
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.Job;
+import org.xerial.snappy.OSInfo;
+import org.xerial.snappy.SnappyLoader;
+
+import com.asakusafw.runtime.stage.StageConfigurator;
+import com.asakusafw.runtime.workaround.RuntimeWorkaround;
+
+/**
+ * Workaround for {@code snappy-java} on Mac OSX.
+ * @since 0.8.0
+ */
+public class MacSnappyJavaWorkaround extends StageConfigurator {
+
+    static final Log LOG = LogFactory.getLog(MacSnappyJavaWorkaround.class);
+
+    private static final String KEY_PREFIX = RuntimeWorkaround.KEY_PREFIX + "snappyjava."; //$NON-NLS-1$
+
+    /**
+     * The configuration key of whether this feature is enabled or not.
+     */
+    public static final String KEY_ENABLED = KEY_PREFIX + "enabled"; //$NON-NLS-1$
+
+    /**
+     * The configuration key of whether skip installing for unrecognized versions or not.
+     */
+    public static final String KEY_SKIP_ON_UNKNOWN = KEY_PREFIX + "skipOnUnknown"; //$NON-NLS-1$
+
+    static final boolean DEFAULT_ENABLED = true;
+
+    static final boolean DEFAULT_SKIP_ON_UNKNOWN = true;
+
+    private static final Pattern PATTERN_VERSION =
+            Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)([\\.\\-].+)?"); //$NON-NLS-1$
+
+    /**
+     * The fixed snappy-java version.
+     * @see <a href="https://github.com/xerial/snappy-java/blob/develop/Milestone.md#snappy-java-111-m4-4-july-2014">
+     *    snappy-java-1.1.1-M4
+     * </a>
+     */
+    private static final int[] FIXED_VERSION = { 1, 1, 1 };
+
+    @Override
+    public void configure(Job job) throws IOException, InterruptedException {
+        Configuration conf = job.getConfiguration();
+        if (conf.getBoolean(KEY_ENABLED, DEFAULT_ENABLED) == false) {
+            return;
+        }
+        install(conf.getBoolean(KEY_SKIP_ON_UNKNOWN, DEFAULT_SKIP_ON_UNKNOWN));
+    }
+
+    /**
+     * Installs workaround for {@code snappy-java} if it is effective.
+     */
+    public static void install() {
+        install(DEFAULT_SKIP_ON_UNKNOWN);
+    }
+
+    /**
+     * Installs workaround for {@code snappy-java} if it is effective.
+     * @param skipOnUnknown {@code true} to skip if version is unrecognized, otherwise {@code false}
+     */
+    public static void install(boolean skipOnUnknown) {
+        String os = OSInfo.getOSName();
+        if (os == null || os.equalsIgnoreCase("mac") == false) { //$NON-NLS-1$
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(MessageFormat.format(
+                        "not a snappy-java workaround target: os={0}", //$NON-NLS-1$
+                        os));
+            }
+            return;
+        }
+        if (isFixed(skipOnUnknown)) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(MessageFormat.format(
+                        "not a snappy-java workaround target: version={0}", //$NON-NLS-1$
+                        SnappyLoader.getVersion()));
+            }
+            return;
+        }
+        // isFixed() -> SnappyLoader.<clinit> may change System.properties
+        if (System.getProperty(SnappyLoader.KEY_SNAPPY_LIB_NAME) != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(MessageFormat.format(
+                        "not a snappy-java workaround target: defined {0}={1}", //$NON-NLS-1$
+                        SnappyLoader.KEY_SNAPPY_LIB_NAME,
+                        System.getProperty(SnappyLoader.KEY_SNAPPY_LIB_NAME)));
+            }
+            return;
+        }
+        LOG.info(MessageFormat.format(
+                "installing snappy-java workaround for Mac OSX: version={0}",
+                SnappyLoader.getVersion()));
+        System.setProperty(SnappyLoader.KEY_SNAPPY_LIB_NAME, "libsnappyjava.jnilib"); //$NON-NLS-1$
+    }
+
+    private static boolean isFixed(boolean skipOnUnknown) {
+        String versionString = SnappyLoader.getVersion();
+        Matcher matcher = PATTERN_VERSION.matcher(versionString);
+        if (matcher.matches() == false) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(MessageFormat.format(
+                        "unrecognized snappy-java version: {0}", //$NON-NLS-1$
+                        versionString));
+            }
+            return skipOnUnknown;
+        }
+        int[] version = {
+                Integer.parseInt(matcher.group(1)),
+                Integer.parseInt(matcher.group(2)),
+                Integer.parseInt(matcher.group(3)),
+        };
+        int[] required = FIXED_VERSION;
+        assert required.length == version.length;
+        for (int i = 0; i < version.length; i++) {
+            int v = version[i];
+            int r = required[i];
+            if (v > r) {
+                return true;
+            } else if (v < r) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/core-project/asakusa-runtime-workaround/src/main/java/com/asakusafw/runtime/workaround/snappyjava/package-info.java
+++ b/core-project/asakusa-runtime-workaround/src/main/java/com/asakusafw/runtime/workaround/snappyjava/package-info.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2011-2015 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Workaround for {@code snappy-java}.
+ * @see <a href="https://github.com/xerial/snappy-java.git">GitHub site</a>
+ */
+package com.asakusafw.runtime.workaround.snappyjava;

--- a/core-project/asakusa-runtime-workaround/src/main/resources/META-INF/services/com.asakusafw.runtime.stage.StageConfigurator
+++ b/core-project/asakusa-runtime-workaround/src/main/resources/META-INF/services/com.asakusafw.runtime.stage.StageConfigurator
@@ -1,0 +1,1 @@
+com.asakusafw.runtime.workaround.snappyjava.MacSnappyJavaWorkaround

--- a/core-project/pom.xml
+++ b/core-project/pom.xml
@@ -19,6 +19,7 @@
     <module>asakusa-runtime-configuration</module>
     <module>asakusa-simple-mapreduce</module>
     <module>asakusa-runtime-inprocess</module>
+    <module>asakusa-runtime-workaround</module>
     <module>asakusa-runtime-all</module>
   </modules>
 

--- a/testing-project/asakusa-test-driver/pom.xml
+++ b/testing-project/asakusa-test-driver/pom.xml
@@ -17,14 +17,14 @@
         <directory>src/main/resources</directory>
         <filtering>true</filtering>
         <includes>
-          <include>**/*.properties</include>
+          <include>**/information.properties</include>
         </includes>
       </resource>
       <resource>
         <directory>src/main/resources</directory>
         <filtering>false</filtering>
         <excludes>
-          <exclude>**/*.properties</exclude>
+          <exclude>**/information.properties</exclude>
         </excludes>
       </resource>
     </resources>
@@ -162,6 +162,11 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>asakusa-runtime-inprocess</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>asakusa-runtime-workaround</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/configurator/SnappyConfigurator.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/configurator/SnappyConfigurator.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xerial.snappy.Snappy;
 
+import com.asakusafw.runtime.workaround.snappyjava.MacSnappyJavaWorkaround;
 import com.asakusafw.testdriver.core.TestingEnvironmentConfigurator;
 
 /**
@@ -46,6 +47,7 @@ public class SnappyConfigurator extends TestingEnvironmentConfigurator {
             return;
         }
         // Preloads native snappy library.
+        MacSnappyJavaWorkaround.install();
         Snappy.getNativeLibraryVersion();
     }
 

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/TesterTestRoot.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/TesterTestRoot.java
@@ -22,6 +22,7 @@ import org.junit.Rule;
 import com.asakusafw.runtime.configuration.FrameworkDeployer;
 import com.asakusafw.runtime.mapreduce.simple.SimpleJobRunner;
 import com.asakusafw.runtime.stage.inprocess.InProcessStageConfigurator;
+import com.asakusafw.runtime.workaround.RuntimeWorkaround;
 import com.asakusafw.utils.io.Sources;
 
 /**
@@ -33,6 +34,7 @@ public abstract class TesterTestRoot {
         InProcessStageConfigurator.class,
         SimpleJobRunner.class,
         Sources.class,
+        RuntimeWorkaround.class,
     };
 
     /**


### PR DESCRIPTION
Some Hadoop distributions contain old versions of `snappy-java`, and they don't work well on Mac with JDK7+. This workaround will fix its problem.

Hadoop configurations:

`com.asakusafw.workaround.snappyjava.enabled`
  whether the feature is enabled or not (default: `true`)

`com.asakusafw.workaround.snappyjava.skipOnUnknown`
  whether skip unrecognized versions or not (default: `true`)