### PR TITLE
Add IntelliJ-generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /.project
 .DS_Store
 *.swp
+*.iml
+.idea


### PR DESCRIPTION
## Summary

`.idea` and `*.iml` is automatically-generated files by IntelliJ, which floods the result of `git status`.
