### PR TITLE
Reduce synchronized scope in `Shared.get()`.

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/util/Shared.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/util/Shared.java
@@ -16,7 +16,6 @@
 package com.asakusafw.runtime.core.util;
 
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * An abstract super class of shared object holder for operator classes.
@@ -50,7 +49,7 @@ public abstract class SomeOperator {
  */
 public abstract class Shared<T> {
 
-    private final AtomicReference<T> shared = new AtomicReference<>();
+    private volatile T shared;
 
     private boolean initialized;
 
@@ -62,7 +61,7 @@ public abstract class Shared<T> {
      * @throws Shared.InitializationException if failed to initialize the shared value
      */
     public final T get() {
-        T cached = shared.get();
+        T cached = shared;
         if (cached != null) {
             return cached;
         }
@@ -74,7 +73,7 @@ public abstract class Shared<T> {
                     throw new InitializationException("failed to initialize shared value", e);
                 }
             }
-            return shared.get();
+            return shared;
         }
     }
 
@@ -86,7 +85,7 @@ public abstract class Shared<T> {
      */
     public final void remove() {
         synchronized (this) {
-            this.shared.set(null);
+            this.shared = null;
             this.initialized = false;
         }
     }
@@ -100,7 +99,7 @@ public abstract class Shared<T> {
      */
     public final void set(T value) {
         synchronized (this) {
-            this.shared.set(value);
+            this.shared = value;
             this.initialized = true;
         }
     }

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/core/util/SharedTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/core/util/SharedTest.java
@@ -44,6 +44,7 @@ public class SharedTest {
         assertThat(shared.get(), is(0));
         assertThat(shared.isInitialzed(), is(true));
         assertThat(shared.get(), is(0));
+        assertThat(shared.get(), is(0));
 
         shared.remove();
         assertThat(shared.isInitialzed(), is(false));


### PR DESCRIPTION
## Summary

This PR may improve performance of `Shared.get()`.

## Background, Problem or Goal of the patch

In the latest implementation, `Shared.get()` always enters the object monitor. This PR reduces `synchronized` scope and use `AtomicReference` to provide the shared value outside the `synchronized`.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@shino 