### PR TITLE
Remove `WIP` version in Javadoc.

### DIFF
--- a/hive-project/asakusa-hive-info/src/main/java/com/asakusafw/directio/hive/info/MapType.java
+++ b/hive-project/asakusa-hive-info/src/main/java/com/asakusafw/directio/hive/info/MapType.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * Represents a Hive map type.
  * Each type category must be {@link com.asakusafw.directio.hive.info.FieldType.Category#MAP}.
- * @since WIP
+ * @since 0.8.1
  */
 public class MapType implements FieldType {
 


### PR DESCRIPTION
## Summary

This PR removes `WIP` version in Javadoc.

## Background, Problem or Goal of the patch

#624 includes `@since WIP` tag.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #624

## Wanted reviewer

N/A.
