### PR TITLE
Add Hive schema info generator to Hive SDK artifact

### DIFF
--- a/sdk-project/asakusa-sdk-app-hive/.gitignore
+++ b/sdk-project/asakusa-sdk-app-hive/.gitignore
@@ -1,0 +1,4 @@
+/.settings
+/target
+/.classpath
+/.project

--- a/sdk-project/asakusa-sdk-app-hive/pom.xml
+++ b/sdk-project/asakusa-sdk-app-hive/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <name>Asakusa App SDK Hive</name>
+  <artifactId>asakusa-sdk-app-hive</artifactId>
+  <parent>
+    <artifactId>asakusa-sdk-project</artifactId>
+    <groupId>com.asakusafw.sdk</groupId>
+    <version>0.8.1-SNAPSHOT</version>
+  </parent>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.asakusafw</groupId>
+      <artifactId>asakusa-hive-plugin</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/sdk-project/asakusa-sdk-hive/pom.xml
+++ b/sdk-project/asakusa-sdk-hive/pom.xml
@@ -45,6 +45,11 @@
     </dependency>
     <dependency>
       <groupId>com.asakusafw.sdk</groupId>
+      <artifactId>asakusa-sdk-app-hive</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.asakusafw.sdk</groupId>
       <artifactId>asakusa-sdk-dmdl-hive</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/sdk-project/pom.xml
+++ b/sdk-project/pom.xml
@@ -22,6 +22,7 @@
     <module>asakusa-sdk-app-windgate</module>
     <module>asakusa-sdk-test-windgate</module>
     <module>asakusa-sdk-dmdl-windgate</module>
+    <module>asakusa-sdk-app-hive</module>
     <module>asakusa-sdk-dmdl-hive</module>
     <module>asakusa-sdk-core</module>
     <module>asakusa-sdk-directio</module>


### PR DESCRIPTION
## Summary
This PR adds `com.asakusafw:asakusa-hive-plugin`  ( see: #625 ) to `asakusafw-sdk-hive`

## Background, Problem or Goal of the patch
Executes Hive schema info generator at MapReduce DSL Compile ( ex. run at `mapreduceCompileBatchapps` )

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
#625

## Wanted reviewer
N/A.
