### PR TITLE
Revise error message on Direct I/O input missing.

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/DirectDataSource.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/DirectDataSource.java
@@ -58,10 +58,20 @@ import com.asakusafw.runtime.io.ModelOutput;
  * </li>
  * </ol>
  * @since 0.2.5
- * @version 0.7.0
+ * @version 0.8.1
  * @see AbstractDirectDataSource
  */
 public interface DirectDataSource {
+
+    /**
+     * Returns a textually representation of the target path pattern.
+     * @param basePath base path of target resources
+     * @param resourcePattern search pattern of target resources from {@code basePath}
+     * @return the found resources, or an empty list if there are no resources
+     * @throws IllegalArgumentException if some parameters were {@code null}
+     * @since 0.8.1
+     */
+    String path(String basePath, ResourcePattern resourcePattern);
 
     /**
      * Collects input fragments about target resources.

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/hadoop/HadoopDataSource.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/hadoop/HadoopDataSource.java
@@ -86,6 +86,11 @@ public class HadoopDataSource extends AbstractDirectDataSource implements Config
     }
 
     @Override
+    public String path(String basePath, ResourcePattern resourcePattern) {
+        return core.path(basePath, resourcePattern);
+    }
+
+    @Override
     public <T> List<DirectInputFragment> findInputFragments(
             DataDefinition<T> definition,
             String basePath,

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/hadoop/HadoopDataSourceCore.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/hadoop/HadoopDataSourceCore.java
@@ -73,6 +73,14 @@ public class HadoopDataSourceCore implements DirectDataSource {
     }
 
     @Override
+    public String path(String basePath, ResourcePattern resourcePattern) {
+        HadoopDataSourceProfile p = profile;
+        Path root = p.getFileSystemPath();
+        Path base = append(root, basePath);
+        return String.format("%s/%s", base, resourcePattern); //$NON-NLS-1$
+    }
+
+    @Override
     public <T> List<DirectInputFragment> findInputFragments(
             DataDefinition<T> definition,
             String basePath,

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/keepalive/KeepAliveDataSource.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/keepalive/KeepAliveDataSource.java
@@ -55,6 +55,11 @@ public class KeepAliveDataSource implements DirectDataSource {
     }
 
     @Override
+    public String path(String basePath, ResourcePattern resourcePattern) {
+        return entity.path(basePath, resourcePattern);
+    }
+
+    @Override
     public <T> List<DirectInputFragment> findInputFragments(
             DataDefinition<T> definition,
             String basePath,

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/stage/input/BridgeInputFormat.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/stage/input/BridgeInputFormat.java
@@ -158,34 +158,22 @@ public final class BridgeInputFormat extends InputFormat<NullWritable, Object> {
             dataSource.findInputFragments(definition, path.componentPath, path.pattern);
         if (fragments.isEmpty()) {
             String id = repo.getRelatedId(group.containerPath);
-            String containerPath = repo.getContainerPath(group.containerPath);
+            String pathString = dataSource.path(path.componentPath, path.pattern);
             if (path.optional) {
                 LOG.info(MessageFormat.format(
-                        "Skipped optional input (datasource={0}, basePath=\"{1}\", resourcePattern=\"{2}\", type={3})",
+                        "Skipped optional input (datasource={0}, path=\"{1}\", type={2})",
                         id,
-                        getBasePath(containerPath, path),
-                        path.pattern,
+                        pathString,
                         definition.getDataFormat().getSupportedType().getName()));
             } else {
                 throw new IOException(MessageFormat.format(
-                        "Input not found (datasource={0}, basePath=\"{1}\", resourcePattern=\"{2}\", type={3})",
+                        "Input not found (datasource={0}, path=\"{1}\", type={2})",
                         id,
-                        getBasePath(containerPath, path),
-                        path.pattern,
+                        pathString,
                         definition.getDataFormat().getSupportedType().getName()));
             }
         }
         return fragments;
-    }
-
-    private String getBasePath(String containerPath, InputPath input) {
-        if (containerPath.isEmpty()) {
-            return input.componentPath;
-        }
-        if (input.componentPath.isEmpty()) {
-            return containerPath;
-        }
-        return String.format("%s/%s", containerPath, input.componentPath); //$NON-NLS-1$
     }
 
     private Map<DirectInputGroup, List<InputPath>> extractInputList(

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/directio/MockDirectDataSource.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/directio/MockDirectDataSource.java
@@ -38,6 +38,11 @@ public class MockDirectDataSource extends AbstractDirectDataSource {
     }
 
     @Override
+    public String path(String basePath, ResourcePattern resourcePattern) {
+        return String.format("%s/%s", basePath, resourcePattern);
+    }
+
+    @Override
     public <T> List<DirectInputFragment> findInputFragments(
             DataDefinition<T> definition,
             String basePath,

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/directio/keepalive/KeepAliveDataSourceTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/directio/keepalive/KeepAliveDataSourceTest.java
@@ -198,6 +198,11 @@ public class KeepAliveDataSourceTest {
         }
 
         @Override
+        public String path(String basePath, ResourcePattern resourcePattern) {
+            return String.format("%s/%s", basePath, resourcePattern);
+        }
+
+        @Override
         public <T> List<DirectInputFragment> findInputFragments(
                 DataDefinition<T> definition,
                 String basePath,


### PR DESCRIPTION
## Summary

This PR revises error messages when Direct I/O input does not exist.

## Background, Problem or Goal of the patch

The latest implementation only shows the base path and resource pattern of missed resources, like
> java.io.IOException: Input not found (datasource=root, **basePath="master"**, **resourcePattern="store_info.csv"**, type=com.example.modelgen.dmdl.model.StoreInfo)

The new implementation will show the *resolved path* on the target datastore instead, like:
> java.io.IOException: Input not found (datasource=root, **path="file:/.../target/testing/directio/master/store_info.csv"**, type=com.example.modelgen.dmdl.model.StoreInfo)

## Design of the fix, or a new feature

This PR introduces a new method `DirectDataSource.path()` to resolve a pair of base path and resource pattern into a path on its datastore.

Note that, this revision is only for Asakusa on MapReduce. We will also revise for other platforms soon.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 