### PR TITLE
Bump Gradle version to 2.14.1 on documents

### DIFF
--- a/docs/ja/source/application/gradle-plugin.rst
+++ b/docs/ja/source/application/gradle-plugin.rst
@@ -149,7 +149,7 @@ Asakusa Gradle Pluginを使った標準的なアプリケーション開発環�
     * - :file:`gradlew.bat`
       - Gradleラッパーコマンド (Windows)
     * - :file:`.buildtools`
-      - Gradleラッパーライブラリ (Gradle Version: 2.14)
+      - Gradleラッパーライブラリ (Gradle Version: 2.14.1)
 
 アプリケーション開発者は :file:`src` ディレクトリ配下を編集することでアプリケーションを開発します。
 :file:`build` ディレクトリは :file:`src` ディレクトリ配下のファイルをビルドすることで生成される成果物が配置されます。

--- a/docs/ja/source/product/target-platform.rst
+++ b/docs/ja/source/product/target-platform.rst
@@ -65,7 +65,7 @@ Asakusa Frameworkを利用したバッチアプリケーションの開発環境
       - 1.7.0_79 / 1.8.0_91
     * - ビルドツール
       - Gradle [#]_
-      - 2.14
+      - 2.14.1
     * - IDE
       - Eclipse IDE for Java Developers
       - 4.5.2 / 4.6.0


### PR DESCRIPTION
## Summary
This PR modifies Gradle version to 2.14.1 on documents.

## Background, Problem or Goal of the patch
See as follows:
- asakusafw/asakusafw-sdk#100
- asakusafw/asakusafw-spark#198
- asakusafw/asakusafw-m3bp#72

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
- asakusafw/asakusafw-sdk#100
- asakusafw/asakusafw-spark#198
- asakusafw/asakusafw-m3bp#72

## Wanted reviewer
N/A
