### PR TITLE
Fix document build warning on Sphinx 1.4

### DIFF
--- a/docs/ja/source/conf.py
+++ b/docs/ja/source/conf.py
@@ -26,7 +26,7 @@ sys.path.append(os.path.abspath('_exts'))
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.pngmath', 'sphinx.ext.todo', 'sphinx.ext.extlinks', 'asakusafw.javadoclinks']
+extensions = ['sphinx.ext.imgmath', 'sphinx.ext.todo', 'sphinx.ext.extlinks', 'asakusafw.javadoclinks']
 
 # -- EXTENSIONS ----------------------------------------------------------------
 [extensions]


### PR DESCRIPTION
## Summary
This PR fixes to document build warning on Sphinx 1.4.

## Background, Problem or Goal of the patch
Sphinx extention `sphinx.ext.pngmath` has been deprecated and should use `sphinx.ext.imgmath` instead.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.

## Wanted reviewer
N/A.
