### PR TITLE
Introduce VOID resource to WindGate.

### DIFF
--- a/windgate-project/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/GateProfile.java
+++ b/windgate-project/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/GateProfile.java
@@ -28,6 +28,7 @@ import com.asakusafw.windgate.core.process.ProcessProfile;
 import com.asakusafw.windgate.core.process.ProcessProvider;
 import com.asakusafw.windgate.core.resource.ResourceProfile;
 import com.asakusafw.windgate.core.session.SessionProfile;
+import com.asakusafw.windgate.core.util.VoidResourceProvider;
 
 /**
  * A total profile for WindGate execution.
@@ -179,6 +180,24 @@ public class GateProfile {
             WGLOG.warn("W02001",
                     copy.keySet());
         }
+        resources = addVoidResource(resources, context);
         return new GateProfile(name, core, session, processes, resources);
+    }
+
+    private static Collection<? extends ResourceProfile> addVoidResource(
+            Collection<? extends ResourceProfile> resources, ProfileContext context) {
+        for (ResourceProfile profile : resources) {
+            if (profile.getName().equals(VoidResourceProvider.NAME)) {
+                return resources;
+            }
+        }
+        List<ResourceProfile> results = new ArrayList<>(resources.size() + 1);
+        results.addAll(resources);
+        results.add(new ResourceProfile(
+                VoidResourceProvider.NAME,
+                VoidResourceProvider.class,
+                context,
+                Collections.<String, String>emptyMap()));
+        return results;
     }
 }

--- a/windgate-project/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/util/VoidDrainDriver.java
+++ b/windgate-project/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/util/VoidDrainDriver.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.windgate.core.util;
+
+import com.asakusafw.windgate.core.resource.DrainDriver;
+
+/**
+ * A void implementation of {@link DrainDriver} which drops any inputs.
+ * @param <T> the data model type.
+ * @since 0.8.1
+ */
+public class VoidDrainDriver<T> implements DrainDriver<T> {
+
+    @Override
+    public void prepare() {
+        return;
+    }
+
+    @Override
+    public void put(T object) {
+        return;
+    }
+
+    @Override
+    public void close() {
+        return;
+    }
+}

--- a/windgate-project/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/util/VoidResourceProvider.java
+++ b/windgate-project/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/util/VoidResourceProvider.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.windgate.core.util;
+
+import java.io.IOException;
+
+import com.asakusafw.windgate.core.GateScript;
+import com.asakusafw.windgate.core.ParameterList;
+import com.asakusafw.windgate.core.ProcessScript;
+import com.asakusafw.windgate.core.resource.DrainDriver;
+import com.asakusafw.windgate.core.resource.ResourceManipulator;
+import com.asakusafw.windgate.core.resource.ResourceMirror;
+import com.asakusafw.windgate.core.resource.ResourceProfile;
+import com.asakusafw.windgate.core.resource.ResourceProvider;
+import com.asakusafw.windgate.core.resource.SourceDriver;
+
+/**
+ * Provides void resources.
+ * @since 0.8.1
+ */
+public class VoidResourceProvider extends ResourceProvider {
+
+    private static final ResourceMirror MIRROR = new Mirror();
+
+    private static final ResourceManipulator MANIPULATOR = new Manipulator();
+
+    /**
+     * The resource name.
+     */
+    public static final String NAME = "void"; //$NON-NLS-1$
+
+    @Override
+    public ResourceMirror create(String sessionId, ParameterList arguments) throws IOException {
+        return MIRROR;
+    }
+
+    @Override
+    public ResourceManipulator createManipulator(ParameterList arguments) throws IOException {
+        return MANIPULATOR;
+    }
+
+    @Override
+    protected void configure(ResourceProfile profile) throws IOException {
+        return;
+    }
+
+    private static class Mirror extends ResourceMirror {
+
+        Mirror() {
+            return;
+        }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+
+        @Override
+        public void prepare(GateScript script) throws IOException {
+            return;
+        }
+
+        @Override
+        public <T> SourceDriver<T> createSource(ProcessScript<T> script) throws IOException {
+            return new VoidSourceDriver<>();
+        }
+
+        @Override
+        public <T> DrainDriver<T> createDrain(ProcessScript<T> script) throws IOException {
+            return new VoidDrainDriver<>();
+        }
+
+        @Override
+        public void close() throws IOException {
+            return;
+        }
+    }
+
+    private static class Manipulator extends ResourceManipulator {
+
+        Manipulator() {
+            return;
+        }
+
+        @Override
+        public String getName() {
+            return NAME;
+        }
+
+        @Override
+        public void cleanupSource(ProcessScript<?> script) throws IOException {
+            return;
+        }
+
+        @Override
+        public void cleanupDrain(ProcessScript<?> script) throws IOException {
+            return;
+        }
+
+        @Override
+        public <T> SourceDriver<T> createSourceForSource(ProcessScript<T> script) throws IOException {
+            return new VoidSourceDriver<>();
+        }
+
+        @Override
+        public <T> DrainDriver<T> createDrainForSource(ProcessScript<T> script) throws IOException {
+            return new VoidDrainDriver<>();
+        }
+
+        @Override
+        public <T> SourceDriver<T> createSourceForDrain(ProcessScript<T> script) throws IOException {
+            return new VoidSourceDriver<>();
+        }
+
+        @Override
+        public <T> DrainDriver<T> createDrainForDrain(ProcessScript<T> script) throws IOException {
+            return new VoidDrainDriver<>();
+        }
+    }
+}

--- a/windgate-project/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/util/VoidSourceDriver.java
+++ b/windgate-project/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/util/VoidSourceDriver.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.windgate.core.util;
+
+import com.asakusafw.windgate.core.resource.SourceDriver;
+
+/**
+ * The void implementation of {@link SourceDriver} which provides nothing.
+ * @param <T> the data model type
+ * @since 0.8.1
+ */
+public class VoidSourceDriver<T> implements SourceDriver<T> {
+
+    @Override
+    public void prepare() {
+        return;
+    }
+
+    @Override
+    public boolean next() {
+        return false;
+    }
+
+    @Override
+    public T get() {
+        throw new IllegalStateException();
+    }
+
+    @Override
+    public void close() {
+        return;
+    }
+}

--- a/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/Constants.java
+++ b/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/Constants.java
@@ -18,6 +18,7 @@ package com.asakusafw.vocabulary.windgate;
 /**
  * The common constants of WindGate vocabularies.
  * @since 0.2.2
+ * @version 0.8.1
  */
 public final class Constants {
 
@@ -35,6 +36,12 @@ public final class Constants {
      * The abstract resource name of local file systems.
      */
     public static final String LOCAL_FILE_RESOURCE_NAME = "local"; //$NON-NLS-1$
+
+    /**
+     * The abstract resource name of void inputs/outputs.
+     * @since 0.8.1
+     */
+    public static final String VOID_RESOURCE_NAME = "void"; //$NON-NLS-1$
 
     /**
      * The default process provider name.


### PR DESCRIPTION
## Summary

This commit introduces `void` resource into WindGate.

## Background, Problem or Goal of the patch

Current `hadoop` resource always requires one or more input paths to execute data transferring. But in some situations, only resource initialization operation is required without any inputs. For example, some optimization will remove all upstream sources to WindGate outputs (asakusafw/asakusafw-compiler#54).

## Design of the fix, or a new feature

This commit introduces `void` resource, and it is automatically enabled even if it is explicitly declared in each WindGate profile file.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-compiler#54

## Wanted reviewer

@akirakw