### PR TITLE
Fix the region name

### DIFF
--- a/dmdl-project/asakusa-dmdl-core/src/main/javacc/DmdlParser.jj
+++ b/dmdl-project/asakusa-dmdl-core/src/main/javacc/DmdlParser.jj
@@ -1044,7 +1044,7 @@ private List<AstAttributeElement> AttributeElementList() :
 */
 private AstAttributeElement AttributeElement() :
 {
-    begin("attribute-element-list");
+    begin("attribute-element");
     AstSimpleName name;
     AstAttributeValue value;
 }
@@ -1053,7 +1053,7 @@ private AstAttributeElement AttributeElement() :
     "="
     value = AttributeValue()
     {
-        Region region = end("attribute-element-list");
+        Region region = end("attribute-element");
         return new AstAttributeElement(region, name, value);
     }
 }


### PR DESCRIPTION
## Summary

The region name for the AttributeElement rule should be "attribute-element."

## Background, Problem or Goal of the patch

Change the region name for the AttributeElement rule from "attribute-element-list" to "attribute-element."

## Design of the fix, or a new feature

N/A

## Related Issue, Pull Request or Code

N/A

## Wanted reviewer

ashigeru