### PR TITLE
Add syntax highlight to DMDL using pygments-dmdl

### DIFF
--- a/docs/ja/source/directio/csv-format.rst
+++ b/docs/ja/source/directio/csv-format.rst
@@ -9,7 +9,7 @@ CSV形式のDataFormatの作成
 
 CSV形式 [#]_ に対応した ``DataFormat`` の実装クラスを自動的に生成するには、対象のデータモデルに対応するDMDLスクリプトに ``@directio.csv`` を指定します。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @directio.csv
     document = {
@@ -31,7 +31,7 @@ DMDLコンパイラについては :doc:`../dmdl/user-guide` を参照してく�
 
 ..  hint::
     :doc:`../application/gradle-plugin` の手順に従ってプロジェクトテンプレートから作成したプロジェクトは、これらのライブラリやプラグインがSDKアーティファクトという依存性定義によってデフォルトで利用可能になっています。詳しくは :doc:`../application/sdk-artifact` を参照してください。
-    
+
 ..  note::
     この機構は :doc:`WindGate <../windgate/user-guide>` のものと将来統合されるかもしれません。
 
@@ -107,7 +107,7 @@ CSV形式の設定
 
 以下はDMDLスクリプトの記述例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @directio.csv(
         charset = "ISO-2022-JP",
@@ -135,7 +135,7 @@ CSV形式の設定
 
 以下はヘッダの内容の付加したDMDLスクリプトの記述例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @directio.csv
     document = {

--- a/docs/ja/source/directio/sequencefile-format.rst
+++ b/docs/ja/source/directio/sequencefile-format.rst
@@ -127,7 +127,7 @@ Hadoopのシーケンスファイル [#]_ を直接読み書きするには、 `
 
 シーケンスファイル対し、Asakusa Frameworkで利用するデータモデル形式を直接保存したり復元したりするような ``DataFormat`` の実装クラスを自動的に生成するには、対象のデータモデルに ``@directio.sequence_file`` を指定します。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @directio.sequence_file
     document = {
@@ -163,6 +163,6 @@ DMDLコンパイラについては :doc:`../dmdl/user-guide` を参照してく�
     シーケンスファイルの中身をテキスト形式で確認する場合、以下のコマンドを利用すると便利です。
 
     ..  code-block:: sh
-    
+
         hadoop fs -libjars "$ASAKUSA_HOME/core/lib/asakusa-runtime-all.jar,$ASAKUSA_HOME/batchapps/<バッチID>/lib/jobflow-<フローID>.jar" -text "<path/to/sequence-file>"
 

--- a/docs/ja/source/directio/using-hive.rst
+++ b/docs/ja/source/directio/using-hive.rst
@@ -82,7 +82,7 @@ ORC File形式のDataFormatの作成
 
 ORC File形式に対応した ``DataFormat`` の実装クラスを自動的に生成するには、対象のデータモデルに対応するDMDLスクリプトに ``@directio.hive.orc`` を指定します。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @directio.hive.orc
     document = {
@@ -160,7 +160,7 @@ Hiveのバージョンについては 後述の `Hiveのバージョンに関し
 
 以下はDMDLスクリプトの記述例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @directio.hive.orc(
         table_name = "tb_lineitem",
@@ -181,7 +181,7 @@ Parquet形式のDataFormatの作成
 
 Parquet形式に対応した ``DataFormat`` の実装クラスを自動的に生成するには、対象のデータモデルに対応するDMDLスクリプトに ``@directio.hive.parquet`` を指定します。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @directio.hive.parquet
     document = {
@@ -272,7 +272,7 @@ Parquet形式の設定
 
 以下はDMDLスクリプトの記述例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @directio.hive.parquet(
         table_name = "tb_lineitem",
@@ -321,7 +321,7 @@ Parquet形式の設定
 
 以下は名前マッピングの定義を付加したDMDLスクリプトの記述例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @directio.hive.orc
     document = {
@@ -504,7 +504,7 @@ Asakusa Framework バージョン |version| では、Direct I/O の Hive連携�
 
 以下はマッピング変換機能の定義を付加したDMDLスクリプトの記述例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     item = {
         @directio.hive.char(length = 2)

--- a/docs/ja/source/dmdl/start-guide.rst
+++ b/docs/ja/source/dmdl/start-guide.rst
@@ -24,7 +24,7 @@ DMDLスクリプトを作成する
 
 データモデルを新たに定義するには、作成したDMDLスクリプト内に ``<データモデル名> = <プロパティ定義>;`` のように記述します。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     model_name = {
         property_name : INT;
@@ -38,7 +38,7 @@ DMDLスクリプトを作成する
 
 データモデル内に複数のプロパティを定義するには、 ``{`` と ``}`` の間にプロパティを続けて指定します。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     model_name = {
         property_name : INT;
@@ -48,7 +48,7 @@ DMDLスクリプトを作成する
 
 複数のデータモデルを定義するには、DMDLスクリプト内にデータモデルを続けて記述します。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     model_name = {
         property_name : INT;
@@ -102,7 +102,7 @@ DMDLスクリプトを作成する
 
 DMDLでは、定義した複数のデータモデルを組み合わせて新しいデータモデルを定義できます。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     both = left + right;
     left = {
@@ -115,7 +115,7 @@ DMDLでは、定義した複数のデータモデルを組み合わせて新し�
 上記のようにデータモデル定義の右辺で「モデル名 + モデル名」と記述した場合、それぞれのデータモデルで定義したプロパティをすべて持つような新しいデータモデルを定義します。
 この例では、以下のようなデータモデルを定義したことになります。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     both = {
         left_value : INT;
@@ -129,7 +129,7 @@ DMDLでは、定義した複数のデータモデルを組み合わせて新し�
 
 以下のように他のデータモデルと新しいプロパティを合成して、新しいデータモデルを定義できます。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     origin = {
         value : INT;
@@ -141,7 +141,7 @@ DMDLでは、定義した複数のデータモデルを組み合わせて新し�
 上記の ``extended`` では、 ``origin`` で定義したプロパティ ``value`` に加えて、新たに ``extra`` というプロパティを定義しています。
 この ``extended`` は以下のような構造になります。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     extended = {
         value : INT;

--- a/docs/ja/source/dmdl/user-guide.rst
+++ b/docs/ja/source/dmdl/user-guide.rst
@@ -41,7 +41,7 @@ DMDLでは4種類のデータモデルを記述できます。
 
 以下はモデル名が `example_model` 、プロパティがそれぞれ整数型の `number` , 文字列型の `item_code` , 日時型の `last_updated` である場合の記述です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     example_model = {
         number : INT;
@@ -126,7 +126,7 @@ DMDLでは4種類のデータモデルを記述できます。
 
 合成されたデータモデルは、対象のデータモデルが定義する全てのプロパティを持つことになります。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     both = left + right;
     left = {
@@ -138,7 +138,7 @@ DMDLでは4種類のデータモデルを記述できます。
 
 上記の例では、以下のようなデータモデルを定義したことになります。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     both = {
         left_value : INT;
@@ -161,7 +161,7 @@ DMDLでは4種類のデータモデルを記述できます。
 
 拡張されたデータモデルは、対象のデータモデルが定義するすべてのプロパティに加え、新たに定義したプロパティを持つことになります。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     origin = {
         value : INT;
@@ -172,7 +172,7 @@ DMDLでは4種類のデータモデルを記述できます。
 
 上記の例では、以下のようなデータモデルを定義したことになります。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     extended = {
         value : INT;
@@ -196,7 +196,7 @@ DMDLでは4種類のデータモデルを記述できます。
 
 プロパティマッピングを行わない場合、次のような方法で結合モデルを定義します。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     joined <結合モデル名> = <対象モデル1> % <結合キー1> + <対象モデル2> % <結合キー2>;
 
@@ -207,7 +207,7 @@ DMDLでは4種類のデータモデルを記述できます。
 
 たとえば、次のような結合モデル `item_order` を定義できます。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     item = {
         code : LONG;
@@ -249,7 +249,7 @@ DMDLでは4種類のデータモデルを記述できます。
 
 以下はプロパティのマッピングを行いながら結合モデルを定義する例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     item = {
         code : LONG;
@@ -322,7 +322,7 @@ DMDLでは4種類のデータモデルを記述できます。
 
 たとえば、次のような集計モデル `item_order` を定義できます。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     order = {
         item_code : LONG;
@@ -478,7 +478,7 @@ DMDLでは4種類のデータモデルを記述できます。
 
 射影モデルを合成してレコードモデルを定義した場合、通常のデータモデルを合成した際と同様に、全てのプロパティが定義するレコードモデルに取り込まれます。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     projective proj_model = {
         value : INT;
@@ -487,7 +487,7 @@ DMDLでは4種類のデータモデルを記述できます。
 上記のように記述した場合、 `proj_model` に対応するJavaのデータモデルクラスは生成されず、代わりに同様のプロパティを持つインターフェースが生成されます。
 このインターフェースを実装( ``implements`` )するデータモデルクラスを生成するには、次のようにデータモデル定義の右辺にこの射影モデルを利用します。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     conc_model = proj_model + {
         other : INT;
@@ -501,7 +501,7 @@ DMDLでは4種類のデータモデルを記述できます。
 
 たとえば、以下の例で `record` は、 `sub_proj` , `super_proj` がどちらも射影として登録されます。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     projective super_proj = { a : INT; };
     projective sub_proj = super_proj + { b : INT; };
@@ -517,7 +517,7 @@ DMDLスクリプトにコメントを挿入するには、以下のように記�
 
 以下コメントの使用例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     item = {
         code : LONG; -- XYZコード体系で表現される商品コード
@@ -658,7 +658,7 @@ DMDLコンパイラが生成するJavaのクラスやインターフェースに
 
 データモデルのドキュメンテーションを変更するには、データモデルの定義の直前に ``"<データモデルの説明>"`` を付与します。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     "サンプルのデータモデル"
     example = { ... };
@@ -672,7 +672,7 @@ DMDLコンパイラが生成するJavaのクラスやインターフェースに
 
 プロパティのドキュメンテーションを変更するには、プロパティ定義やマッピングの直前に ``"<プロパティの説明>"`` を付与します。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     order = {
         "商品コード"
@@ -697,7 +697,7 @@ DMDLコンパイラが生成するJavaのクラスやインターフェースに
 このパッケージ名は、データモデルの名前と同様に ``snake_case`` の形式で記述します ( `名前の形式`_ を参照 )。
 また、 ``.`` で区切って深い階層の名前も指定できます。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     "名前空間付きのモデル"
     @namespace(value = your.namespace)
@@ -718,7 +718,7 @@ DMDLコンパイラが生成するJavaのクラスやインターフェースに
 
 射影モデルが持つプロパティをすべて持つモデルに ``@auto_projection`` 属性を指定した場合、そのデータモデルには対象の射影が自動的に登録されます。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     projective foo = {
         value1 : INT;

--- a/docs/ja/source/sandbox/directio-line.rst
+++ b/docs/ja/source/sandbox/directio-line.rst
@@ -29,7 +29,7 @@ Direct I/O lineはAsakusa FrameworkのMavenリポジトリにグループID ``co
       - アーティファクトID
     * - ``com.asakusafw.sandbox``
       - ``asakusa-directio-dmdl-ext``
-      
+
 ..  note::
     Sandoxモジュールとして提供するDirect I/Oの各フォーマット拡張機能は同一のMavenアーティファクトで提供しています。
 
@@ -54,7 +54,7 @@ Direct I/O lineを利用するには、DMDLに対してDirect I/O lineを利用�
 
 以下はDirect I/O lineと連携するデータモデル定義の最もシンプルな例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @directio.line
     model = {
@@ -91,7 +91,7 @@ Direct I/O lineを利用するには、DMDLに対してDirect I/O lineを利用�
 
 以下はDMDLスクリプトの記述例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @directio.line(
         charset="ISO-2022-jp",
@@ -118,7 +118,7 @@ Direct I/O lineで利用できるモデルプロパティの設定について�
 
 以下は、モデルプロパティの設定を指定したDMDLスクリプトの記述例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @directio.line
     model = {
@@ -185,7 +185,7 @@ Direct I/O lineで利用できるモデルプロパティの設定について�
 
 ..  attention::
     ``@directio.line.line_number`` が指定された場合、 :ref:`directio-input-split` が行われなくなります。
-    
+
 ..  attention::
     これらの属性はファイルを読み込みの解析時のみ有効です。
     ファイルを書き出す際には無視されます。

--- a/docs/ja/source/sandbox/directio-tsv.rst
+++ b/docs/ja/source/sandbox/directio-tsv.rst
@@ -17,7 +17,7 @@ Direct I/OのTSVファイル連携モジュールはAsakusa FrameworkのMavenリ
       - アーティファクトID
     * - ``com.asakusafw.sandbox``
       - ``asakusa-directio-dmdl-ext``
-      
+
 ..  note::
     Sandoxモジュールとして提供するDirect I/Oの各フォーマット拡張機能は同一のMavenアーティファクトで提供しています。
 
@@ -44,7 +44,7 @@ TSVファイル連携を行うために、DMDLに対してTSVファイルを扱�
 
 以下にTSVファイルを扱う場合のDMDLスクリプトの例を示します。
 
-..  code-block:: sh
+..  code-block:: dmdl
 
     "テーブルEX1"
     ...
@@ -97,7 +97,7 @@ TSV形式の設定
 
 以下はDMDLスクリプトの記述例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @directio.tsv(
         charset = "ISO-2022-jp",
@@ -118,7 +118,7 @@ TSV形式の設定
 
 以下はヘッダの内容の付加したDMDLスクリプトの記述例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @directio.tsv
     document = {
@@ -241,7 +241,7 @@ DMDLスクリプトに対応するTSVファイルの例を以下に示します�
 サンプル:DMDLスクリプト
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-..  code-block:: java
+..  code-block:: dmdl
 
     "テーブルEX1"
     ...
@@ -261,7 +261,7 @@ DMDLスクリプトに対応するTSVファイルの例を以下に示します�
 ..  attention::
     以下サンプルのドキュメント上の区切り文字はスペースになっていますが、実際のファイルはタブ文字を使用してください。
 
-..  code-block:: java
+..  code-block:: none
 
     1	111	hoge1
     2	222	fuga2

--- a/docs/ja/source/sandbox/windgate-tsv.rst
+++ b/docs/ja/source/sandbox/windgate-tsv.rst
@@ -10,7 +10,7 @@ Mavenアーティファクト
 WindGateのTSVファイル連携モジュールはAsakusa FrameworkのMavenリポジトリにグループID ``com.asakusafw.sandbox`` を持つMavenアーティファクトとして登録されています。
 
 ..  list-table:: WindGateのTSVファイル連携で使用するMavenアーティファクト
-    :widths: 5 5 
+    :widths: 5 5
     :header-rows: 1
 
     * - グループID
@@ -41,7 +41,7 @@ TSVファイル連携を行うために、DMDLに対してTSVファイルを扱�
 
 以下にTSVファイルを扱う場合のDMDLスクリプトの例を示します。
 
-..  code-block:: sh
+..  code-block:: dmdl
 
     "テーブルEX1"
     ...
@@ -111,19 +111,19 @@ DMDLスクリプトに対応するTSVファイルの例を以下に示します�
 サンプル:DMDLスクリプト
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-..  code-block:: java
+..  code-block:: dmdl
 
     "テーブルEX1"
-    ... 
+    ...
     @windgate.stream_format(type="tsv")
-    ex1 = { 
+    ex1 = {
         "SID"
         sid : LONG;
         "VALUE"
         value : INT;
         "STRING"
         string : TEXT;
-    };  
+    };
 
 サンプル:TSVファイル
 ~~~~~~~~~~~~~~~~~~~~
@@ -131,7 +131,7 @@ DMDLスクリプトに対応するTSVファイルの例を以下に示します�
 ..  attention::
     以下サンプルのドキュメント上の区切り文字はスペースになっていますが、実際のファイルはタブ文字を使用してください。
 
-..  code-block:: java
+..  code-block:: none
 
     1	111	hoge1
     2	222	fuga2

--- a/docs/ja/source/windgate/start-guide.rst
+++ b/docs/ja/source/windgate/start-guide.rst
@@ -69,7 +69,7 @@ CSV入出力への対応
 この属性は、データモデルの宣言の直前に指定します。
 以下は記述例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @windgate.csv
     example_model = {
@@ -90,7 +90,7 @@ Asakusa DSLの記述
 WindGateを利用する場合でも、Asakusa DSLの基本的な記述方法は同様です。
 WindGate特有の部分は、以降で説明する `CSVファイルをインポートする`_ と `CSVファイルをエクスポートする`_ 部分のみです。
 
-それ以外の部分については、 :doc:`../dsl/start-guide` を参照してください。 
+それ以外の部分については、 :doc:`../dsl/start-guide` を参照してください。
 
 CSVファイルをインポートする
 ---------------------------

--- a/docs/ja/source/windgate/user-guide.rst
+++ b/docs/ja/source/windgate/user-guide.rst
@@ -466,7 +466,7 @@ WindGateをAsakusa Frameworkのバッチから利用する場合、以下の環�
 ..  hint::
     :program:`hadoop` コマンドが見つからない場合、WindGateは代わりに :program:`java` コマンドを利用してアプリケーションを起動します。
     前者はHadoopに関する設定やクラスライブラリなどが有効になりますが、後者は :file:`$ASAKUSA_HOME/windgate/lib` 以下のライブラリのみをクラスパスに通し、Hadoopに関する設定を行いません。
-    
+
     特別な理由がない限り、 :file:`$ASAKUSA_HOME/windgate/conf/env.sh` 内で ``HADOOP_CMD`` や ``HADOOP_HOME`` を設定しておくのがよいでしょう。
     または、 :doc:`YAESS <../yaess/index>` を利用して外部から環境変数を設定することも可能です。
 
@@ -514,7 +514,7 @@ WindGateの様々な機能は、プラグイン機構を利用して実現して
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Asakusa Frameworkのデプロイメントアーカイブには、デフォルトのWindGate用プラグインライブラリとして、あらかじめ以下のプラグインライブラリと、プラグインライブラリが使用する依存ライブラリが同梱されています。
-   
+
 ..  list-table:: WindGate標準プラグインライブラリ
     :widths: 4 6
     :header-rows: 1
@@ -555,7 +555,7 @@ Asakusa FrameworkのバッチアプリケーションからWindGateを利用し�
 
 ..  hint::
     :doc:`../application/gradle-plugin` の手順に従ってプロジェクトテンプレートから作成したプロジェクトは、これらのライブラリやプラグインがSDKアーティファクトという依存性定義によってデフォルトで利用可能になっています。詳しくは :doc:`../application/sdk-artifact` を参照してください。
-    
+
 ..  [#] :javadoc:`com.asakusafw.runtime.directio.DataFormat`
 ..  [#] :javadoc:`com.asakusafw.windgate.core.vocabulary.DataModelStreamSupport`
 
@@ -564,7 +564,7 @@ CSV形式のDataModelStreamSupportの作成
 
 CSV形式 [#]_ に対応した ``DataModelStreamSupport`` の実装クラスを自動的に生成するには、対象のデータモデルに ``@windgate.csv`` を指定します。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @windgate.csv
     document = {
@@ -631,7 +631,7 @@ CSV形式の設定
 
 以下は記述例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @windgate.csv(
         charset = "ISO-2022-JP",
@@ -656,7 +656,7 @@ CSV形式の設定
 
 以下は利用例です。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @windgate.csv
     document = {
@@ -861,7 +861,7 @@ DataModelJdbcSupportの自動生成
 データモデルから ``DataModelJdbcSupport`` の実装クラスを自動的に生成するには、それぞれのプロパティに ``@windgate.jdbc.column`` を指定してさらに ``name`` 要素で対応するカラム名を記述します。
 また、テーブル名を指定するにはデータモデルに ``@windgate.jdbc.table`` を指定して ``name`` 要素内に記述します [#]_ 。
 
-..  code-block:: none
+..  code-block:: dmdl
 
     @windgate.jdbc.table(name = "DOCUMENT")
     document = {


### PR DESCRIPTION
## Summary
This PR add DMDL script syntax highlighting on sphinx documentation using [pygments-dmdl](https://pypi.python.org/pypi/pygments-dmdl).

(very thanks to @cocoatomo for creating excellent product!)

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.

## Wanted reviewer
N/A.
