### PR TITLE
Add licene-maven pom definition to build-tools

### DIFF
--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -63,6 +63,22 @@
         <artifactId>maven-deploy-plugin</artifactId>
         <version>2.8.1</version>
       </plugin>
+      <plugin>
+        <groupId>com.mycila</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>2.11</version>
+        <configuration>
+          <aggregate>true</aggregate>
+          <strictCheck>true</strictCheck>
+          <header>/com/asakusafw/source-header.txt</header>
+          <excludes>
+            <exclude>**/*.html</exclude>
+            <exclude>**/*.xml</exclude>
+            <exclude>**/*.txt</exclude>
+          </excludes>
+          <encoding>UTF-8</encoding>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## Summary

Add licene-maven-plugin pom definition to build-tools

## Background, Problem or Goal of the patch

Fix fail to run `mvn license:check` on asakusafw root directory
because of missing licene-maven-plugin definition to  pom.xml on build-tools project.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.

## Wanted reviewer
N/A.
