### PR TITLE
Support Java 8 syntax in Java DOM library.

### DIFF
--- a/dmdl-project/asakusa-dmdl-java/src/main/java/com/asakusafw/dmdl/java/emitter/EmitContext.java
+++ b/dmdl-project/asakusa-dmdl-java/src/main/java/com/asakusafw/dmdl/java/emitter/EmitContext.java
@@ -248,8 +248,7 @@ public final class EmitContext {
         CompilationUnit compilationUnit = factory.newCompilationUnit(
                 imports.getPackageDeclaration(),
                 imports.toImportDeclarations(),
-                Collections.singletonList(type),
-                Collections.emptyList());
+                Collections.singletonList(type));
         try (PrintWriter writer = config.getOutput().openFor(compilationUnit)) {
             Models.emit(compilationUnit, writer);
         }

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/jobflow/CleanupStageClientEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/jobflow/CleanupStageClientEmitter.java
@@ -114,8 +114,7 @@ public class CleanupStageClientEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/jobflow/StageClientEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/jobflow/StageClientEmitter.java
@@ -136,8 +136,7 @@ public class StageClientEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/join/JoinResourceEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/join/JoinResourceEmitter.java
@@ -108,8 +108,7 @@ public final class JoinResourceEmitter {
         return factory.newCompilationUnit(
                 importer.getPackageDeclaration(),
                 importer.toImportDeclarations(),
-                Collections.singletonList(type),
-                Collections.emptyList());
+                Collections.singletonList(type));
     }
 
     private ClassDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/mapreduce/copy/CopierClientEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/mapreduce/copy/CopierClientEmitter.java
@@ -182,8 +182,7 @@ public class CopierClientEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() throws IOException {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/mapreduce/copy/CopierMapperEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/mapreduce/copy/CopierMapperEmitter.java
@@ -135,8 +135,7 @@ final class CopierMapperEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/mapreduce/parallel/ParallelSortClientEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/mapreduce/parallel/ParallelSortClientEmitter.java
@@ -162,8 +162,7 @@ public class ParallelSortClientEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() throws IOException {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/mapreduce/parallel/ParallelSortMapperEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/mapreduce/parallel/ParallelSortMapperEmitter.java
@@ -132,8 +132,7 @@ final class ParallelSortMapperEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {
@@ -209,8 +208,7 @@ final class ParallelSortMapperEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/mapreduce/parallel/ParallelSortReducerEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/mapreduce/parallel/ParallelSortReducerEmitter.java
@@ -114,8 +114,7 @@ final class ParallelSortReducerEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/CombinerEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/CombinerEmitter.java
@@ -156,8 +156,7 @@ public class CombinerEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/MapFragmentEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/MapFragmentEmitter.java
@@ -156,8 +156,7 @@ public class MapFragmentEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/MapperEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/MapperEmitter.java
@@ -166,8 +166,7 @@ public class MapperEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ReduceFragmentEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ReduceFragmentEmitter.java
@@ -179,8 +179,7 @@ public class ReduceFragmentEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ReducerEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ReducerEmitter.java
@@ -145,8 +145,7 @@ public class ReducerEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ShuffleFragmentEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ShuffleFragmentEmitter.java
@@ -266,8 +266,7 @@ public class ShuffleFragmentEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ShuffleGroupingComparatorEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ShuffleGroupingComparatorEmitter.java
@@ -129,8 +129,7 @@ public class ShuffleGroupingComparatorEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ShuffleKeyEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ShuffleKeyEmitter.java
@@ -120,8 +120,7 @@ public class ShuffleKeyEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ShufflePartitionerEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ShufflePartitionerEmitter.java
@@ -136,8 +136,7 @@ public class ShufflePartitionerEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ShuffleSortComparatorEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ShuffleSortComparatorEmitter.java
@@ -131,8 +131,7 @@ public class ShuffleSortComparatorEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ShuffleValueEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/stage/ShuffleValueEmitter.java
@@ -118,8 +118,7 @@ public class ShuffleValueEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/operator/OperatorClassEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/operator/OperatorClassEmitter.java
@@ -163,12 +163,10 @@ public class OperatorClassEmitter {
             List<ImportDeclaration> importDecls,
             TypeDeclaration typeDecl,
             TypeElement originating) throws IOException {
-
         CompilationUnit unit = factory.newCompilationUnit(
                 packageDecl,
                 importDecls,
-                Collections.singletonList(typeDecl),
-                Collections.emptyList());
+                Collections.singletonList(typeDecl));
         try {
             environment.emit(unit, originating);
             if (key != null) {

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/operator/flow/FlowClassEmitter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/operator/flow/FlowClassEmitter.java
@@ -103,13 +103,10 @@ public class FlowClassEmitter {
             List<ImportDeclaration> importDecls,
             TypeDeclaration typeDecl,
             TypeElement originating) throws IOException {
-
         CompilationUnit unit = factory.newCompilationUnit(
                 packageDecl,
                 importDecls,
-                Collections.singletonList(typeDecl),
-                Collections.emptyList());
-
+                Collections.singletonList(typeDecl));
         try {
             environment.emit(unit, originating);
             if (key != null) {

--- a/mapreduce/compiler/core/src/test/java/com/asakusafw/compiler/flow/packager/FilePackagerTest.java
+++ b/mapreduce/compiler/core/src/test/java/com/asakusafw/compiler/flow/packager/FilePackagerTest.java
@@ -191,11 +191,9 @@ public class FilePackagerTest extends JobflowCompilerTestRoot {
                             .Private()
                             .toAttributes(),
                         f.newSimpleName("Hello"),
-                        Collections.emptyList(),
                         null,
                         Collections.emptyList(),
-                        Collections.emptyList())),
-                Collections.emptyList());
+                        Collections.emptyList())));
         return cu;
     }
 
@@ -241,10 +239,8 @@ public class FilePackagerTest extends JobflowCompilerTestRoot {
                             .Public()
                             .toAttributes(),
                         f.newSimpleName(name),
-                        Collections.emptyList(),
                         null,
                         Collections.emptyList(),
-                        Collections.emptyList())),
-                Collections.emptyList());
+                        Collections.emptyList())));
     }
 }

--- a/mapreduce/compiler/directio/src/main/java/com/asakusafw/compiler/directio/emitter/NamingClassEmitter.java
+++ b/mapreduce/compiler/directio/src/main/java/com/asakusafw/compiler/directio/emitter/NamingClassEmitter.java
@@ -183,8 +183,7 @@ public class NamingClassEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/directio/src/main/java/com/asakusafw/compiler/directio/emitter/OrderingClassEmitter.java
+++ b/mapreduce/compiler/directio/src/main/java/com/asakusafw/compiler/directio/emitter/OrderingClassEmitter.java
@@ -169,8 +169,7 @@ public class OrderingClassEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/mapreduce/compiler/directio/src/main/java/com/asakusafw/compiler/directio/emitter/StageEmitter.java
+++ b/mapreduce/compiler/directio/src/main/java/com/asakusafw/compiler/directio/emitter/StageEmitter.java
@@ -387,8 +387,7 @@ public class StageEmitter {
         CompilationUnit source = f.newCompilationUnit(
                 importer.getPackageDeclaration(),
                 importer.toImportDeclarations(),
-                Collections.singletonList(typeDecl),
-                Collections.emptyList());
+                Collections.singletonList(typeDecl));
         environment.emit(source);
         Name packageName = source.getPackageDeclaration().getName();
         SimpleName simpleName = source.getTypeDeclarations().get(0).getName();
@@ -517,8 +516,7 @@ public class StageEmitter {
             return factory.newCompilationUnit(
                     importer.getPackageDeclaration(),
                     importer.toImportDeclarations(),
-                    Collections.singletonList(type),
-                    Collections.emptyList());
+                    Collections.singletonList(type));
         }
 
         private TypeDeclaration createType() {

--- a/operator/core/src/main/java/com/asakusafw/operator/flowpart/FlowPartFactoryEmitter.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/flowpart/FlowPartFactoryEmitter.java
@@ -153,8 +153,7 @@ public class FlowPartFactoryEmitter {
             return f.newCompilationUnit(
                     imports.getPackageDeclaration(),
                     imports.toImportDeclarations(),
-                    Collections.singletonList(typeDecl),
-                    Collections.emptyList());
+                    Collections.singletonList(typeDecl));
         }
 
         private ClassDeclaration generateClass() {

--- a/operator/core/src/main/java/com/asakusafw/operator/method/OperatorFactoryEmitter.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/method/OperatorFactoryEmitter.java
@@ -147,8 +147,7 @@ public class OperatorFactoryEmitter {
             return f.newCompilationUnit(
                     imports.getPackageDeclaration(),
                     imports.toImportDeclarations(),
-                    Collections.singletonList(typeDecl),
-                    Collections.emptyList());
+                    Collections.singletonList(typeDecl));
         }
 
         private ClassDeclaration generateClass() {

--- a/operator/core/src/main/java/com/asakusafw/operator/method/OperatorImplementationEmitter.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/method/OperatorImplementationEmitter.java
@@ -142,8 +142,7 @@ public class OperatorImplementationEmitter {
             return f.newCompilationUnit(
                     imports.getPackageDeclaration(),
                     imports.toImportDeclarations(),
-                    Collections.singletonList(typeDecl),
-                    Collections.emptyList());
+                    Collections.singletonList(typeDecl));
         }
 
         private ClassDeclaration generateClass() {

--- a/operator/core/src/test/java/com/asakusafw/operator/util/DescriptionHelperTest.java
+++ b/operator/core/src/test/java/com/asakusafw/operator/util/DescriptionHelperTest.java
@@ -237,8 +237,7 @@ public class DescriptionHelperTest extends OperatorCompilerTestRoot {
                 env.emit(f.newCompilationUnit(
                         imports.getPackageDeclaration(),
                         imports.toImportDeclarations(),
-                        Collections.singletonList(type),
-                        Collections.emptyList()));
+                        Collections.singletonList(type)));
             }
         });
         try {
@@ -280,8 +279,7 @@ public class DescriptionHelperTest extends OperatorCompilerTestRoot {
                 env.emit(f.newCompilationUnit(
                         imports.getPackageDeclaration(),
                         imports.toImportDeclarations(),
-                        Collections.singletonList(type),
-                        Collections.emptyList()));
+                        Collections.singletonList(type)));
             }
         });
         try {
@@ -322,8 +320,7 @@ public class DescriptionHelperTest extends OperatorCompilerTestRoot {
                 env.emit(f.newCompilationUnit(
                         imports.getPackageDeclaration(),
                         imports.toImportDeclarations(),
-                        Collections.singletonList(type),
-                        Collections.emptyList()));
+                        Collections.singletonList(type)));
             }
         });
         try {

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/LambdaExpressionImpl.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/LambdaExpressionImpl.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.utils.java.internal.model.syntax;
+
+import java.util.List;
+
+import com.asakusafw.utils.java.model.syntax.LambdaBody;
+import com.asakusafw.utils.java.model.syntax.LambdaExpression;
+import com.asakusafw.utils.java.model.syntax.LambdaParameter;
+import com.asakusafw.utils.java.model.syntax.ModelKind;
+import com.asakusafw.utils.java.model.syntax.Visitor;
+
+/**
+ * An implementation of {@link LambdaExpression}.
+ * @since 0.9.0
+ */
+public class LambdaExpressionImpl extends ModelRoot implements LambdaExpression {
+
+    private List<? extends LambdaParameter> parameters;
+
+    private LambdaBody body;
+
+    @Override
+    public ModelKind getModelKind() {
+        return ModelKind.LAMBDA_EXPRESSION;
+    }
+
+    @Override
+    public List<? extends LambdaParameter> getParameters() {
+        return parameters;
+    }
+
+    /**
+     * Sets a parameters.
+     * @param parameters the parameters
+     */
+    public void setParameters(List<? extends LambdaParameter> parameters) {
+        Util.notNull(parameters, "parameters"); //$NON-NLS-1$
+        this.parameters = Util.freeze(parameters);
+    }
+
+    @Override
+    public LambdaBody getBody() {
+        return body;
+    }
+
+    /**
+     * Sets a body.
+     * @param body the body
+     */
+    public void setBody(LambdaBody body) {
+        Util.notNull(body, "body"); //$NON-NLS-1$
+        this.body = body;
+    }
+
+    @Override
+    public <R, C, E extends Throwable> R accept(Visitor<R, C, E> visitor, C context) throws E {
+        Util.notNull(visitor, "visitor"); //$NON-NLS-1$
+        return visitor.visitLambdaExpression(this, context);
+    }
+}

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/ModelFactoryImpl.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/ModelFactoryImpl.java
@@ -769,21 +769,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public FormalParameterDeclaration newFormalParameterDeclaration(Type type, SimpleName name) {
-        return this.newFormalParameterDeclaration0(Collections.emptyList(), type, false, name, 0);
-    }
-
-    @Override
     public FormalParameterDeclaration newFormalParameterDeclaration(
-            List<? extends Attribute> modifiers,
-            Type type,
-            boolean variableArity,
-            SimpleName name,
-            int extraDimensions) {
-        return this.newFormalParameterDeclaration0(modifiers, type, variableArity, name, extraDimensions);
-    }
-
-    private FormalParameterDeclarationImpl newFormalParameterDeclaration0(
             List<? extends Attribute> modifiers,
             Type type,
             boolean variableArity,
@@ -1407,11 +1393,28 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public TryStatement newTryStatement(Block tryBlock, List<? extends CatchClause> catchClauses, Block finallyBlock) {
+    public TryResource newTryResource(FormalParameterDeclaration parameter, Expression expression) {
+        Util.notNull(parameter, "parameter"); //$NON-NLS-1$
+        Util.notNull(expression, "expression"); //$NON-NLS-1$
+        TryResourceImpl result = new TryResourceImpl();
+        result.setParameter(parameter);
+        result.setInitializer(expression);
+        return result;
+    }
+
+    @Override
+    public TryStatement newTryStatement(
+            List<? extends TryResource> resources,
+            Block tryBlock,
+            List<? extends CatchClause> catchClauses,
+            Block finallyBlock) {
+        Util.notNull(resources, "resources"); //$NON-NLS-1$
+        Util.notContainNull(resources, "resources"); //$NON-NLS-1$
         Util.notNull(tryBlock, "tryBlock"); //$NON-NLS-1$
         Util.notNull(catchClauses, "catchClauses"); //$NON-NLS-1$
         Util.notContainNull(catchClauses, "catchClauses"); //$NON-NLS-1$
         TryStatementImpl result = new TryStatementImpl();
+        result.setResources(resources);
         result.setTryBlock(tryBlock);
         result.setCatchClauses(catchClauses);
         result.setFinallyBlock(finallyBlock);

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/ModelFactoryImpl.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/ModelFactoryImpl.java
@@ -1451,6 +1451,22 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
+    public UnionType newUnionType(Type... alternativeTypes) {
+        Util.notNull(alternativeTypes, "alternativeTypes"); //$NON-NLS-1$
+        return newUnionType(Arrays.asList(alternativeTypes));
+    }
+
+    @Override
+    public UnionType newUnionType(List<? extends Type> alternativeTypes) {
+        Util.notNull(alternativeTypes, "alternativeTypes"); //$NON-NLS-1$
+        Util.notContainNull(alternativeTypes, "alternativeTypes"); //$NON-NLS-1$
+        Util.notEmpty(alternativeTypes, "alternativeTypes"); //$NON-NLS-1$
+        UnionTypeImpl result = new UnionTypeImpl();
+        result.setAlternativeTypes(alternativeTypes);
+        return result;
+    }
+
+    @Override
     public VariableDeclarator newVariableDeclarator(SimpleName name, int extraDimensions, Expression initializer) {
         Util.notNull(name, "name"); //$NON-NLS-1$
         VariableDeclaratorImpl result = new VariableDeclaratorImpl();

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/ModelFactoryImpl.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/ModelFactoryImpl.java
@@ -32,32 +32,21 @@ import com.asakusafw.utils.java.model.syntax.*;
 public class ModelFactoryImpl implements ModelFactory {
 
     @Override
-    public AlternateConstructorInvocation newAlternateConstructorInvocation(
-            Expression...arguments) {
+    public AlternateConstructorInvocation newAlternateConstructorInvocation(Expression... arguments) {
         Util.notNull(arguments, "arguments"); //$NON-NLS-1$
-        return this.newAlternateConstructorInvocation0(
-            Collections.emptyList(),
-            Arrays.asList(arguments)
-        );
+        return this.newAlternateConstructorInvocation0(Collections.emptyList(), Arrays.asList(arguments));
     }
 
     @Override
-    public AlternateConstructorInvocation newAlternateConstructorInvocation(
-            List<? extends Expression> arguments) {
-        return this.newAlternateConstructorInvocation0(
-            Collections.emptyList(),
-            arguments
-        );
+    public AlternateConstructorInvocation newAlternateConstructorInvocation(List<? extends Expression> arguments) {
+        return this.newAlternateConstructorInvocation0(Collections.emptyList(), arguments);
     }
 
     @Override
     public AlternateConstructorInvocation newAlternateConstructorInvocation(
             List<? extends Type> typeArguments,
             List<? extends Expression> arguments) {
-        return this.newAlternateConstructorInvocation0(
-            typeArguments,
-            arguments
-        );
+        return this.newAlternateConstructorInvocation0(typeArguments, arguments);
     }
 
     private AlternateConstructorInvocationImpl newAlternateConstructorInvocation0(
@@ -79,19 +68,6 @@ public class ModelFactoryImpl implements ModelFactory {
             List<? extends Attribute> modifiers,
             SimpleName name,
             List<? extends TypeBodyDeclaration> bodyDeclarations) {
-        return this.newAnnotationDeclaration0(
-            javadoc,
-            modifiers,
-            name,
-            bodyDeclarations
-        );
-    }
-
-    private AnnotationDeclarationImpl newAnnotationDeclaration0(
-            Javadoc javadoc,
-            List<? extends Attribute> modifiers,
-            SimpleName name,
-            List<? extends TypeBodyDeclaration> bodyDeclarations) {
         Util.notNull(modifiers, "modifiers"); //$NON-NLS-1$
         Util.notContainNull(modifiers, "modifiers"); //$NON-NLS-1$
         Util.notNull(name, "name"); //$NON-NLS-1$
@@ -106,18 +82,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public AnnotationElement newAnnotationElement(
-            SimpleName name,
-            Expression expression) {
-        return this.newAnnotationElement0(
-            name,
-            expression
-        );
-    }
-
-    private AnnotationElementImpl newAnnotationElement0(
-            SimpleName name,
-            Expression expression) {
+    public AnnotationElement newAnnotationElement(SimpleName name, Expression expression) {
         Util.notNull(name, "name"); //$NON-NLS-1$
         Util.notNull(expression, "expression"); //$NON-NLS-1$
         AnnotationElementImpl result = new AnnotationElementImpl();
@@ -128,21 +93,6 @@ public class ModelFactoryImpl implements ModelFactory {
 
     @Override
     public AnnotationElementDeclaration newAnnotationElementDeclaration(
-            Javadoc javadoc,
-            List<? extends Attribute> modifiers,
-            Type type,
-            SimpleName name,
-            Expression defaultExpression) {
-        return this.newAnnotationElementDeclaration0(
-            javadoc,
-            modifiers,
-            type,
-            name,
-            defaultExpression
-        );
-    }
-
-    private AnnotationElementDeclarationImpl newAnnotationElementDeclaration0(
             Javadoc javadoc,
             List<? extends Attribute> modifiers,
             Type type,
@@ -162,18 +112,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public ArrayAccessExpression newArrayAccessExpression(
-            Expression array,
-            Expression index) {
-        return this.newArrayAccessExpression0(
-            array,
-            index
-        );
-    }
-
-    private ArrayAccessExpressionImpl newArrayAccessExpression0(
-            Expression array,
-            Expression index) {
+    public ArrayAccessExpression newArrayAccessExpression(Expression array, Expression index) {
         Util.notNull(array, "array"); //$NON-NLS-1$
         Util.notNull(index, "index"); //$NON-NLS-1$
         ArrayAccessExpressionImpl result = new ArrayAccessExpressionImpl();
@@ -183,14 +122,8 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public ArrayCreationExpression newArrayCreationExpression(
-            ArrayType type,
-            ArrayInitializer arrayInitializer) {
-        return this.newArrayCreationExpression0(
-            type,
-            Collections.emptyList(),
-            arrayInitializer
-        );
+    public ArrayCreationExpression newArrayCreationExpression(ArrayType type, ArrayInitializer arrayInitializer) {
+        return this.newArrayCreationExpression0(type, Collections.emptyList(), arrayInitializer);
     }
 
     @Override
@@ -198,11 +131,7 @@ public class ModelFactoryImpl implements ModelFactory {
             ArrayType type,
             List<? extends Expression> dimensionExpressions,
             ArrayInitializer arrayInitializer) {
-        return this.newArrayCreationExpression0(
-            type,
-            dimensionExpressions,
-            arrayInitializer
-        );
+        return this.newArrayCreationExpression0(type, dimensionExpressions, arrayInitializer);
     }
 
     private ArrayCreationExpressionImpl newArrayCreationExpression0(
@@ -220,23 +149,17 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public ArrayInitializer newArrayInitializer(Expression...elements) {
+    public ArrayInitializer newArrayInitializer(Expression... elements) {
         Util.notNull(elements, "elements"); //$NON-NLS-1$
-        return this.newArrayInitializer0(
-            Arrays.asList(elements)
-        );
+        return this.newArrayInitializer0(Arrays.asList(elements));
     }
 
     @Override
-    public ArrayInitializer newArrayInitializer(
-            List<? extends Expression> elements) {
-        return this.newArrayInitializer0(
-            elements
-        );
+    public ArrayInitializer newArrayInitializer(List<? extends Expression> elements) {
+        return this.newArrayInitializer0(elements);
     }
 
-    private ArrayInitializerImpl newArrayInitializer0(
-            List<? extends Expression> elements) {
+    private ArrayInitializerImpl newArrayInitializer0(List<? extends Expression> elements) {
         Util.notNull(elements, "elements"); //$NON-NLS-1$
         Util.notContainNull(elements, "elements"); //$NON-NLS-1$
         ArrayInitializerImpl result = new ArrayInitializerImpl();
@@ -245,15 +168,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public ArrayType newArrayType(
-            Type componentType) {
-        return this.newArrayType0(
-            componentType
-        );
-    }
-
-    private ArrayTypeImpl newArrayType0(
-            Type componentType) {
+    public ArrayType newArrayType(Type componentType) {
         Util.notNull(componentType, "componentType"); //$NON-NLS-1$
         ArrayTypeImpl result = new ArrayTypeImpl();
         result.setComponentType(componentType);
@@ -261,27 +176,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public AssertStatement newAssertStatement(
-            Expression expression) {
-        return this.newAssertStatement0(
-            expression,
-            null
-        );
-    }
-
-    @Override
-    public AssertStatement newAssertStatement(
-            Expression expression,
-            Expression message) {
-        return this.newAssertStatement0(
-            expression,
-            message
-        );
-    }
-
-    private AssertStatementImpl newAssertStatement0(
-            Expression expression,
-            Expression message) {
+    public AssertStatement newAssertStatement(Expression expression, Expression message) {
         Util.notNull(expression, "expression"); //$NON-NLS-1$
         AssertStatementImpl result = new AssertStatementImpl();
         result.setExpression(expression);
@@ -291,28 +186,6 @@ public class ModelFactoryImpl implements ModelFactory {
 
     @Override
     public AssignmentExpression newAssignmentExpression(
-            Expression leftHandSide,
-            Expression rightHandSide) {
-        return this.newAssignmentExpression0(
-            leftHandSide,
-            InfixOperator.ASSIGN,
-            rightHandSide
-        );
-    }
-
-    @Override
-    public AssignmentExpression newAssignmentExpression(
-            Expression leftHandSide,
-            InfixOperator operator,
-            Expression rightHandSide) {
-        return this.newAssignmentExpression0(
-            leftHandSide,
-            operator,
-            rightHandSide
-        );
-    }
-
-    private AssignmentExpressionImpl newAssignmentExpression0(
             Expression leftHandSide,
             InfixOperator operator,
             Expression rightHandSide) {
@@ -327,15 +200,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public BasicType newBasicType(
-            BasicTypeKind typeKind) {
-        return this.newBasicType0(
-            typeKind
-        );
-    }
-
-    private BasicTypeImpl newBasicType0(
-            BasicTypeKind typeKind) {
+    public BasicType newBasicType(BasicTypeKind typeKind) {
         Util.notNull(typeKind, "typeKind"); //$NON-NLS-1$
         BasicTypeImpl result = new BasicTypeImpl();
         result.setTypeKind(typeKind);
@@ -343,24 +208,17 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public Block newBlock(
-            Statement... statements) {
+    public Block newBlock(Statement... statements) {
         Util.notNull(statements, "statements"); //$NON-NLS-1$
-        return this.newBlock0(
-            Arrays.asList(statements)
-        );
+        return this.newBlock0(Arrays.asList(statements));
     }
 
     @Override
-    public Block newBlock(
-            List<? extends Statement> statements) {
-        return this.newBlock0(
-            statements
-        );
+    public Block newBlock(List<? extends Statement> statements) {
+        return this.newBlock0(statements);
     }
 
-    private BlockImpl newBlock0(
-            List<? extends Statement> statements) {
+    private BlockImpl newBlock0(List<? extends Statement> statements) {
         Util.notNull(statements, "statements"); //$NON-NLS-1$
         Util.notContainNull(statements, "statements"); //$NON-NLS-1$
         BlockImpl result = new BlockImpl();
@@ -369,15 +227,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public BlockComment newBlockComment(
-            String string) {
-        return this.newBlockComment0(
-            string
-        );
-    }
-
-    private BlockCommentImpl newBlockComment0(
-            String string) {
+    public BlockComment newBlockComment(String string) {
         Util.notNull(string, "string"); //$NON-NLS-1$
         BlockCommentImpl result = new BlockCommentImpl();
         result.setString(string);
@@ -385,40 +235,14 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public BreakStatement newBreakStatement() {
-        return this.newBreakStatement0(
-            null
-        );
-    }
-
-    @Override
-    public BreakStatement newBreakStatement(
-            SimpleName target) {
-        return this.newBreakStatement0(
-            target
-        );
-    }
-
-    private BreakStatementImpl newBreakStatement0(
-            SimpleName target) {
+    public BreakStatement newBreakStatement(SimpleName target) {
         BreakStatementImpl result = new BreakStatementImpl();
         result.setTarget(target);
         return result;
     }
 
     @Override
-    public CastExpression newCastExpression(
-            Type type,
-            Expression expression) {
-        return this.newCastExpression0(
-            type,
-            expression
-        );
-    }
-
-    private CastExpressionImpl newCastExpression0(
-            Type type,
-            Expression expression) {
+    public CastExpression newCastExpression(Type type, Expression expression) {
         Util.notNull(type, "type"); //$NON-NLS-1$
         Util.notNull(expression, "expression"); //$NON-NLS-1$
         CastExpressionImpl result = new CastExpressionImpl();
@@ -428,18 +252,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public CatchClause newCatchClause(
-            FormalParameterDeclaration parameter,
-            Block body) {
-        return this.newCatchClause0(
-            parameter,
-            body
-        );
-    }
-
-    private CatchClauseImpl newCatchClause0(
-            FormalParameterDeclaration parameter,
-            Block body) {
+    public CatchClause newCatchClause(FormalParameterDeclaration parameter, Block body) {
         Util.notNull(parameter, "parameter"); //$NON-NLS-1$
         Util.notNull(body, "body"); //$NON-NLS-1$
         CatchClauseImpl result = new CatchClauseImpl();
@@ -449,15 +262,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public ClassBody newClassBody(
-            List<? extends TypeBodyDeclaration> bodyDeclarations) {
-        return this.newClassBody0(
-            bodyDeclarations
-        );
-    }
-
-    private ClassBodyImpl newClassBody0(
-            List<? extends TypeBodyDeclaration> bodyDeclarations) {
+    public ClassBody newClassBody(List<? extends TypeBodyDeclaration> bodyDeclarations) {
         Util.notNull(bodyDeclarations, "bodyDeclarations"); //$NON-NLS-1$
         Util.notContainNull(bodyDeclarations, "bodyDeclarations"); //$NON-NLS-1$
         ClassBodyImpl result = new ClassBodyImpl();
@@ -533,9 +338,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public ClassInstanceCreationExpression newClassInstanceCreationExpression(
-            Type type,
-            Expression...arguments) {
+    public ClassInstanceCreationExpression newClassInstanceCreationExpression(Type type, Expression... arguments) {
         Util.notNull(arguments, "arguments"); //$NON-NLS-1$
         return this.newClassInstanceCreationExpression0(
             null,
@@ -550,13 +353,7 @@ public class ModelFactoryImpl implements ModelFactory {
     public ClassInstanceCreationExpression newClassInstanceCreationExpression(
             Type type,
             List<? extends Expression> arguments) {
-        return this.newClassInstanceCreationExpression0(
-            null,
-            Collections.emptyList(),
-            type,
-            arguments,
-            null
-        );
+        return this.newClassInstanceCreationExpression0(null, Collections.emptyList(), type, arguments, null);
     }
 
     @Override
@@ -566,13 +363,7 @@ public class ModelFactoryImpl implements ModelFactory {
             Type type,
             List<? extends Expression> arguments,
             ClassBody body) {
-        return this.newClassInstanceCreationExpression0(
-            qualifier,
-            typeArguments,
-            type,
-            arguments,
-            body
-        );
+        return this.newClassInstanceCreationExpression0(qualifier, typeArguments, type, arguments, body);
     }
 
     private ClassInstanceCreationExpressionImpl newClassInstanceCreationExpression0(
@@ -596,15 +387,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public ClassLiteral newClassLiteral(
-            Type type) {
-        return this.newClassLiteral0(
-            type
-        );
-    }
-
-    private ClassLiteralImpl newClassLiteral0(
-            Type type) {
+    public ClassLiteral newClassLiteral(Type type) {
         Util.notNull(type, "type"); //$NON-NLS-1$
         ClassLiteralImpl result = new ClassLiteralImpl();
         result.setType(type);
@@ -613,19 +396,6 @@ public class ModelFactoryImpl implements ModelFactory {
 
     @Override
     public CompilationUnit newCompilationUnit(
-            PackageDeclaration packageDeclaration,
-            List<? extends ImportDeclaration> importDeclarations,
-            List<? extends TypeDeclaration> typeDeclarations,
-            List<? extends Comment> comments) {
-        return this.newCompilationUnit0(
-            packageDeclaration,
-            importDeclarations,
-            typeDeclarations,
-            comments
-        );
-    }
-
-    private CompilationUnitImpl newCompilationUnit0(
             PackageDeclaration packageDeclaration,
             List<? extends ImportDeclaration> importDeclarations,
             List<? extends TypeDeclaration> typeDeclarations,
@@ -646,17 +416,6 @@ public class ModelFactoryImpl implements ModelFactory {
 
     @Override
     public ConditionalExpression newConditionalExpression(
-            Expression condition,
-            Expression thenExpression,
-            Expression elseExpression) {
-        return this.newConditionalExpression0(
-            condition,
-            thenExpression,
-            elseExpression
-        );
-    }
-
-    private ConditionalExpressionImpl newConditionalExpression0(
             Expression condition,
             Expression thenExpression,
             Expression elseExpression) {
@@ -739,40 +498,14 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public ContinueStatement newContinueStatement() {
-        return this.newContinueStatement0(
-            null
-        );
-    }
-
-    @Override
-    public ContinueStatement newContinueStatement(
-            SimpleName target) {
-        return this.newContinueStatement0(
-            target
-        );
-    }
-
-    private ContinueStatementImpl newContinueStatement0(
-            SimpleName target) {
+    public ContinueStatement newContinueStatement(SimpleName target) {
         ContinueStatementImpl result = new ContinueStatementImpl();
         result.setTarget(target);
         return result;
     }
 
     @Override
-    public DoStatement newDoStatement(
-            Statement body,
-            Expression condition) {
-        return this.newDoStatement0(
-            body,
-            condition
-        );
-    }
-
-    private DoStatementImpl newDoStatement0(
-            Statement body,
-            Expression condition) {
+    public DoStatement newDoStatement(Statement body, Expression condition) {
         Util.notNull(body, "body"); //$NON-NLS-1$
         Util.notNull(condition, "condition"); //$NON-NLS-1$
         DoStatementImpl result = new DoStatementImpl();
@@ -782,18 +515,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public DocBlock newDocBlock(
-            String tag,
-            List<? extends DocElement> elements) {
-        return this.newDocBlock0(
-            tag,
-            elements
-        );
-    }
-
-    private DocBlockImpl newDocBlock0(
-            String tag,
-            List<? extends DocElement> elements) {
+    public DocBlock newDocBlock(String tag, List<? extends DocElement> elements) {
         Util.notNull(tag, "tag"); //$NON-NLS-1$
         Util.notNull(elements, "elements"); //$NON-NLS-1$
         Util.notContainNull(elements, "elements"); //$NON-NLS-1$
@@ -804,18 +526,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public DocField newDocField(
-            Type type,
-            SimpleName name) {
-        return this.newDocField0(
-            type,
-            name
-        );
-    }
-
-    private DocFieldImpl newDocField0(
-            Type type,
-            SimpleName name) {
+    public DocField newDocField(Type type, SimpleName name) {
         Util.notNull(name, "name"); //$NON-NLS-1$
         DocFieldImpl result = new DocFieldImpl();
         result.setType(type);
@@ -824,21 +535,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public DocMethod newDocMethod(
-            Type type,
-            SimpleName name,
-            List<? extends DocMethodParameter> formalParameters) {
-        return this.newDocMethod0(
-            type,
-            name,
-            formalParameters
-        );
-    }
-
-    private DocMethodImpl newDocMethod0(
-            Type type,
-            SimpleName name,
-            List<? extends DocMethodParameter> formalParameters) {
+    public DocMethod newDocMethod(Type type, SimpleName name, List<? extends DocMethodParameter> formalParameters) {
         Util.notNull(name, "name"); //$NON-NLS-1$
         Util.notNull(formalParameters, "formalParameters"); //$NON-NLS-1$
         Util.notContainNull(formalParameters, "formalParameters"); //$NON-NLS-1$
@@ -850,21 +547,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public DocMethodParameter newDocMethodParameter(
-            Type type,
-            SimpleName name,
-            boolean variableArity) {
-        return this.newDocMethodParameter0(
-            type,
-            name,
-            variableArity
-        );
-    }
-
-    private DocMethodParameterImpl newDocMethodParameter0(
-            Type type,
-            SimpleName name,
-            boolean variableArity) {
+    public DocMethodParameter newDocMethodParameter(Type type, SimpleName name, boolean variableArity) {
         Util.notNull(type, "type"); //$NON-NLS-1$
         DocMethodParameterImpl result = new DocMethodParameterImpl();
         result.setType(type);
@@ -874,15 +557,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public DocText newDocText(
-            String string) {
-        return this.newDocText0(
-            string
-        );
-    }
-
-    private DocTextImpl newDocText0(
-            String string) {
+    public DocText newDocText(String string) {
         Util.notNull(string, "string"); //$NON-NLS-1$
         DocTextImpl result = new DocTextImpl();
         result.setString(string);
@@ -890,32 +565,13 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public EmptyStatement newEmptyStatement(
-            ) {
-        return this.newEmptyStatement0(
-
-        );
-    }
-
-    private EmptyStatementImpl newEmptyStatement0(
-            ) {
+    public EmptyStatement newEmptyStatement() {
         EmptyStatementImpl result = new EmptyStatementImpl();
         return result;
     }
 
     @Override
     public EnhancedForStatement newEnhancedForStatement(
-            FormalParameterDeclaration parameter,
-            Expression expression,
-            Statement body) {
-        return this.newEnhancedForStatement0(
-            parameter,
-            expression,
-            body
-        );
-    }
-
-    private EnhancedForStatementImpl newEnhancedForStatement0(
             FormalParameterDeclaration parameter,
             Expression expression,
             Statement body) {
@@ -951,13 +607,7 @@ public class ModelFactoryImpl implements ModelFactory {
             SimpleName name,
             List<? extends Expression> arguments,
             ClassBody body) {
-        return this.newEnumConstantDeclaration0(
-            javadoc,
-            modifiers,
-            name,
-            arguments,
-            body
-        );
+        return this.newEnumConstantDeclaration0(javadoc, modifiers, name, arguments, body);
     }
 
     private EnumConstantDeclarationImpl newEnumConstantDeclaration0(
@@ -1043,15 +693,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public ExpressionStatement newExpressionStatement(
-            Expression expression) {
-        return this.newExpressionStatement0(
-            expression
-        );
-    }
-
-    private ExpressionStatementImpl newExpressionStatement0(
-            Expression expression) {
+    public ExpressionStatement newExpressionStatement(Expression expression) {
         Util.notNull(expression, "expression"); //$NON-NLS-1$
         ExpressionStatementImpl result = new ExpressionStatementImpl();
         result.setExpression(expression);
@@ -1059,18 +701,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public FieldAccessExpression newFieldAccessExpression(
-            Expression qualifier,
-            SimpleName name) {
-        return this.newFieldAccessExpression0(
-            qualifier,
-            name
-        );
-    }
-
-    private FieldAccessExpressionImpl newFieldAccessExpression0(
-            Expression qualifier,
-            SimpleName name) {
+    public FieldAccessExpression newFieldAccessExpression(Expression qualifier, SimpleName name) {
         Util.notNull(qualifier, "qualifier"); //$NON-NLS-1$
         Util.notNull(name, "name"); //$NON-NLS-1$
         FieldAccessExpressionImpl result = new FieldAccessExpressionImpl();
@@ -1090,10 +721,7 @@ public class ModelFactoryImpl implements ModelFactory {
             javadoc,
             modifiers,
             type,
-            Collections.singletonList(newVariableDeclarator(
-                name,
-                0,
-                initializer))
+            Collections.singletonList(newVariableDeclarator(name, initializer))
         );
     }
 
@@ -1103,12 +731,7 @@ public class ModelFactoryImpl implements ModelFactory {
             List<? extends Attribute> modifiers,
             Type type,
             List<? extends VariableDeclarator> variableDeclarators) {
-        return this.newFieldDeclaration0(
-            javadoc,
-            modifiers,
-            type,
-            variableDeclarators
-        );
+        return this.newFieldDeclaration0(javadoc, modifiers, type, variableDeclarators);
     }
 
     private FieldDeclarationImpl newFieldDeclaration0(
@@ -1136,19 +759,6 @@ public class ModelFactoryImpl implements ModelFactory {
             Expression condition,
             StatementExpressionList update,
             Statement body) {
-        return this.newForStatement0(
-            initialization,
-            condition,
-            update,
-            body
-        );
-    }
-
-    private ForStatementImpl newForStatement0(
-            ForInitializer initialization,
-            Expression condition,
-            StatementExpressionList update,
-            Statement body) {
         Util.notNull(body, "body"); //$NON-NLS-1$
         ForStatementImpl result = new ForStatementImpl();
         result.setInitialization(initialization);
@@ -1159,16 +769,8 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public FormalParameterDeclaration newFormalParameterDeclaration(
-            Type type,
-            SimpleName name) {
-        return this.newFormalParameterDeclaration0(
-            Collections.emptyList(),
-            type,
-            false,
-            name,
-            0
-        );
+    public FormalParameterDeclaration newFormalParameterDeclaration(Type type, SimpleName name) {
+        return this.newFormalParameterDeclaration0(Collections.emptyList(), type, false, name, 0);
     }
 
     @Override
@@ -1178,13 +780,7 @@ public class ModelFactoryImpl implements ModelFactory {
             boolean variableArity,
             SimpleName name,
             int extraDimensions) {
-        return this.newFormalParameterDeclaration0(
-            modifiers,
-            type,
-            variableArity,
-            name,
-            extraDimensions
-        );
+        return this.newFormalParameterDeclaration0(modifiers, type, variableArity, name, extraDimensions);
     }
 
     private FormalParameterDeclarationImpl newFormalParameterDeclaration0(
@@ -1207,32 +803,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public IfStatement newIfStatement(
-            Expression condition,
-            Statement thenStatement) {
-        return this.newIfStatement0(
-            condition,
-            thenStatement,
-            null
-        );
-    }
-
-    @Override
-    public IfStatement newIfStatement(
-            Expression condition,
-            Statement thenStatement,
-            Statement elseStatement) {
-        return this.newIfStatement0(
-            condition,
-            thenStatement,
-            elseStatement
-        );
-    }
-
-    private IfStatementImpl newIfStatement0(
-            Expression condition,
-            Statement thenStatement,
-            Statement elseStatement) {
+    public IfStatement newIfStatement(Expression condition, Statement thenStatement, Statement elseStatement) {
         Util.notNull(condition, "condition"); //$NON-NLS-1$
         Util.notNull(thenStatement, "thenStatement"); //$NON-NLS-1$
         IfStatementImpl result = new IfStatementImpl();
@@ -1243,18 +814,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public ImportDeclaration newImportDeclaration(
-            ImportKind importKind,
-            Name name) {
-        return this.newImportDeclaration0(
-            importKind,
-            name
-        );
-    }
-
-    private ImportDeclarationImpl newImportDeclaration0(
-            ImportKind importKind,
-            Name name) {
+    public ImportDeclaration newImportDeclaration(ImportKind importKind, Name name) {
         Util.notNull(importKind, "importKind"); //$NON-NLS-1$
         Util.notNull(name, "name"); //$NON-NLS-1$
         ImportDeclarationImpl result = new ImportDeclarationImpl();
@@ -1265,17 +825,6 @@ public class ModelFactoryImpl implements ModelFactory {
 
     @Override
     public InfixExpression newInfixExpression(
-            Expression leftOperand,
-            InfixOperator operator,
-            Expression rightOperand) {
-        return this.newInfixExpression0(
-            leftOperand,
-            operator,
-            rightOperand
-        );
-    }
-
-    private InfixExpressionImpl newInfixExpression0(
             Expression leftOperand,
             InfixOperator operator,
             Expression rightOperand) {
@@ -1290,14 +839,9 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public InitializerDeclaration newInitializerDeclaration(
-            List<? extends Statement> statements) {
+    public InitializerDeclaration newInitializerDeclaration(List<? extends Statement> statements) {
         Util.notNull(statements, "statements"); //$NON-NLS-1$
-        return this.newInitializerDeclaration0(
-            null,
-            Collections.emptyList(),
-            newBlock(statements)
-        );
+        return this.newInitializerDeclaration0(null, Collections.emptyList(), newBlock(statements));
     }
 
     @Override
@@ -1305,11 +849,7 @@ public class ModelFactoryImpl implements ModelFactory {
             Javadoc javadoc,
             List<? extends Attribute> modifiers,
             Block body) {
-        return this.newInitializerDeclaration0(
-            javadoc,
-            modifiers,
-            body
-        );
+        return this.newInitializerDeclaration0(javadoc, modifiers, body);
     }
 
     private InitializerDeclarationImpl newInitializerDeclaration0(
@@ -1327,18 +867,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public InstanceofExpression newInstanceofExpression(
-            Expression expression,
-            Type type) {
-        return this.newInstanceofExpression0(
-            expression,
-            type
-        );
-    }
-
-    private InstanceofExpressionImpl newInstanceofExpression0(
-            Expression expression,
-            Type type) {
+    public InstanceofExpression newInstanceofExpression(Expression expression, Type type) {
         Util.notNull(expression, "expression"); //$NON-NLS-1$
         Util.notNull(type, "type"); //$NON-NLS-1$
         InstanceofExpressionImpl result = new InstanceofExpressionImpl();
@@ -1409,15 +938,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public Javadoc newJavadoc(
-            List<? extends DocBlock> blocks) {
-        return this.newJavadoc0(
-            blocks
-        );
-    }
-
-    private JavadocImpl newJavadoc0(
-            List<? extends DocBlock> blocks) {
+    public Javadoc newJavadoc(List<? extends DocBlock> blocks) {
         Util.notNull(blocks, "blocks"); //$NON-NLS-1$
         Util.notContainNull(blocks, "blocks"); //$NON-NLS-1$
         JavadocImpl result = new JavadocImpl();
@@ -1426,18 +947,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public LabeledStatement newLabeledStatement(
-            SimpleName label,
-            Statement body) {
-        return this.newLabeledStatement0(
-            label,
-            body
-        );
-    }
-
-    private LabeledStatementImpl newLabeledStatement0(
-            SimpleName label,
-            Statement body) {
+    public LabeledStatement newLabeledStatement(SimpleName label, Statement body) {
         Util.notNull(label, "label"); //$NON-NLS-1$
         Util.notNull(body, "body"); //$NON-NLS-1$
         LabeledStatementImpl result = new LabeledStatementImpl();
@@ -1447,15 +957,32 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public LineComment newLineComment(
-            String string) {
-        return this.newLineComment0(
-            string
-        );
+    public LambdaExpression newLambdaExpression(List<? extends LambdaParameter> parameters, LambdaBody body) {
+        Util.notNull(parameters, "parameters");
+        Util.notNull(body, "body");
+        return newLambdaExpression0(parameters, body);
     }
 
-    private LineCommentImpl newLineComment0(
-            String string) {
+    @Override
+    public LambdaExpression newLambdaExpression(LambdaParameter parameter, LambdaBody body) {
+        Util.notNull(parameter, "parameter");
+        Util.notNull(body, "body");
+        return newLambdaExpression0(Arrays.asList(parameter), body);
+    }
+
+    private LambdaExpressionImpl newLambdaExpression0(List<? extends LambdaParameter> parameters, LambdaBody body) {
+        LambdaExpressionImpl result = new LambdaExpressionImpl();
+        result.setParameters(parameters);
+        result.setBody(body);
+        return result;
+    }
+
+    @Override
+    public LineComment newLineComment(String string) {
+        return this.newLineComment0(string);
+    }
+
+    private LineCommentImpl newLineComment0(String string) {
         Util.notNull(string, "string"); //$NON-NLS-1$
         LineCommentImpl result = new LineCommentImpl();
         result.setString(string);
@@ -1463,15 +990,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public Literal newLiteral(
-            String token) {
-        return this.newLiteral0(
-            token
-        );
-    }
-
-    private LiteralImpl newLiteral0(
-            String token) {
+    public Literal newLiteral(String token) {
         Util.notNull(token, "token"); //$NON-NLS-1$
         LiteralImpl result = new LiteralImpl();
         result.setToken(token);
@@ -1479,15 +998,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public LocalClassDeclaration newLocalClassDeclaration(
-            ClassDeclaration declaration) {
-        return this.newLocalClassDeclaration0(
-            declaration
-        );
-    }
-
-    private LocalClassDeclarationImpl newLocalClassDeclaration0(
-            ClassDeclaration declaration) {
+    public LocalClassDeclaration newLocalClassDeclaration(ClassDeclaration declaration) {
         Util.notNull(declaration, "declaration"); //$NON-NLS-1$
         LocalClassDeclarationImpl result = new LocalClassDeclarationImpl();
         result.setDeclaration(declaration);
@@ -1495,18 +1006,11 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public LocalVariableDeclaration newLocalVariableDeclaration(
-            Type type,
-            SimpleName name,
-            Expression initializer) {
+    public LocalVariableDeclaration newLocalVariableDeclaration(Type type, SimpleName name, Expression initializer) {
         return this.newLocalVariableDeclaration0(
-            Collections.emptyList(),
-            type,
-            Collections.singletonList(newVariableDeclarator(
-                name,
-                0,
-                initializer))
-        );
+                Collections.emptyList(),
+                type,
+                Collections.singletonList(newVariableDeclarator(name, 0, initializer)));
     }
 
     @Override
@@ -1514,11 +1018,7 @@ public class ModelFactoryImpl implements ModelFactory {
             List<? extends Attribute> modifiers,
             Type type,
             List<? extends VariableDeclarator> variableDeclarators) {
-        return this.newLocalVariableDeclaration0(
-            modifiers,
-            type,
-            variableDeclarators
-        );
+        return this.newLocalVariableDeclaration0(modifiers, type, variableDeclarators);
     }
 
     private LocalVariableDeclarationImpl newLocalVariableDeclaration0(
@@ -1539,15 +1039,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public MarkerAnnotation newMarkerAnnotation(
-            NamedType type) {
-        return this.newMarkerAnnotation0(
-            type
-        );
-    }
-
-    private MarkerAnnotationImpl newMarkerAnnotation0(
-            NamedType type) {
+    public MarkerAnnotation newMarkerAnnotation(NamedType type) {
         Util.notNull(type, "type"); //$NON-NLS-1$
         MarkerAnnotationImpl result = new MarkerAnnotationImpl();
         result.setType(type);
@@ -1639,12 +1131,7 @@ public class ModelFactoryImpl implements ModelFactory {
             SimpleName name,
             Expression...arguments) {
         Util.notNull(arguments, "arguments"); //$NON-NLS-1$
-        return this.newMethodInvocationExpression0(
-            qualifier,
-            Collections.emptyList(),
-            name,
-            Arrays.asList(arguments)
-        );
+        return this.newMethodInvocationExpression0(qualifier, Collections.emptyList(), name, Arrays.asList(arguments));
     }
 
     @Override
@@ -1652,12 +1139,7 @@ public class ModelFactoryImpl implements ModelFactory {
             Expression qualifier,
             SimpleName name,
             List<? extends Expression> arguments) {
-        return this.newMethodInvocationExpression0(
-            qualifier,
-            Collections.emptyList(),
-            name,
-            arguments
-        );
+        return this.newMethodInvocationExpression0(qualifier, Collections.emptyList(), name, arguments);
     }
 
     @Override
@@ -1666,12 +1148,7 @@ public class ModelFactoryImpl implements ModelFactory {
             List<? extends Type> typeArguments,
             SimpleName name,
             List<? extends Expression> arguments) {
-        return this.newMethodInvocationExpression0(
-            qualifier,
-            typeArguments,
-            name,
-            arguments
-        );
+        return this.newMethodInvocationExpression0(qualifier, typeArguments, name, arguments);
     }
 
     private MethodInvocationExpressionImpl newMethodInvocationExpression0(
@@ -1693,15 +1170,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public Modifier newModifier(
-            ModifierKind modifierKind) {
-        return this.newModifier0(
-            modifierKind
-        );
-    }
-
-    private ModifierImpl newModifier0(
-            ModifierKind modifierKind) {
+    public Modifier newModifier(ModifierKind modifierKind) {
         Util.notNull(modifierKind, "modifierKind"); //$NON-NLS-1$
         ModifierImpl result = new ModifierImpl();
         result.setModifierKind(modifierKind);
@@ -1709,15 +1178,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public NamedType newNamedType(
-            Name name) {
-        return this.newNamedType0(
-            name
-        );
-    }
-
-    private NamedTypeImpl newNamedType0(
-            Name name) {
+    public NamedType newNamedType(Name name) {
         Util.notNull(name, "name"); //$NON-NLS-1$
         NamedTypeImpl result = new NamedTypeImpl();
         result.setName(name);
@@ -1725,18 +1186,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public NormalAnnotation newNormalAnnotation(
-            NamedType type,
-            List<? extends AnnotationElement> elements) {
-        return this.newNormalAnnotation0(
-            type,
-            elements
-        );
-    }
-
-    private NormalAnnotationImpl newNormalAnnotation0(
-            NamedType type,
-            List<? extends AnnotationElement> elements) {
+    public NormalAnnotation newNormalAnnotation(NamedType type, List<? extends AnnotationElement> elements) {
         Util.notNull(type, "type"); //$NON-NLS-1$
         Util.notNull(elements, "elements"); //$NON-NLS-1$
         Util.notContainNull(elements, "elements"); //$NON-NLS-1$
@@ -1747,27 +1197,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public PackageDeclaration newPackageDeclaration(Name name) {
-        return this.newPackageDeclaration0(
-            null,
-            Collections.emptyList(),
-            name
-        );
-    }
-
-    @Override
     public PackageDeclaration newPackageDeclaration(
-            Javadoc javadoc,
-            List<? extends Annotation> annotations,
-            Name name) {
-        return this.newPackageDeclaration0(
-            javadoc,
-            annotations,
-            name
-        );
-    }
-
-    private PackageDeclarationImpl newPackageDeclaration0(
             Javadoc javadoc,
             List<? extends Annotation> annotations,
             Name name) {
@@ -1782,29 +1212,17 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public ParameterizedType newParameterizedType(
-            Type type,
-            Type...typeArguments) {
+    public ParameterizedType newParameterizedType(Type type, Type... typeArguments) {
         Util.notNull(typeArguments, "typeArguments"); //$NON-NLS-1$
-        return this.newParameterizedType0(
-            type,
-            Arrays.asList(typeArguments)
-        );
+        return this.newParameterizedType0(type, Arrays.asList(typeArguments));
     }
 
     @Override
-    public ParameterizedType newParameterizedType(
-            Type type,
-            List<? extends Type> typeArguments) {
-        return this.newParameterizedType0(
-            type,
-            typeArguments
-        );
+    public ParameterizedType newParameterizedType(Type type, List<? extends Type> typeArguments) {
+        return this.newParameterizedType0(type, typeArguments);
     }
 
-    private ParameterizedTypeImpl newParameterizedType0(
-            Type type,
-            List<? extends Type> typeArguments) {
+    private ParameterizedTypeImpl newParameterizedType0(Type type, List<? extends Type> typeArguments) {
         Util.notNull(type, "type"); //$NON-NLS-1$
         Util.notNull(typeArguments, "typeArguments"); //$NON-NLS-1$
         Util.notContainNull(typeArguments, "typeArguments"); //$NON-NLS-1$
@@ -1815,15 +1233,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public ParenthesizedExpression newParenthesizedExpression(
-            Expression expression) {
-        return this.newParenthesizedExpression0(
-            expression
-        );
-    }
-
-    private ParenthesizedExpressionImpl newParenthesizedExpression0(
-            Expression expression) {
+    public ParenthesizedExpression newParenthesizedExpression(Expression expression) {
         Util.notNull(expression, "expression"); //$NON-NLS-1$
         ParenthesizedExpressionImpl result = new ParenthesizedExpressionImpl();
         result.setExpression(expression);
@@ -1831,18 +1241,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public PostfixExpression newPostfixExpression(
-            Expression operand,
-            PostfixOperator operator) {
-        return this.newPostfixExpression0(
-            operand,
-            operator
-        );
-    }
-
-    private PostfixExpressionImpl newPostfixExpression0(
-            Expression operand,
-            PostfixOperator operator) {
+    public PostfixExpression newPostfixExpression(Expression operand, PostfixOperator operator) {
         Util.notNull(operand, "operand"); //$NON-NLS-1$
         Util.notNull(operator, "operator"); //$NON-NLS-1$
         PostfixExpressionImpl result = new PostfixExpressionImpl();
@@ -1852,18 +1251,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public QualifiedName newQualifiedName(
-            Name qualifier,
-            SimpleName simpleName) {
-        return this.newQualifiedName0(
-            qualifier,
-            simpleName
-        );
-    }
-
-    private QualifiedNameImpl newQualifiedName0(
-            Name qualifier,
-            SimpleName simpleName) {
+    public QualifiedName newQualifiedName(Name qualifier, SimpleName simpleName) {
         Util.notNull(qualifier, "qualifier"); //$NON-NLS-1$
         Util.notNull(simpleName, "simpleName"); //$NON-NLS-1$
         QualifiedNameImpl result = new QualifiedNameImpl();
@@ -1873,18 +1261,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public QualifiedType newQualifiedType(
-            Type qualifier,
-            SimpleName simpleName) {
-        return this.newQualifiedType0(
-            qualifier,
-            simpleName
-        );
-    }
-
-    private QualifiedTypeImpl newQualifiedType0(
-            Type qualifier,
-            SimpleName simpleName) {
+    public QualifiedType newQualifiedType(Type qualifier, SimpleName simpleName) {
         Util.notNull(qualifier, "qualifier"); //$NON-NLS-1$
         Util.notNull(simpleName, "simpleName"); //$NON-NLS-1$
         QualifiedTypeImpl result = new QualifiedTypeImpl();
@@ -1894,37 +1271,14 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public ReturnStatement newReturnStatement() {
-        return this.newReturnStatement0(
-            null
-        );
-    }
-
-    @Override
-    public ReturnStatement newReturnStatement(
-            Expression expression) {
-        return this.newReturnStatement0(
-            expression
-        );
-    }
-
-    private ReturnStatementImpl newReturnStatement0(
-            Expression expression) {
+    public ReturnStatement newReturnStatement(Expression expression) {
         ReturnStatementImpl result = new ReturnStatementImpl();
         result.setExpression(expression);
         return result;
     }
 
     @Override
-    public SimpleName newSimpleName(
-            String string) {
-        return this.newSimpleName0(
-            string
-        );
-    }
-
-    private SimpleNameImpl newSimpleName0(
-            String string) {
+    public SimpleName newSimpleName(String string) {
         Util.notNull(string, "string"); //$NON-NLS-1$
         SimpleNameImpl result = new SimpleNameImpl();
         result.setToken(string);
@@ -1932,18 +1286,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public SingleElementAnnotation newSingleElementAnnotation(
-            NamedType type,
-            Expression expression) {
-        return this.newSingleElementAnnotation0(
-            type,
-            expression
-        );
-    }
-
-    private SingleElementAnnotationImpl newSingleElementAnnotation0(
-            NamedType type,
-            Expression expression) {
+    public SingleElementAnnotation newSingleElementAnnotation(NamedType type, Expression expression) {
         Util.notNull(type, "type"); //$NON-NLS-1$
         Util.notNull(expression, "expression"); //$NON-NLS-1$
         SingleElementAnnotationImpl result = new SingleElementAnnotationImpl();
@@ -1953,24 +1296,17 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public StatementExpressionList newStatementExpressionList(
-            Expression...expressions) {
+    public StatementExpressionList newStatementExpressionList(Expression... expressions) {
         Util.notNull(expressions, "expressions"); //$NON-NLS-1$
-        return this.newStatementExpressionList0(
-            Arrays.asList(expressions)
-        );
+        return this.newStatementExpressionList0(Arrays.asList(expressions));
     }
 
     @Override
-    public StatementExpressionList newStatementExpressionList(
-            List<? extends Expression> expressions) {
-        return this.newStatementExpressionList0(
-            expressions
-        );
+    public StatementExpressionList newStatementExpressionList(List<? extends Expression> expressions) {
+        return this.newStatementExpressionList0(expressions);
     }
 
-    private StatementExpressionListImpl newStatementExpressionList0(
-            List<? extends Expression> expressions) {
+    private StatementExpressionListImpl newStatementExpressionList0(List<? extends Expression> expressions) {
         Util.notNull(expressions, "expressions"); //$NON-NLS-1$
         Util.notContainNull(expressions, "expressions"); //$NON-NLS-1$
         Util.notEmpty(expressions, "expressions"); //$NON-NLS-1$
@@ -1980,46 +1316,21 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public Super newSuper() {
-        return this.newSuper0(
-            null
-        );
-    }
-
-    @Override
-    public Super newSuper(
-            NamedType qualifier) {
-        return this.newSuper0(
-            qualifier
-        );
-    }
-
-    private SuperImpl newSuper0(
-            NamedType qualifier) {
+    public Super newSuper(NamedType qualifier) {
         SuperImpl result = new SuperImpl();
         result.setQualifier(qualifier);
         return result;
     }
 
     @Override
-    public SuperConstructorInvocation newSuperConstructorInvocation(
-            Expression...arguments) {
+    public SuperConstructorInvocation newSuperConstructorInvocation(Expression... arguments) {
         Util.notNull(arguments, "arguments"); //$NON-NLS-1$
-        return this.newSuperConstructorInvocation0(
-            null,
-            Collections.emptyList(),
-            Arrays.asList(arguments)
-        );
+        return this.newSuperConstructorInvocation0(null, Collections.emptyList(), Arrays.asList(arguments));
     }
 
     @Override
-    public SuperConstructorInvocation newSuperConstructorInvocation(
-            List<? extends Expression> arguments) {
-        return this.newSuperConstructorInvocation0(
-            null,
-            Collections.emptyList(),
-            arguments
-        );
+    public SuperConstructorInvocation newSuperConstructorInvocation(List<? extends Expression> arguments) {
+        return this.newSuperConstructorInvocation0(null, Collections.emptyList(), arguments);
     }
 
     @Override
@@ -2027,11 +1338,7 @@ public class ModelFactoryImpl implements ModelFactory {
             Expression qualifier,
             List<? extends Type> typeArguments,
             List<? extends Expression> arguments) {
-        return this.newSuperConstructorInvocation0(
-            qualifier,
-            typeArguments,
-            arguments
-        );
+        return this.newSuperConstructorInvocation0(qualifier, typeArguments, arguments);
     }
 
     private SuperConstructorInvocationImpl newSuperConstructorInvocation0(
@@ -2050,15 +1357,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public SwitchCaseLabel newSwitchCaseLabel(
-            Expression expression) {
-        return this.newSwitchCaseLabel0(
-            expression
-        );
-    }
-
-    private SwitchCaseLabelImpl newSwitchCaseLabel0(
-            Expression expression) {
+    public SwitchCaseLabel newSwitchCaseLabel(Expression expression) {
         Util.notNull(expression, "expression"); //$NON-NLS-1$
         SwitchCaseLabelImpl result = new SwitchCaseLabelImpl();
         result.setExpression(expression);
@@ -2066,32 +1365,13 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public SwitchDefaultLabel newSwitchDefaultLabel(
-            ) {
-        return this.newSwitchDefaultLabel0(
-
-        );
-    }
-
-    private SwitchDefaultLabelImpl newSwitchDefaultLabel0(
-            ) {
+    public SwitchDefaultLabel newSwitchDefaultLabel() {
         SwitchDefaultLabelImpl result = new SwitchDefaultLabelImpl();
         return result;
     }
 
     @Override
-    public SwitchStatement newSwitchStatement(
-            Expression expression,
-            List<? extends Statement> statements) {
-        return this.newSwitchStatement0(
-            expression,
-            statements
-        );
-    }
-
-    private SwitchStatementImpl newSwitchStatement0(
-            Expression expression,
-            List<? extends Statement> statements) {
+    public SwitchStatement newSwitchStatement(Expression expression, List<? extends Statement> statements) {
         Util.notNull(expression, "expression"); //$NON-NLS-1$
         Util.notNull(statements, "statements"); //$NON-NLS-1$
         Util.notContainNull(statements, "statements"); //$NON-NLS-1$
@@ -2102,18 +1382,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public SynchronizedStatement newSynchronizedStatement(
-            Expression expression,
-            Block body) {
-        return this.newSynchronizedStatement0(
-            expression,
-            body
-        );
-    }
-
-    private SynchronizedStatementImpl newSynchronizedStatement0(
-            Expression expression,
-            Block body) {
+    public SynchronizedStatement newSynchronizedStatement(Expression expression, Block body) {
         Util.notNull(expression, "expression"); //$NON-NLS-1$
         Util.notNull(body, "body"); //$NON-NLS-1$
         SynchronizedStatementImpl result = new SynchronizedStatementImpl();
@@ -2123,37 +1392,14 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public This newThis() {
-        return this.newThis0(
-            null
-        );
-    }
-
-    @Override
-    public This newThis(
-            NamedType qualifier) {
-        return this.newThis0(
-            qualifier
-        );
-    }
-
-    private ThisImpl newThis0(
-            NamedType qualifier) {
+    public This newThis(NamedType qualifier) {
         ThisImpl result = new ThisImpl();
         result.setQualifier(qualifier);
         return result;
     }
 
     @Override
-    public ThrowStatement newThrowStatement(
-            Expression expression) {
-        return this.newThrowStatement0(
-            expression
-        );
-    }
-
-    private ThrowStatementImpl newThrowStatement0(
-            Expression expression) {
+    public ThrowStatement newThrowStatement(Expression expression) {
         Util.notNull(expression, "expression"); //$NON-NLS-1$
         ThrowStatementImpl result = new ThrowStatementImpl();
         result.setExpression(expression);
@@ -2161,21 +1407,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public TryStatement newTryStatement(
-            Block tryBlock,
-            List<? extends CatchClause> catchClauses,
-            Block finallyBlock) {
-        return this.newTryStatement0(
-            tryBlock,
-            catchClauses,
-            finallyBlock
-        );
-    }
-
-    private TryStatementImpl newTryStatement0(
-            Block tryBlock,
-            List<? extends CatchClause> catchClauses,
-            Block finallyBlock) {
+    public TryStatement newTryStatement(Block tryBlock, List<? extends CatchClause> catchClauses, Block finallyBlock) {
         Util.notNull(tryBlock, "tryBlock"); //$NON-NLS-1$
         Util.notNull(catchClauses, "catchClauses"); //$NON-NLS-1$
         Util.notContainNull(catchClauses, "catchClauses"); //$NON-NLS-1$
@@ -2187,28 +1419,17 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public TypeParameterDeclaration newTypeParameterDeclaration(
-            SimpleName name,
-            Type...typeBounds) {
+    public TypeParameterDeclaration newTypeParameterDeclaration(SimpleName name, Type... typeBounds) {
         Util.notNull(typeBounds, "typeBounds"); //$NON-NLS-1$
-        return this.newTypeParameterDeclaration0(
-            name,
-            Arrays.asList(typeBounds)
-        );
+        return this.newTypeParameterDeclaration0(name, Arrays.asList(typeBounds));
     }
 
     @Override
-    public TypeParameterDeclaration newTypeParameterDeclaration(
-            SimpleName name,
-            List<? extends Type> typeBounds) {
-        return this.newTypeParameterDeclaration0(
-            name,
-            typeBounds
-        );
+    public TypeParameterDeclaration newTypeParameterDeclaration(SimpleName name, List<? extends Type> typeBounds) {
+        return this.newTypeParameterDeclaration0(name, typeBounds);
     }
 
-    private TypeParameterDeclarationImpl newTypeParameterDeclaration0(
-            SimpleName name,
+    private TypeParameterDeclarationImpl newTypeParameterDeclaration0(SimpleName name,
             List<? extends Type> typeBounds) {
         Util.notNull(name, "name"); //$NON-NLS-1$
         Util.notNull(typeBounds, "typeBounds"); //$NON-NLS-1$
@@ -2220,18 +1441,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public UnaryExpression newUnaryExpression(
-            UnaryOperator operator,
-            Expression operand) {
-        return this.newUnaryExpression0(
-            operator,
-            operand
-        );
-    }
-
-    private UnaryExpressionImpl newUnaryExpression0(
-            UnaryOperator operator,
-            Expression operand) {
+    public UnaryExpression newUnaryExpression(UnaryOperator operator, Expression operand) {
         Util.notNull(operator, "operator"); //$NON-NLS-1$
         Util.notNull(operand, "operand"); //$NON-NLS-1$
         UnaryExpressionImpl result = new UnaryExpressionImpl();
@@ -2241,32 +1451,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public VariableDeclarator newVariableDeclarator(
-            SimpleName name,
-            Expression initializer) {
-        return this.newVariableDeclarator0(
-            name,
-            0,
-            initializer
-        );
-    }
-
-    @Override
-    public VariableDeclarator newVariableDeclarator(
-            SimpleName name,
-            int extraDimensions,
-            Expression initializer) {
-        return this.newVariableDeclarator0(
-            name,
-            extraDimensions,
-            initializer
-        );
-    }
-
-    private VariableDeclaratorImpl newVariableDeclarator0(
-            SimpleName name,
-            int extraDimensions,
-            Expression initializer) {
+    public VariableDeclarator newVariableDeclarator(SimpleName name, int extraDimensions, Expression initializer) {
         Util.notNull(name, "name"); //$NON-NLS-1$
         VariableDeclaratorImpl result = new VariableDeclaratorImpl();
         result.setName(name);
@@ -2276,18 +1461,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public WhileStatement newWhileStatement(
-            Expression condition,
-            Statement body) {
-        return this.newWhileStatement0(
-            condition,
-            body
-        );
-    }
-
-    private WhileStatementImpl newWhileStatement0(
-            Expression condition,
-            Statement body) {
+    public WhileStatement newWhileStatement(Expression condition, Statement body) {
         Util.notNull(condition, "condition"); //$NON-NLS-1$
         Util.notNull(body, "body"); //$NON-NLS-1$
         WhileStatementImpl result = new WhileStatementImpl();
@@ -2297,26 +1471,7 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
-    public Wildcard newWildcard() {
-        return this.newWildcard0(
-            WildcardBoundKind.UNBOUNDED,
-            null
-        );
-    }
-
-    @Override
-    public Wildcard newWildcard(
-            WildcardBoundKind boundKind,
-            Type typeBound) {
-        return this.newWildcard0(
-            boundKind,
-            typeBound
-        );
-    }
-
-    private WildcardImpl newWildcard0(
-            WildcardBoundKind boundKind,
-            Type typeBound) {
+    public Wildcard newWildcard(WildcardBoundKind boundKind, Type typeBound) {
         Util.notNull(boundKind, "boundKind"); //$NON-NLS-1$
         WildcardImpl result = new WildcardImpl();
         result.setBoundKind(boundKind);
@@ -2330,7 +1485,7 @@ public class ModelFactoryImpl implements ModelFactory {
         }
         ExpressionPriority priority = ExpressionPriority.valueOf(expression);
         if (ExpressionPriority.isParenthesesRequired(context, false, priority)) {
-            return newParenthesizedExpression0(expression);
+            return newParenthesizedExpression(expression);
         } else {
             return expression;
         }
@@ -2342,7 +1497,7 @@ public class ModelFactoryImpl implements ModelFactory {
         }
         ExpressionPriority priority = ExpressionPriority.valueOf(expression);
         if (ExpressionPriority.isParenthesesRequired(context, true, priority)) {
-            return newParenthesizedExpression0(expression);
+            return newParenthesizedExpression(expression);
         } else {
             return expression;
         }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/TryResourceImpl.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/TryResourceImpl.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.utils.java.internal.model.syntax;
+
+import com.asakusafw.utils.java.model.syntax.Expression;
+import com.asakusafw.utils.java.model.syntax.FormalParameterDeclaration;
+import com.asakusafw.utils.java.model.syntax.ModelKind;
+import com.asakusafw.utils.java.model.syntax.TryResource;
+import com.asakusafw.utils.java.model.syntax.Visitor;
+
+/**
+ * An implementation of {@link TryResource}.
+ */
+public final class TryResourceImpl extends ModelRoot implements TryResource {
+
+    private FormalParameterDeclaration parameter;
+
+    private Expression initializer;
+
+    @Override
+    public FormalParameterDeclaration getParameter() {
+        return this.parameter;
+    }
+
+    /**
+     * Sets the resource variable declaration.
+     * @param parameter the resource variable declaration
+     * @throws IllegalArgumentException if {@code parameter} was {@code null}
+     */
+    public void setParameter(FormalParameterDeclaration parameter) {
+        Util.notNull(parameter, "parameter"); //$NON-NLS-1$
+        this.parameter = parameter;
+    }
+
+    @Override
+    public Expression getInitializer() {
+        return this.initializer;
+    }
+
+    /**
+     * Sets the resource expression.
+     * @param initializer the resource expression
+     * @throws IllegalArgumentException if {@code initializer} was {@code null}
+     */
+    public void setInitializer(Expression initializer) {
+        Util.notNull(initializer, "initializer"); //$NON-NLS-1$
+        this.initializer = initializer;
+    }
+
+    /**
+     * Returns {@link ModelKind#TRY_RESOURCE} which represents this element kind.
+     * @return {@link ModelKind#TRY_RESOURCE}
+     */
+    @Override
+    public ModelKind getModelKind() {
+        return ModelKind.TRY_RESOURCE;
+    }
+
+    @Override
+    public <R, C, E extends Throwable> R accept(Visitor<R, C, E> visitor, C context) throws E {
+        Util.notNull(visitor, "visitor"); //$NON-NLS-1$
+        return visitor.visitTryResource(this, context);
+    }
+}

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/TryStatementImpl.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/TryStatementImpl.java
@@ -20,19 +20,40 @@ import java.util.List;
 import com.asakusafw.utils.java.model.syntax.Block;
 import com.asakusafw.utils.java.model.syntax.CatchClause;
 import com.asakusafw.utils.java.model.syntax.ModelKind;
+import com.asakusafw.utils.java.model.syntax.TryResource;
 import com.asakusafw.utils.java.model.syntax.TryStatement;
 import com.asakusafw.utils.java.model.syntax.Visitor;
 
 /**
  * An implementation of {@link TryStatement}.
+ * @since 0.1.0
+ * @version 0.9.0
  */
 public final class TryStatementImpl extends ModelRoot implements TryStatement {
+
+    private List<? extends TryResource> resources;
 
     private Block tryBlock;
 
     private List<? extends CatchClause> catchClauses;
 
     private Block finallyBlock;
+
+    @Override
+    public List<? extends TryResource> getResources() {
+        return resources;
+    }
+
+    /**
+     * Sets the resources.
+     * @param resources the resources
+     * @since 0.9.0
+     */
+    public void setResources(List<? extends TryResource> resources) {
+        Util.notNull(resources, "resources"); //$NON-NLS-1$
+        Util.notContainNull(resources, "resources"); //$NON-NLS-1$
+        this.resources = Util.freeze(resources);
+    }
 
     @Override
     public Block getTryBlock() {

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/UnionTypeImpl.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/UnionTypeImpl.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.utils.java.internal.model.syntax;
+
+import java.util.List;
+
+import com.asakusafw.utils.java.model.syntax.ModelKind;
+import com.asakusafw.utils.java.model.syntax.Type;
+import com.asakusafw.utils.java.model.syntax.UnionType;
+import com.asakusafw.utils.java.model.syntax.Visitor;
+
+/**
+ * An implementation of {@link UnionType}.
+ * @since 0.9.0
+ */
+public class UnionTypeImpl extends ModelRoot implements UnionType {
+
+    private List<? extends Type> alternativeTypes;
+
+    @Override
+    public List<? extends Type> getAlternativeTypes() {
+        return alternativeTypes;
+    }
+
+    /**
+     * Sets the alternatives.
+     * @param alternativeTypes the alternatives
+     */
+    public void setAlternativeTypes(List<? extends Type> alternativeTypes) {
+        Util.notNull(alternativeTypes, "alternativeTypes"); //$NON-NLS-1$
+        Util.notContainNull(alternativeTypes, "alternativeTypes"); //$NON-NLS-1$
+        Util.notEmpty(alternativeTypes, "alternativeTypes"); //$NON-NLS-1$
+        this.alternativeTypes = Util.freeze(alternativeTypes);
+    }
+
+    @Override
+    public ModelKind getModelKind() {
+        return ModelKind.UNION_TYPE;
+    }
+
+    @Override
+    public <R, C, E extends Throwable> R accept(Visitor<R, C, E> visitor, C context) throws E {
+        Util.notNull(visitor, "visitor"); //$NON-NLS-1$
+        return visitor.visitUnionType(this, context);
+    }
+}

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelDigester.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelDigester.java
@@ -64,6 +64,7 @@ import com.asakusafw.utils.java.model.syntax.InstanceofExpression;
 import com.asakusafw.utils.java.model.syntax.InterfaceDeclaration;
 import com.asakusafw.utils.java.model.syntax.Javadoc;
 import com.asakusafw.utils.java.model.syntax.LabeledStatement;
+import com.asakusafw.utils.java.model.syntax.LambdaExpression;
 import com.asakusafw.utils.java.model.syntax.LineComment;
 import com.asakusafw.utils.java.model.syntax.Literal;
 import com.asakusafw.utils.java.model.syntax.LocalClassDeclaration;
@@ -630,6 +631,15 @@ public final class ModelDigester extends StrictVisitor<Void, DigestContext, NoTh
             DigestContext context) {
         digest(elem.getModelKind(), context);
         digest(elem.getLabel(), context);
+        digest(elem.getBody(), context);
+        return null;
+    }
+
+    @Override
+    public Void visitLambdaExpression(
+            LambdaExpression elem,
+            DigestContext context) {
+        digest(elem.getParameters(), context);
         digest(elem.getBody(), context);
         return null;
     }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelDigester.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelDigester.java
@@ -98,6 +98,7 @@ import com.asakusafw.utils.java.model.syntax.ThrowStatement;
 import com.asakusafw.utils.java.model.syntax.TryStatement;
 import com.asakusafw.utils.java.model.syntax.TypeParameterDeclaration;
 import com.asakusafw.utils.java.model.syntax.UnaryExpression;
+import com.asakusafw.utils.java.model.syntax.UnionType;
 import com.asakusafw.utils.java.model.syntax.VariableDeclarator;
 import com.asakusafw.utils.java.model.syntax.WhileStatement;
 import com.asakusafw.utils.java.model.syntax.Wildcard;
@@ -948,6 +949,15 @@ public final class ModelDigester extends StrictVisitor<Void, DigestContext, NoTh
         digest(elem.getModelKind(), context);
         digest(elem.getOperator(), context);
         digest(elem.getOperand(), context);
+        return null;
+    }
+
+    @Override
+    public Void visitUnionType(
+            UnionType elem,
+            DigestContext context) {
+        digest(elem.getModelKind(), context);
+        digest(elem.getAlternativeTypes(), context);
         return null;
     }
 

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelDigester.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelDigester.java
@@ -95,6 +95,7 @@ import com.asakusafw.utils.java.model.syntax.SwitchStatement;
 import com.asakusafw.utils.java.model.syntax.SynchronizedStatement;
 import com.asakusafw.utils.java.model.syntax.This;
 import com.asakusafw.utils.java.model.syntax.ThrowStatement;
+import com.asakusafw.utils.java.model.syntax.TryResource;
 import com.asakusafw.utils.java.model.syntax.TryStatement;
 import com.asakusafw.utils.java.model.syntax.TypeParameterDeclaration;
 import com.asakusafw.utils.java.model.syntax.UnaryExpression;
@@ -922,10 +923,21 @@ public final class ModelDigester extends StrictVisitor<Void, DigestContext, NoTh
     }
 
     @Override
+    public Void visitTryResource(
+            TryResource elem,
+            DigestContext context) {
+        digest(elem.getModelKind(), context);
+        digest(elem.getParameter(), context);
+        digest(elem.getInitializer(), context);
+        return null;
+    }
+
+    @Override
     public Void visitTryStatement(
             TryStatement elem,
             DigestContext context) {
         digest(elem.getModelKind(), context);
+        digest(elem.getResources(), context);
         digest(elem.getTryBlock(), context);
         digest(elem.getCatchClauses(), context);
         digest(elem.getFinallyBlock(), context);

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelEmitter.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelEmitter.java
@@ -114,6 +114,7 @@ import com.asakusafw.utils.java.model.syntax.TryStatement;
 import com.asakusafw.utils.java.model.syntax.Type;
 import com.asakusafw.utils.java.model.syntax.TypeParameterDeclaration;
 import com.asakusafw.utils.java.model.syntax.UnaryExpression;
+import com.asakusafw.utils.java.model.syntax.UnionType;
 import com.asakusafw.utils.java.model.syntax.VariableDeclarator;
 import com.asakusafw.utils.java.model.syntax.WhileStatement;
 import com.asakusafw.utils.java.model.syntax.Wildcard;
@@ -789,7 +790,7 @@ class EmitEngine extends StrictVisitor<Void, EmitContext, NoThrow> {
             processJoinWithComma(parameters, context);
             context.separator(")"); //$NON-NLS-1$
         }
-        context.separator("->"); //$NON-NLS-1$
+        context.operator("->"); //$NON-NLS-1$
         process(elem.getBody(), context);
         return null;
     }
@@ -1191,6 +1192,13 @@ class EmitEngine extends StrictVisitor<Void, EmitContext, NoThrow> {
     }
 
     @Override
+    public Void visitUnionType(UnionType elem, EmitContext context) {
+        begin(elem, context);
+        processJoin("|", elem.getAlternativeTypes(), context); //$NON-NLS-1$
+        return null;
+    }
+
+    @Override
     public Void visitVariableDeclarator(VariableDeclarator elem, EmitContext context) {
         begin(elem, context);
         processInlineComment(elem, context);
@@ -1383,11 +1391,15 @@ class EmitEngine extends StrictVisitor<Void, EmitContext, NoThrow> {
     }
 
     private void processJoinWithComma(List<? extends Model> elements, EmitContext context) {
+        processJoin(",", elements, context); //$NON-NLS-1$
+    }
+
+    private void processJoin(String separator, List<? extends Model> elements, EmitContext context) {
         Iterator<? extends Model> iter = elements.iterator();
         if (iter.hasNext()) {
             process(iter.next(), context);
             while (iter.hasNext()) {
-                context.separator(","); //$NON-NLS-1$
+                context.separator(separator);
                 process(iter.next(), context);
             }
         }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelEmitter.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelEmitter.java
@@ -75,6 +75,8 @@ import com.asakusafw.utils.java.model.syntax.InstanceofExpression;
 import com.asakusafw.utils.java.model.syntax.InterfaceDeclaration;
 import com.asakusafw.utils.java.model.syntax.Javadoc;
 import com.asakusafw.utils.java.model.syntax.LabeledStatement;
+import com.asakusafw.utils.java.model.syntax.LambdaExpression;
+import com.asakusafw.utils.java.model.syntax.LambdaParameter;
 import com.asakusafw.utils.java.model.syntax.LineComment;
 import com.asakusafw.utils.java.model.syntax.Literal;
 import com.asakusafw.utils.java.model.syntax.LocalClassDeclaration;
@@ -774,6 +776,21 @@ class EmitEngine extends StrictVisitor<Void, EmitContext, NoThrow> {
         context.separator(":"); //$NON-NLS-1$
         process(elem.getBody(), context);
         context.statement(EmitDirection.END);
+        return null;
+    }
+
+    @Override
+    public Void visitLambdaExpression(LambdaExpression elem, EmitContext context) {
+        List<? extends LambdaParameter> parameters = elem.getParameters();
+        if (parameters.size() == 1 && parameters.get(0).getModelKind() == ModelKind.SIMPLE_NAME) {
+            process(parameters.get(0), context);
+        } else {
+            context.symbol("("); //$NON-NLS-1$
+            processJoinWithComma(parameters, context);
+            context.separator(")"); //$NON-NLS-1$
+        }
+        context.separator("->"); //$NON-NLS-1$
+        process(elem.getBody(), context);
         return null;
     }
 

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelEmitter.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelEmitter.java
@@ -640,7 +640,7 @@ class EmitEngine extends StrictVisitor<Void, EmitContext, NoThrow> {
     public Void visitFormalParameterDeclaration(FormalParameterDeclaration elem, EmitContext context) {
         begin(elem, context);
         processInlineComment(elem, context);
-        processAttributes(elem.getModifiers(), context);
+        process(elem.getModifiers(), context); // one liner instead of processAttributes(...)
         process(elem.getType(), context);
         if (elem.isVariableArity()) {
             context.separator("..."); //$NON-NLS-1$

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelMatcher.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelMatcher.java
@@ -98,6 +98,7 @@ import com.asakusafw.utils.java.model.syntax.ThrowStatement;
 import com.asakusafw.utils.java.model.syntax.TryStatement;
 import com.asakusafw.utils.java.model.syntax.TypeParameterDeclaration;
 import com.asakusafw.utils.java.model.syntax.UnaryExpression;
+import com.asakusafw.utils.java.model.syntax.UnionType;
 import com.asakusafw.utils.java.model.syntax.VariableDeclarator;
 import com.asakusafw.utils.java.model.syntax.WhileStatement;
 import com.asakusafw.utils.java.model.syntax.Wildcard;
@@ -1543,6 +1544,20 @@ public final class ModelMatcher extends StrictVisitor<Boolean, Model, NoThrow> {
             return Boolean.FALSE;
         }
         if (Boolean.FALSE.equals(match(elem.getOperand(), that.getOperand()))) {
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+
+    @Override
+    public Boolean visitUnionType(
+            UnionType elem,
+            Model context) {
+        if (elem.getModelKind() != context.getModelKind()) {
+            return Boolean.FALSE;
+        }
+        UnionType that = (UnionType) context;
+        if (Boolean.FALSE.equals(match(elem.getAlternativeTypes(), that.getAlternativeTypes()))) {
             return Boolean.FALSE;
         }
         return Boolean.TRUE;

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelMatcher.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelMatcher.java
@@ -64,6 +64,7 @@ import com.asakusafw.utils.java.model.syntax.InstanceofExpression;
 import com.asakusafw.utils.java.model.syntax.InterfaceDeclaration;
 import com.asakusafw.utils.java.model.syntax.Javadoc;
 import com.asakusafw.utils.java.model.syntax.LabeledStatement;
+import com.asakusafw.utils.java.model.syntax.LambdaExpression;
 import com.asakusafw.utils.java.model.syntax.LineComment;
 import com.asakusafw.utils.java.model.syntax.Literal;
 import com.asakusafw.utils.java.model.syntax.LocalClassDeclaration;
@@ -1005,6 +1006,23 @@ public final class ModelMatcher extends StrictVisitor<Boolean, Model, NoThrow> {
         }
         LabeledStatement that = (LabeledStatement) context;
         if (Boolean.FALSE.equals(match(elem.getLabel(), that.getLabel()))) {
+            return Boolean.FALSE;
+        }
+        if (Boolean.FALSE.equals(match(elem.getBody(), that.getBody()))) {
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+
+    @Override
+    public Boolean visitLambdaExpression(
+            LambdaExpression elem,
+            Model context) {
+        if (elem.getModelKind() != context.getModelKind()) {
+            return Boolean.FALSE;
+        }
+        LambdaExpression that = (LambdaExpression) context;
+        if (Boolean.FALSE.equals(match(elem.getParameters(), elem.getParameters()))) {
             return Boolean.FALSE;
         }
         if (Boolean.FALSE.equals(match(elem.getBody(), that.getBody()))) {

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelMatcher.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelMatcher.java
@@ -95,6 +95,7 @@ import com.asakusafw.utils.java.model.syntax.SwitchStatement;
 import com.asakusafw.utils.java.model.syntax.SynchronizedStatement;
 import com.asakusafw.utils.java.model.syntax.This;
 import com.asakusafw.utils.java.model.syntax.ThrowStatement;
+import com.asakusafw.utils.java.model.syntax.TryResource;
 import com.asakusafw.utils.java.model.syntax.TryStatement;
 import com.asakusafw.utils.java.model.syntax.TypeParameterDeclaration;
 import com.asakusafw.utils.java.model.syntax.UnaryExpression;
@@ -1496,6 +1497,23 @@ public final class ModelMatcher extends StrictVisitor<Boolean, Model, NoThrow> {
     }
 
     @Override
+    public Boolean visitTryResource(
+            TryResource elem,
+            Model context) {
+        if (elem.getModelKind() != context.getModelKind()) {
+            return Boolean.FALSE;
+        }
+        TryResource that = (TryResource) context;
+        if (Boolean.FALSE.equals(match(elem.getParameter(), that.getParameter()))) {
+            return Boolean.FALSE;
+        }
+        if (Boolean.FALSE.equals(match(elem.getInitializer(), that.getInitializer()))) {
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+
+    @Override
     public Boolean visitTryStatement(
             TryStatement elem,
             Model context) {
@@ -1503,6 +1521,9 @@ public final class ModelMatcher extends StrictVisitor<Boolean, Model, NoThrow> {
             return Boolean.FALSE;
         }
         TryStatement that = (TryStatement) context;
+        if (Boolean.FALSE.equals(match(elem.getResources(), that.getResources()))) {
+            return Boolean.FALSE;
+        }
         if (Boolean.FALSE.equals(match(elem.getTryBlock(), that.getTryBlock()))) {
             return Boolean.FALSE;
         }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/Block.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/Block.java
@@ -26,7 +26,7 @@ import java.util.List;
  * </ul>
  */
 public interface Block
-        extends Statement {
+        extends Statement, LambdaBody {
 
     /**
      * Returns the element statements.

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/Expression.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/Expression.java
@@ -25,7 +25,7 @@ package com.asakusafw.utils.java.model.syntax;
  * </ul>
  */
 public interface Expression
-        extends TypedElement {
+        extends TypedElement, LambdaBody {
 
     // properties
 }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/FormalParameterDeclaration.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/FormalParameterDeclaration.java
@@ -26,7 +26,7 @@ import java.util.List;
  * </ul>
  */
 public interface FormalParameterDeclaration
-        extends TypedElement {
+        extends TypedElement, LambdaParameter {
 
     /**
      * Returns the modifiers and annotations.
@@ -50,6 +50,7 @@ public interface FormalParameterDeclaration
      * Returns the parameter name.
      * @return the parameter name
      */
+    @Override
     SimpleName getName();
 
     /**

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/LambdaBody.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/LambdaBody.java
@@ -15,26 +15,17 @@
  */
 package com.asakusafw.utils.java.model.syntax;
 
-
 /**
- * An interface which represents simple names.
+ * An abstract super interface of lambda bodies.
  * <ul>
  *   <li> Specified In: <ul>
- *     <li> {@code [JLS3:6.2] Names and Identifiers} </li>
+ *     <li> {@code [JLS8:15.27.2] Lambda Body} </li>
  *   </ul> </li>
  * </ul>
+ * @since 0.9.0
  */
-public interface SimpleName
-        extends Name, LambdaParameter {
+public interface LambdaBody
+        extends Model {
 
-    /**
-     * Returns the identifier.
-     * @return the identifier
-     */
-    String getToken();
-
-    @Override
-    default SimpleName getName() {
-        return this;
-    }
+    // properties
 }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/LambdaExpression.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/LambdaExpression.java
@@ -15,26 +15,28 @@
  */
 package com.asakusafw.utils.java.model.syntax;
 
+import java.util.List;
 
 /**
- * An interface which represents simple names.
+ * An abstract super interface of lambda expressions.
  * <ul>
  *   <li> Specified In: <ul>
- *     <li> {@code [JLS3:6.2] Names and Identifiers} </li>
+ *     <li> {@code [JLS8:15.27] Lambda Expressions} </li>
  *   </ul> </li>
  * </ul>
+ * @since 0.9.0
  */
-public interface SimpleName
-        extends Name, LambdaParameter {
+public interface LambdaExpression extends Expression {
 
     /**
-     * Returns the identifier.
-     * @return the identifier
+     * Returns the lambda parameters.
+     * @return the lambda parameters
      */
-    String getToken();
+    List<? extends LambdaParameter> getParameters();
 
-    @Override
-    default SimpleName getName() {
-        return this;
-    }
+    /**
+     * Returns the lambda body.
+     * @return the lambda body
+     */
+    LambdaBody getBody();
 }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/LambdaParameter.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/LambdaParameter.java
@@ -15,26 +15,21 @@
  */
 package com.asakusafw.utils.java.model.syntax;
 
-
 /**
- * An interface which represents simple names.
+ * An abstract super interface of lambda parameters.
  * <ul>
  *   <li> Specified In: <ul>
- *     <li> {@code [JLS3:6.2] Names and Identifiers} </li>
+ *     <li> {@code [JLS8:15.27.1] Lambda Parameters} </li>
  *   </ul> </li>
  * </ul>
+ * @since 0.9.0
  */
-public interface SimpleName
-        extends Name, LambdaParameter {
+public interface LambdaParameter
+        extends Model {
 
     /**
-     * Returns the identifier.
-     * @return the identifier
+     * Returns the parameter name.
+     * @return the parameter name
      */
-    String getToken();
-
-    @Override
-    default SimpleName getName() {
-        return this;
-    }
+    SimpleName getName();
 }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelFactory.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelFactory.java
@@ -15,14 +15,16 @@
  */
 package com.asakusafw.utils.java.model.syntax;
 
+import java.util.Collections;
 import java.util.List;
-
-import javax.annotation.Generated;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * A factory for providing {@link Model} objects.
+ * @since 0.1.0
+ * @version 0.9.0
  */
-@Generated("com.asakusafw.utils.java.model.syntax.ModelFactory")
 public interface ModelFactory {
 
     /**
@@ -31,9 +33,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code arguments} was {@code null}
      */
-    AlternateConstructorInvocation newAlternateConstructorInvocation(
-            Expression... arguments
-    );
+    AlternateConstructorInvocation newAlternateConstructorInvocation(Expression... arguments);
 
     /**
      * Returns a new {@link AlternateConstructorInvocation} object.
@@ -41,9 +41,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code arguments} was {@code null}
      */
-    AlternateConstructorInvocation newAlternateConstructorInvocation(
-            List<? extends Expression> arguments
-    );
+    AlternateConstructorInvocation newAlternateConstructorInvocation(List<? extends Expression> arguments);
 
     /**
      * Returns a new {@link AlternateConstructorInvocation} object.
@@ -84,10 +82,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code name} was {@code null}
      * @throws IllegalArgumentException if {@code expression} was {@code null}
      */
-    AnnotationElement newAnnotationElement(
-            SimpleName name,
-            Expression expression
-    );
+    AnnotationElement newAnnotationElement(SimpleName name, Expression expression);
 
     /**
      * Returns a new {@link AnnotationElementDeclaration} object.
@@ -117,10 +112,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code array} was {@code null}
      * @throws IllegalArgumentException if {@code index} was {@code null}
      */
-    ArrayAccessExpression newArrayAccessExpression(
-            Expression array,
-            Expression index
-    );
+    ArrayAccessExpression newArrayAccessExpression(Expression array, Expression index);
 
     /**
      * Returns a new {@link ArrayCreationExpression} object.
@@ -129,10 +121,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code type} was {@code null}
      */
-    ArrayCreationExpression newArrayCreationExpression(
-            ArrayType type,
-            ArrayInitializer arrayInitializer
-    );
+    ArrayCreationExpression newArrayCreationExpression(ArrayType type, ArrayInitializer arrayInitializer);
 
     /**
      * Returns a new {@link ArrayCreationExpression} object.
@@ -155,9 +144,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code elements} was {@code null}
      */
-    ArrayInitializer newArrayInitializer(
-            Expression... elements
-    );
+    ArrayInitializer newArrayInitializer(Expression... elements);
 
     /**
      * Returns a new {@link ArrayInitializer} object.
@@ -165,9 +152,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code elements} was {@code null}
      */
-    ArrayInitializer newArrayInitializer(
-            List<? extends Expression> elements
-    );
+    ArrayInitializer newArrayInitializer(List<? extends Expression> elements);
 
     /**
      * Returns a new {@link ArrayType} object.
@@ -175,9 +160,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code componentType} was {@code null}
      */
-    ArrayType newArrayType(
-            Type componentType
-    );
+    ArrayType newArrayType(Type componentType);
 
     /**
      * Returns a new {@link AssertStatement} object.
@@ -185,9 +168,9 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code expression} was {@code null}
      */
-    AssertStatement newAssertStatement(
-            Expression expression
-    );
+    default AssertStatement newAssertStatement(Expression expression) {
+        return newAssertStatement(expression, null);
+    }
 
     /**
      * Returns a new {@link AssertStatement} object.
@@ -196,10 +179,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code expression} was {@code null}
      */
-    AssertStatement newAssertStatement(
-            Expression expression,
-            Expression message
-    );
+    AssertStatement newAssertStatement(Expression expression, Expression message);
 
     /**
      * Returns a new {@link AssignmentExpression} object.
@@ -209,10 +189,9 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code leftHandSide} was {@code null}
      * @throws IllegalArgumentException if {@code rightHandSide} was {@code null}
      */
-    AssignmentExpression newAssignmentExpression(
-            Expression leftHandSide,
-            Expression rightHandSide
-    );
+    default AssignmentExpression newAssignmentExpression(Expression leftHandSide, Expression rightHandSide) {
+        return newAssignmentExpression(leftHandSide, InfixOperator.ASSIGN, rightHandSide);
+    }
 
     /**
      * Returns a new {@link AssignmentExpression} object.
@@ -236,9 +215,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code typeKind} was {@code null}
      */
-    BasicType newBasicType(
-            BasicTypeKind typeKind
-    );
+    BasicType newBasicType(BasicTypeKind typeKind);
 
     /**
      * Returns a new {@link Block} object.
@@ -246,9 +223,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code statements} was {@code null}
      */
-    Block newBlock(
-            Statement... statements
-    );
+    Block newBlock(Statement... statements);
 
     /**
      * Returns a new {@link Block} object.
@@ -256,9 +231,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code statements} was {@code null}
      */
-    Block newBlock(
-            List<? extends Statement> statements
-    );
+    Block newBlock(List<? extends Statement> statements);
 
     /**
      * Returns a new {@link BlockComment} object.
@@ -267,24 +240,22 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code string} was {@code null}
      * @throws IllegalArgumentException if {@code string} was empty
      */
-    BlockComment newBlockComment(
-            String string
-    );
+    BlockComment newBlockComment(String string);
 
     /**
      * Returns a new {@link BreakStatement} object.
      * @return the created object
      */
-    BreakStatement newBreakStatement();
+    default BreakStatement newBreakStatement() {
+        return newBreakStatement(null);
+    }
 
     /**
      * Returns a new {@link BreakStatement} object.
      * @param target the target label, or {@code null} if there is no target labels
      * @return the created object
      */
-    BreakStatement newBreakStatement(
-            SimpleName target
-    );
+    BreakStatement newBreakStatement(SimpleName target);
 
     /**
      * Returns a new {@link CastExpression} object.
@@ -294,10 +265,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code type} was {@code null}
      * @throws IllegalArgumentException if {@code expression} was {@code null}
      */
-    CastExpression newCastExpression(
-            Type type,
-            Expression expression
-    );
+    CastExpression newCastExpression(Type type, Expression expression);
 
     /**
      * Returns a new {@link CatchClause} object.
@@ -307,10 +275,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code parameter} was {@code null}
      * @throws IllegalArgumentException if {@code body} was {@code null}
      */
-    CatchClause newCatchClause(
-            FormalParameterDeclaration parameter,
-            Block body
-    );
+    CatchClause newCatchClause(FormalParameterDeclaration parameter, Block body);
 
     /**
      * Returns a new {@link ClassBody} object.
@@ -318,9 +283,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code bodyDeclarations} was {@code null}
      */
-    ClassBody newClassBody(
-            List<? extends TypeBodyDeclaration> bodyDeclarations
-    );
+    ClassBody newClassBody(List<? extends TypeBodyDeclaration> bodyDeclarations);
 
     /**
      * Returns a new {@link ClassDeclaration} object.
@@ -379,10 +342,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code type} was {@code null}
      * @throws IllegalArgumentException if {@code arguments} was {@code null}
      */
-    ClassInstanceCreationExpression newClassInstanceCreationExpression(
-            Type type,
-            Expression... arguments
-    );
+    ClassInstanceCreationExpression newClassInstanceCreationExpression(Type type, Expression... arguments);
 
     /**
      * Returns a new {@link ClassInstanceCreationExpression} object.
@@ -423,9 +383,26 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code type} was {@code null}
      */
-    ClassLiteral newClassLiteral(
-            Type type
-    );
+    ClassLiteral newClassLiteral(Type type);
+
+    /**
+     * Returns a new {@link CompilationUnit} object.
+     * @param packageDeclaration the package declaration,
+     *     or {@code null} if this compilation unit is on the default (unnamed) package
+     * @param importDeclarations the import declarations
+     * @param typeDeclarations the type declarations
+     * @return the created object
+     * @throws IllegalArgumentException if {@code importDeclarations} was {@code null}
+     * @throws IllegalArgumentException if {@code typeDeclarations} was {@code null}
+     * @throws IllegalArgumentException if {@code comments} was {@code null}
+     * @since 0.9.0
+     */
+    default CompilationUnit newCompilationUnit(
+            PackageDeclaration packageDeclaration,
+            List<? extends ImportDeclaration> importDeclarations,
+            List<? extends TypeDeclaration> typeDeclarations) {
+        return newCompilationUnit(packageDeclaration, importDeclarations, typeDeclarations, Collections.emptyList());
+    }
 
     /**
      * Returns a new {@link CompilationUnit} object.
@@ -514,16 +491,16 @@ public interface ModelFactory {
      * Returns a new {@link ContinueStatement} object.
      * @return the created object
      */
-    ContinueStatement newContinueStatement();
+    default ContinueStatement newContinueStatement() {
+        return newContinueStatement(null);
+    }
 
     /**
      * Returns a new {@link ContinueStatement} object.
      * @param target the target label, or {@code null} if there is no target labels
      * @return the created object
      */
-    ContinueStatement newContinueStatement(
-            SimpleName target
-    );
+    ContinueStatement newContinueStatement(SimpleName target);
 
     /**
      * Returns a new {@link DoStatement} object.
@@ -533,10 +510,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code body} was {@code null}
      * @throws IllegalArgumentException if {@code condition} was {@code null}
      */
-    DoStatement newDoStatement(
-            Statement body,
-            Expression condition
-    );
+    DoStatement newDoStatement(Statement body, Expression condition);
 
     /**
      * Returns a new {@link DocBlock} object.
@@ -546,10 +520,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code tag} was {@code null}
      * @throws IllegalArgumentException if {@code elements} was {@code null}
      */
-    DocBlock newDocBlock(
-            String tag,
-            List<? extends DocElement> elements
-    );
+    DocBlock newDocBlock(String tag, List<? extends DocElement> elements);
 
     /**
      * Returns a new {@link DocField} object.
@@ -558,10 +529,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code name} was {@code null}
      */
-    DocField newDocField(
-            Type type,
-            SimpleName name
-    );
+    DocField newDocField(Type type, SimpleName name);
 
     /**
      * Returns a new {@link DocMethod} object.
@@ -572,11 +540,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code name} was {@code null}
      * @throws IllegalArgumentException if {@code formalParameters} was {@code null}
      */
-    DocMethod newDocMethod(
-            Type type,
-            SimpleName name,
-            List<? extends DocMethodParameter> formalParameters
-    );
+    DocMethod newDocMethod(Type type, SimpleName name, List<? extends DocMethodParameter> formalParameters);
 
     /**
      * Returns a new {@link DocMethodParameter} object.
@@ -586,11 +550,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code type} was {@code null}
      */
-    DocMethodParameter newDocMethodParameter(
-            Type type,
-            SimpleName name,
-            boolean variableArity
-    );
+    DocMethodParameter newDocMethodParameter(Type type, SimpleName name, boolean variableArity);
 
     /**
      * Returns a new {@link DocText} object.
@@ -598,17 +558,13 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code string} was {@code null}
      */
-    DocText newDocText(
-            String string
-    );
+    DocText newDocText(String string);
 
     /**
      * Returns a new {@link EmptyStatement} object.
      * @return the created object
      */
-    EmptyStatement newEmptyStatement(
-
-    );
+    EmptyStatement newEmptyStatement();
 
     /**
      * Returns a new {@link EnhancedForStatement} object.
@@ -712,9 +668,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code expression} was {@code null}
      */
-    ExpressionStatement newExpressionStatement(
-            Expression expression
-    );
+    ExpressionStatement newExpressionStatement(Expression expression);
 
     /**
      * Returns a new {@link FieldAccessExpression} object.
@@ -724,10 +678,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code qualifier} was {@code null}
      * @throws IllegalArgumentException if {@code name} was {@code null}
      */
-    FieldAccessExpression newFieldAccessExpression(
-            Expression qualifier,
-            SimpleName name
-    );
+    FieldAccessExpression newFieldAccessExpression(Expression qualifier, SimpleName name);
 
     /**
      * Returns a new {@link FieldDeclaration} object.
@@ -792,10 +743,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code type} was {@code null}
      * @throws IllegalArgumentException if {@code name} was {@code null}
      */
-    FormalParameterDeclaration newFormalParameterDeclaration(
-            Type type,
-            SimpleName name
-    );
+    FormalParameterDeclaration newFormalParameterDeclaration(Type type, SimpleName name);
 
     /**
      * Returns a new {@link FormalParameterDeclaration} object.
@@ -826,10 +774,9 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code condition} was {@code null}
      * @throws IllegalArgumentException if {@code thenStatement} was {@code null}
      */
-    IfStatement newIfStatement(
-            Expression condition,
-            Statement thenStatement
-    );
+    default IfStatement newIfStatement(Expression condition, Statement thenStatement) {
+        return newIfStatement(condition, thenStatement, null);
+    }
 
     /**
      * Returns a new {@link IfStatement} object.
@@ -840,11 +787,18 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code condition} was {@code null}
      * @throws IllegalArgumentException if {@code thenStatement} was {@code null}
      */
-    IfStatement newIfStatement(
-            Expression condition,
-            Statement thenStatement,
-            Statement elseStatement
-    );
+    IfStatement newIfStatement(Expression condition, Statement thenStatement, Statement elseStatement);
+
+    /**
+     * Returns a new {@link ImportDeclaration} object.
+     * @param name the import target name
+     * @return the created object
+     * @throws IllegalArgumentException if {@code importKind} was {@code null}
+     * @throws IllegalArgumentException if {@code name} was {@code null}
+     */
+    default ImportDeclaration newImportDeclaration(Name name) {
+        return newImportDeclaration(ImportKind.SINGLE_TYPE, name);
+    }
 
     /**
      * Returns a new {@link ImportDeclaration} object.
@@ -854,10 +808,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code importKind} was {@code null}
      * @throws IllegalArgumentException if {@code name} was {@code null}
      */
-    ImportDeclaration newImportDeclaration(
-            ImportKind importKind,
-            Name name
-    );
+    ImportDeclaration newImportDeclaration(ImportKind importKind, Name name);
 
     /**
      * Returns a new {@link InfixExpression} object.
@@ -869,11 +820,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code operator} was {@code null}
      * @throws IllegalArgumentException if {@code rightOperand} was {@code null}
      */
-    InfixExpression newInfixExpression(
-            Expression leftOperand,
-            InfixOperator operator,
-            Expression rightOperand
-    );
+    InfixExpression newInfixExpression(Expression leftOperand, InfixOperator operator, Expression rightOperand);
 
     /**
      * Returns a new {@link InitializerDeclaration} object.
@@ -881,9 +828,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code body} was {@code null}
      */
-    InitializerDeclaration newInitializerDeclaration(
-            List<? extends Statement> body
-    );
+    InitializerDeclaration newInitializerDeclaration(List<? extends Statement> body);
 
     /**
      * Returns a new {@link InitializerDeclaration} object.
@@ -908,10 +853,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code expression} was {@code null}
      * @throws IllegalArgumentException if {@code type} was {@code null}
      */
-    InstanceofExpression newInstanceofExpression(
-            Expression expression,
-            Type type
-    );
+    InstanceofExpression newInstanceofExpression(Expression expression, Type type);
 
     /**
      * Returns a new {@link InterfaceDeclaration} object.
@@ -964,9 +906,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code blocks} was {@code null}
      */
-    Javadoc newJavadoc(
-            List<? extends DocBlock> blocks
-    );
+    Javadoc newJavadoc(List<? extends DocBlock> blocks);
 
     /**
      * Returns a new {@link LabeledStatement} object.
@@ -976,10 +916,73 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code label} was {@code null}
      * @throws IllegalArgumentException if {@code body} was {@code null}
      */
-    LabeledStatement newLabeledStatement(
-            SimpleName label,
-            Statement body
-    );
+    LabeledStatement newLabeledStatement(SimpleName label, Statement body);
+
+    /**
+     * Returns a new {@link LambdaExpression} object.
+     * @param parameters the lambda parameters
+     * @param body the lambda body
+     * @return the created object
+     * @throws IllegalArgumentException if {@code parameters} was {@code null}
+     * @throws IllegalArgumentException if {@code body} was {@code null}
+     * @since 0.9.0
+     */
+    LambdaExpression newLambdaExpression(List<? extends LambdaParameter> parameters, LambdaBody body);
+
+    /**
+     * Returns a new {@link LambdaExpression} object.
+     * @param parameter the lambda parameter name
+     * @param body the lambda body
+     * @return the created object
+     * @throws IllegalArgumentException if {@code parameters} was {@code null}
+     * @throws IllegalArgumentException if {@code body} was {@code null}
+     * @since 0.9.0
+     */
+    LambdaExpression newLambdaExpression(LambdaParameter parameter, LambdaBody body);
+
+    /**
+     * Returns a new {@link LambdaExpression} object.
+     * @param body the lambda body
+     * @return the created object
+     * @throws IllegalArgumentException if {@code parameters} was {@code null}
+     * @throws IllegalArgumentException if {@code body} was {@code null}
+     * @since 0.9.0
+     */
+    default LambdaExpression newLambdaExpression(LambdaBody body) {
+        return newLambdaExpression(Collections.emptyList(), body);
+    }
+
+    /**
+     * Returns a new {@link LambdaExpression} object.
+     * @param parameters the lambda parameters
+     * @param lambda the lambda function body
+     * @return the created object
+     * @throws IllegalArgumentException if {@code parameters} was {@code null}
+     * @throws IllegalArgumentException if {@code body} was {@code null}
+     * @since 0.9.0
+     */
+    default LambdaExpression newLambdaExpression(
+            List<? extends LambdaParameter> parameters,
+            Function<? super List<? extends SimpleName>, ? extends LambdaBody> lambda) {
+        return newLambdaExpression(
+                parameters,
+                lambda.apply(parameters.stream().map(LambdaParameter::getName).collect(Collectors.toList())));
+    }
+
+    /**
+     * Returns a new {@link LambdaExpression} object.
+     * @param parameter the lambda parameter name
+     * @param lambda the lambda function body
+     * @return the created object
+     * @throws IllegalArgumentException if {@code parameters} was {@code null}
+     * @throws IllegalArgumentException if {@code body} was {@code null}
+     * @since 0.9.0
+     */
+    default LambdaExpression newLambdaExpression(
+            LambdaParameter parameter,
+            Function<? super SimpleName, ? extends LambdaBody> lambda) {
+        return newLambdaExpression(parameter, lambda.apply(parameter.getName()));
+    }
 
     /**
      * Returns a new {@link LineComment} object.
@@ -988,9 +991,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code string} was {@code null}
      * @throws IllegalArgumentException if {@code string} was empty
      */
-    LineComment newLineComment(
-            String string
-    );
+    LineComment newLineComment(String string);
 
     /**
      * Returns a new {@link Literal} object.
@@ -999,9 +1000,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code token} was {@code null}
      * @throws IllegalArgumentException if {@code token} was empty
      */
-    Literal newLiteral(
-            String token
-    );
+    Literal newLiteral(String token);
 
     /**
      * Returns a new {@link LocalClassDeclaration} object.
@@ -1009,9 +1008,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code declaration} was {@code null}
      */
-    LocalClassDeclaration newLocalClassDeclaration(
-            ClassDeclaration declaration
-    );
+    LocalClassDeclaration newLocalClassDeclaration(ClassDeclaration declaration);
 
     /**
      * Returns a new {@link LocalVariableDeclaration} object.
@@ -1022,11 +1019,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code type} was {@code null}
      * @throws IllegalArgumentException if {@code name} was {@code null}
      */
-    LocalVariableDeclaration newLocalVariableDeclaration(
-            Type type,
-            SimpleName name,
-            Expression initializer
-    );
+    LocalVariableDeclaration newLocalVariableDeclaration(Type type, SimpleName name, Expression initializer);
 
     /**
      * Returns a new {@link LocalVariableDeclaration} object.
@@ -1051,9 +1044,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code type} was {@code null}
      */
-    MarkerAnnotation newMarkerAnnotation(
-            NamedType type
-    );
+    MarkerAnnotation newMarkerAnnotation(NamedType type);
 
     /**
      * Returns a new {@link MethodDeclaration} object.
@@ -1167,9 +1158,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code modifierKind} was {@code null}
      */
-    Modifier newModifier(
-            ModifierKind modifierKind
-    );
+    Modifier newModifier(ModifierKind modifierKind);
 
     /**
      * Returns a new {@link NamedType} object.
@@ -1177,9 +1166,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code name} was {@code null}
      */
-    NamedType newNamedType(
-            Name name
-    );
+    NamedType newNamedType(Name name);
 
     /**
      * Returns a new {@link NormalAnnotation} object.
@@ -1189,10 +1176,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code type} was {@code null}
      * @throws IllegalArgumentException if {@code elements} was {@code null}
      */
-    NormalAnnotation newNormalAnnotation(
-            NamedType type,
-            List<? extends AnnotationElement> elements
-    );
+    NormalAnnotation newNormalAnnotation(NamedType type, List<? extends AnnotationElement> elements);
 
     /**
      * Returns a new {@link PackageDeclaration} object.
@@ -1200,9 +1184,9 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code name} was {@code null}
      */
-    PackageDeclaration newPackageDeclaration(
-            Name name
-    );
+    default PackageDeclaration newPackageDeclaration(Name name) {
+        return newPackageDeclaration(null, Collections.emptyList(), name);
+    }
 
     /**
      * Returns a new {@link PackageDeclaration} object.
@@ -1213,11 +1197,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code annotations} was {@code null}
      * @throws IllegalArgumentException if {@code name} was {@code null}
      */
-    PackageDeclaration newPackageDeclaration(
-            Javadoc javadoc,
-            List<? extends Annotation> annotations,
-            Name name
-    );
+    PackageDeclaration newPackageDeclaration(Javadoc javadoc, List<? extends Annotation> annotations, Name name);
 
     /**
      * Returns a new {@link ParameterizedType} object.
@@ -1227,10 +1207,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code type} was {@code null}
      * @throws IllegalArgumentException if {@code typeArguments} was {@code null}
      */
-    ParameterizedType newParameterizedType(
-            Type type,
-            Type... typeArguments
-    );
+    ParameterizedType newParameterizedType(Type type, Type... typeArguments);
 
     /**
      * Returns a new {@link ParameterizedType} object.
@@ -1240,10 +1217,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code type} was {@code null}
      * @throws IllegalArgumentException if {@code typeArguments} was {@code null}
      */
-    ParameterizedType newParameterizedType(
-            Type type,
-            List<? extends Type> typeArguments
-    );
+    ParameterizedType newParameterizedType(Type type, List<? extends Type> typeArguments);
 
     /**
      * Returns a new {@link ParenthesizedExpression} object.
@@ -1251,9 +1225,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code expression} was {@code null}
      */
-    ParenthesizedExpression newParenthesizedExpression(
-            Expression expression
-    );
+    ParenthesizedExpression newParenthesizedExpression(Expression expression);
 
     /**
      * Returns a new {@link PostfixExpression} object.
@@ -1263,10 +1235,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code operand} was {@code null}
      * @throws IllegalArgumentException if {@code operator} was {@code null}
      */
-    PostfixExpression newPostfixExpression(
-            Expression operand,
-            PostfixOperator operator
-    );
+    PostfixExpression newPostfixExpression(Expression operand, PostfixOperator operator);
 
     /**
      * Returns a new {@link QualifiedName} object.
@@ -1276,10 +1245,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code qualifier} was {@code null}
      * @throws IllegalArgumentException if {@code simpleName} was {@code null}
      */
-    QualifiedName newQualifiedName(
-            Name qualifier,
-            SimpleName simpleName
-    );
+    QualifiedName newQualifiedName(Name qualifier, SimpleName simpleName);
 
     /**
      * Returns a new {@link QualifiedType} object.
@@ -1289,25 +1255,22 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code qualifier} was {@code null}
      * @throws IllegalArgumentException if {@code simpleName} was {@code null}
      */
-    QualifiedType newQualifiedType(
-            Type qualifier,
-            SimpleName simpleName
-    );
+    QualifiedType newQualifiedType(Type qualifier, SimpleName simpleName);
 
     /**
      * Returns a new {@link ReturnStatement} object.
      * @return the created object
      */
-    ReturnStatement newReturnStatement();
+    default ReturnStatement newReturnStatement() {
+        return newReturnStatement(null);
+    }
 
     /**
      * Returns a new {@link ReturnStatement} object.
      * @param expression the expression, or {@code null} if this does not return anything
      * @return the created object
      */
-    ReturnStatement newReturnStatement(
-            Expression expression
-    );
+    ReturnStatement newReturnStatement(Expression expression);
 
     /**
      * Returns a new {@link SimpleName} object.
@@ -1316,9 +1279,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code string} was {@code null}
      * @throws IllegalArgumentException if {@code string} was empty
      */
-    SimpleName newSimpleName(
-            String string
-    );
+    SimpleName newSimpleName(String string);
 
     /**
      * Returns a new {@link SingleElementAnnotation} object.
@@ -1328,10 +1289,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code type} was {@code null}
      * @throws IllegalArgumentException if {@code expression} was {@code null}
      */
-    SingleElementAnnotation newSingleElementAnnotation(
-            NamedType type,
-            Expression expression
-    );
+    SingleElementAnnotation newSingleElementAnnotation(NamedType type, Expression expression);
 
     /**
      * Returns a new {@link StatementExpressionList} object.
@@ -1340,9 +1298,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code expressions} was {@code null}
      * @throws IllegalArgumentException if {@code expressions} was empty
      */
-    StatementExpressionList newStatementExpressionList(
-            Expression... expressions
-    );
+    StatementExpressionList newStatementExpressionList(Expression... expressions);
 
     /**
      * Returns a new {@link StatementExpressionList} object.
@@ -1351,24 +1307,22 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code expressions} was {@code null}
      * @throws IllegalArgumentException if {@code expressions} was empty
      */
-    StatementExpressionList newStatementExpressionList(
-            List<? extends Expression> expressions
-    );
+    StatementExpressionList newStatementExpressionList(List<? extends Expression> expressions);
 
     /**
      * Returns a new {@link Super} object.
      * @return the created object
      */
-    Super newSuper();
+    default Super newSuper() {
+        return newSuper(null);
+    }
 
     /**
      * Returns a new {@link Super} object.
      * @param qualifier the type qualifier, or {@code null} if there is no type qualifier
      * @return the created object
      */
-    Super newSuper(
-            NamedType qualifier
-    );
+    Super newSuper(NamedType qualifier);
 
     /**
      * Returns a new {@link SuperConstructorInvocation} object.
@@ -1376,9 +1330,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code arguments} was {@code null}
      */
-    SuperConstructorInvocation newSuperConstructorInvocation(
-            Expression... arguments
-    );
+    SuperConstructorInvocation newSuperConstructorInvocation(Expression... arguments);
 
     /**
      * Returns a new {@link SuperConstructorInvocation} object.
@@ -1386,9 +1338,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code arguments} was {@code null}
      */
-    SuperConstructorInvocation newSuperConstructorInvocation(
-            List<? extends Expression> arguments
-    );
+    SuperConstructorInvocation newSuperConstructorInvocation(List<? extends Expression> arguments);
 
     /**
      * Returns a new {@link SuperConstructorInvocation} object.
@@ -1411,17 +1361,13 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code expression} was {@code null}
      */
-    SwitchCaseLabel newSwitchCaseLabel(
-            Expression expression
-    );
+    SwitchCaseLabel newSwitchCaseLabel(Expression expression);
 
     /**
      * Returns a new {@link SwitchDefaultLabel} object.
      * @return the created object
      */
-    SwitchDefaultLabel newSwitchDefaultLabel(
-
-    );
+    SwitchDefaultLabel newSwitchDefaultLabel();
 
     /**
      * Returns a new {@link SwitchStatement} object.
@@ -1431,10 +1377,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code expression} was {@code null}
      * @throws IllegalArgumentException if {@code statements} was {@code null}
      */
-    SwitchStatement newSwitchStatement(
-            Expression expression,
-            List<? extends Statement> statements
-    );
+    SwitchStatement newSwitchStatement(Expression expression, List<? extends Statement> statements);
 
     /**
      * Returns a new {@link SynchronizedStatement} object.
@@ -1444,25 +1387,22 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code expression} was {@code null}
      * @throws IllegalArgumentException if {@code body} was {@code null}
      */
-    SynchronizedStatement newSynchronizedStatement(
-            Expression expression,
-            Block body
-    );
+    SynchronizedStatement newSynchronizedStatement(Expression expression, Block body);
 
     /**
      * Returns a new {@link This} object.
      * @return the created object
      */
-    This newThis();
+    default This newThis() {
+        return newThis(null);
+    }
 
     /**
      * Returns a new {@link This} object.
      * @param qualifier the type qualifier, or {@code null} if there is no type qualifier
      * @return the created object
      */
-    This newThis(
-            NamedType qualifier
-    );
+    This newThis(NamedType qualifier);
 
     /**
      * Returns a new {@link ThrowStatement} object.
@@ -1470,9 +1410,7 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code expression} was {@code null}
      */
-    ThrowStatement newThrowStatement(
-            Expression expression
-    );
+    ThrowStatement newThrowStatement(Expression expression);
 
     /**
      * Returns a new {@link TryStatement} object.
@@ -1497,10 +1435,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code name} was {@code null}
      * @throws IllegalArgumentException if {@code typeBounds} was {@code null}
      */
-    TypeParameterDeclaration newTypeParameterDeclaration(
-            SimpleName name,
-            Type... typeBounds
-    );
+    TypeParameterDeclaration newTypeParameterDeclaration(SimpleName name, Type... typeBounds);
 
     /**
      * Returns a new {@link TypeParameterDeclaration} object.
@@ -1510,10 +1445,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code name} was {@code null}
      * @throws IllegalArgumentException if {@code typeBounds} was {@code null}
      */
-    TypeParameterDeclaration newTypeParameterDeclaration(
-            SimpleName name,
-            List<? extends Type> typeBounds
-    );
+    TypeParameterDeclaration newTypeParameterDeclaration(SimpleName name, List<? extends Type> typeBounds);
 
     /**
      * Returns a new {@link UnaryExpression} object.
@@ -1523,10 +1455,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code operator} was {@code null}
      * @throws IllegalArgumentException if {@code operand} was {@code null}
      */
-    UnaryExpression newUnaryExpression(
-            UnaryOperator operator,
-            Expression operand
-    );
+    UnaryExpression newUnaryExpression(UnaryOperator operator, Expression operand);
 
     /**
      * Returns a new {@link VariableDeclarator} object.
@@ -1535,10 +1464,9 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code name} was {@code null}
      */
-    VariableDeclarator newVariableDeclarator(
-            SimpleName name,
-            Expression initializer
-    );
+    default VariableDeclarator newVariableDeclarator(SimpleName name, Expression initializer) {
+        return newVariableDeclarator(name, 0, initializer);
+    }
 
     /**
      * Returns a new {@link VariableDeclarator} object.
@@ -1549,11 +1477,7 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code name} was {@code null}
      * @throws IllegalArgumentException if {@code extraDimensions} was negative
      */
-    VariableDeclarator newVariableDeclarator(
-            SimpleName name,
-            int extraDimensions,
-            Expression initializer
-    );
+    VariableDeclarator newVariableDeclarator(SimpleName name, int extraDimensions, Expression initializer);
 
     /**
      * Returns a new {@link WhileStatement} object.
@@ -1563,16 +1487,15 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code condition} was {@code null}
      * @throws IllegalArgumentException if {@code body} was {@code null}
      */
-    WhileStatement newWhileStatement(
-            Expression condition,
-            Statement body
-    );
+    WhileStatement newWhileStatement(Expression condition, Statement body);
 
     /**
      * Returns a new {@link Wildcard} object.
      * @return the created object
      */
-    Wildcard newWildcard();
+    default Wildcard newWildcard() {
+        return newWildcard(WildcardBoundKind.UNBOUNDED, null);
+    }
 
     /**
      * Returns a new {@link Wildcard} object.
@@ -1581,8 +1504,5 @@ public interface ModelFactory {
      * @return the created object
      * @throws IllegalArgumentException if {@code boundKind} was {@code null}
      */
-    Wildcard newWildcard(
-            WildcardBoundKind boundKind,
-            Type typeBound
-    );
+    Wildcard newWildcard(WildcardBoundKind boundKind, Type typeBound);
 }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelFactory.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelFactory.java
@@ -269,6 +269,24 @@ public interface ModelFactory {
 
     /**
      * Returns a new {@link CatchClause} object.
+     * @param type the exception type
+     * @param name the exception parameter name
+     * @param body the {@code catch} block with exception parameter name
+     * @return the created object
+     * @throws IllegalArgumentException if {@code parameter} was {@code null}
+     * @throws IllegalArgumentException if {@code body} was {@code null}
+     * @since 0.9.0
+     */
+    default CatchClause newCatchClause(
+            Type type, SimpleName name,
+            Function<? super SimpleName, ? extends Block> body) {
+        return newCatchClause(
+                newFormalParameterDeclaration(type, name),
+                body.apply(name));
+    }
+
+    /**
+     * Returns a new {@link CatchClause} object.
      * @param parameter the expression parameter
      * @param body the {@code catch} block
      * @return the created object
@@ -568,6 +586,26 @@ public interface ModelFactory {
 
     /**
      * Returns a new {@link EnhancedForStatement} object.
+     * @param type the loop variable type
+     * @param name the loop variable name
+     * @param expression the loop target
+     * @param body the loop body
+     * @return the created object
+     * @throws IllegalArgumentException if {@code parameter} was {@code null}
+     * @throws IllegalArgumentException if {@code expression} was {@code null}
+     * @throws IllegalArgumentException if {@code body} was {@code null}
+     * @since 0.9.0
+     */
+    default EnhancedForStatement newEnhancedForStatement(
+            Type type,
+            SimpleName name,
+            Expression expression,
+            Statement body) {
+        return newEnhancedForStatement(newFormalParameterDeclaration(type, name), expression, body);
+    }
+
+    /**
+     * Returns a new {@link EnhancedForStatement} object.
      * @param parameter the loop parameter
      * @param expression the loop target
      * @param body the loop body
@@ -743,7 +781,9 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code type} was {@code null}
      * @throws IllegalArgumentException if {@code name} was {@code null}
      */
-    FormalParameterDeclaration newFormalParameterDeclaration(Type type, SimpleName name);
+    default FormalParameterDeclaration newFormalParameterDeclaration(Type type, SimpleName name) {
+        return newFormalParameterDeclaration(Collections.emptyList(), type, false, name, 0);
+    }
 
     /**
      * Returns a new {@link FormalParameterDeclaration} object.
@@ -1413,6 +1453,55 @@ public interface ModelFactory {
     ThrowStatement newThrowStatement(Expression expression);
 
     /**
+     * Returns a new {@link TryResource} object.
+     * @param type the resource type
+     * @param name the resource name
+     * @param expression the resource expression
+     * @return the created object
+     * @throws IllegalArgumentException if parameters are {@code null}
+     * @since 0.9.0
+     */
+    default TryResource newTryResource(Type type, SimpleName name, Expression expression) {
+        return newTryResource(newFormalParameterDeclaration(type, name), expression);
+    }
+
+    /**
+     * Returns a new {@link TryResource} object.
+     * @param parameter the resource variable declaration
+     * @param expression the resource expression
+     * @return the created object
+     * @throws IllegalArgumentException if parameters are {@code null}
+     * @since 0.9.0
+     */
+    TryResource newTryResource(FormalParameterDeclaration parameter, Expression expression);
+
+    /**
+     * Returns a new {@link TryStatement} object.
+     * @param tryBlock the {@code try} clause
+     * @param catchClauses the {@code catch} clauses
+     * @return the created object
+     * @throws IllegalArgumentException if {@code tryBlock} was {@code null}
+     * @throws IllegalArgumentException if {@code catchClauses} was {@code null}
+     * @since 0.9.0
+     */
+    default TryStatement newTryStatement(Block tryBlock, List<? extends CatchClause> catchClauses) {
+        return newTryStatement(Collections.emptyList(), tryBlock, catchClauses, null);
+    }
+
+    /**
+     * Returns a new {@link TryStatement} object.
+     * @param tryBlock the {@code try} clause
+     * @param finallyBlock the {@code finally} clause, or {@code null} if it is not specified
+     * @return the created object
+     * @throws IllegalArgumentException if {@code tryBlock} was {@code null}
+     * @throws IllegalArgumentException if {@code catchClauses} was {@code null}
+     * @since 0.9.0
+     */
+    default TryStatement newTryStatement(Block tryBlock, Block finallyBlock) {
+        return newTryStatement(Collections.emptyList(), tryBlock, Collections.emptyList(), finallyBlock);
+    }
+
+    /**
      * Returns a new {@link TryStatement} object.
      * @param tryBlock the {@code try} clause
      * @param catchClauses the {@code catch} clauses
@@ -1421,11 +1510,86 @@ public interface ModelFactory {
      * @throws IllegalArgumentException if {@code tryBlock} was {@code null}
      * @throws IllegalArgumentException if {@code catchClauses} was {@code null}
      */
-    TryStatement newTryStatement(
+    default TryStatement newTryStatement(
             Block tryBlock,
             List<? extends CatchClause> catchClauses,
-            Block finallyBlock
-    );
+            Block finallyBlock) {
+        return newTryStatement(Collections.emptyList(), tryBlock, catchClauses, finallyBlock);
+    }
+
+    /**
+     * Returns a new {@link TryStatement} object.
+     * @param resource the resource statement
+     * @param tryBlock the {@code try} clause
+     * @return the created object
+     * @throws IllegalArgumentException if {@code tryBlock} was {@code null}
+     * @throws IllegalArgumentException if {@code catchClauses} was {@code null}
+     * @since 0.9.0
+     */
+    default TryStatement newTryStatement(TryResource resource, Block tryBlock) {
+        return newTryStatement(Collections.singletonList(resource), tryBlock, Collections.emptyList(), null);
+    }
+
+    /**
+     * Returns a new {@link TryStatement} object.
+     * @param resources the resource statements
+     * @param tryBlock the {@code try} clause
+     * @return the created object
+     * @throws IllegalArgumentException if {@code tryBlock} was {@code null}
+     * @throws IllegalArgumentException if {@code catchClauses} was {@code null}
+     * @since 0.9.0
+     */
+    default TryStatement newTryStatement(List<? extends TryResource> resources, Block tryBlock) {
+        return newTryStatement(resources, tryBlock, Collections.emptyList(), null);
+    }
+
+    /**
+     * Returns a new {@link TryStatement} object.
+     * @param resources the resource statements
+     * @param tryBlock the {@code try} clause
+     * @param catchClauses the {@code catch} clauses
+     * @return the created object
+     * @throws IllegalArgumentException if {@code tryBlock} was {@code null}
+     * @throws IllegalArgumentException if {@code catchClauses} was {@code null}
+     * @since 0.9.0
+     */
+    default TryStatement newTryStatement(
+            List<? extends TryResource> resources,
+            Block tryBlock,
+            List<? extends CatchClause> catchClauses) {
+        return newTryStatement(resources, tryBlock, catchClauses, null);
+    }
+
+    /**
+     * Returns a new {@link TryStatement} object.
+     * @param resources the resource statements
+     * @param tryBlock the {@code try} clause
+     * @param finallyBlock the {@code finally} clause, or {@code null} if it is not specified
+     * @return the created object
+     * @throws IllegalArgumentException if {@code tryBlock} was {@code null}
+     * @throws IllegalArgumentException if {@code catchClauses} was {@code null}
+     * @since 0.9.0
+     */
+    default TryStatement newTryStatement(List<? extends TryResource> resources, Block tryBlock, Block finallyBlock) {
+        return newTryStatement(resources, tryBlock, Collections.emptyList(), finallyBlock);
+    }
+
+    /**
+     * Returns a new {@link TryStatement} object.
+     * @param resources the resource statements
+     * @param tryBlock the {@code try} clause
+     * @param catchClauses the {@code catch} clauses
+     * @param finallyBlock the {@code finally} clause, or {@code null} if it is not specified
+     * @return the created object
+     * @throws IllegalArgumentException if {@code tryBlock} was {@code null}
+     * @throws IllegalArgumentException if {@code catchClauses} was {@code null}
+     * @since 0.9.0
+     */
+    TryStatement newTryStatement(
+            List<? extends TryResource> resources,
+            Block tryBlock,
+            List<? extends CatchClause> catchClauses,
+            Block finallyBlock);
 
     /**
      * Returns a new {@link TypeParameterDeclaration} object.

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelFactory.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelFactory.java
@@ -1458,6 +1458,26 @@ public interface ModelFactory {
     UnaryExpression newUnaryExpression(UnaryOperator operator, Expression operand);
 
     /**
+     * Returns a new {@link UnionType} object.
+     * @param alternativeTypes the alternatives
+     * @return the created object
+     * @throws IllegalArgumentException if {@code alternativeTypes} was {@code null}
+     * @throws IllegalArgumentException if {@code alternativeTypes} was empty
+     * @since 0.9.0
+     */
+    UnionType newUnionType(List<? extends Type> alternativeTypes);
+
+    /**
+     * Returns a new {@link UnionType} object.
+     * @param alternativeTypes the alternatives
+     * @return the created object
+     * @throws IllegalArgumentException if {@code alternativeTypes} was {@code null}
+     * @throws IllegalArgumentException if {@code alternativeTypes} was empty
+     * @since 0.9.0
+     */
+    UnionType newUnionType(Type... alternativeTypes);
+
+    /**
      * Returns a new {@link VariableDeclarator} object.
      * @param name the variable name
      * @param initializer the initializer expression, or {@code null} if it is not specified

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelKind.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelKind.java
@@ -665,9 +665,18 @@ public enum ModelKind {
     }),
 
     /**
+     * Represents {@link TryResource}.
+     */
+    TRY_RESOURCE(TryResource.class, new PropertyKind[] {
+        PropertyKind.TRY_RESOURCE_PARAMETER,
+        PropertyKind.TRY_RESOURCE_INITIALIZER,
+    }),
+
+    /**
      * Represents {@link TryStatement}.
      */
     TRY_STATEMENT(TryStatement.class, new PropertyKind[] {
+        PropertyKind.TRY_STATEMENT_RESOURCES,
         PropertyKind.TRY_STATEMENT_TRY_BLOCK,
         PropertyKind.TRY_STATEMENT_CATCH_CLAUSES,
         PropertyKind.TRY_STATEMENT_FINALLY_BLOCK,
@@ -691,6 +700,7 @@ public enum ModelKind {
 
     /**
      * Represents {@link UnionType}.
+     * @since 0.9.0
      */
     UNION_TYPE(UnaryExpression.class, new PropertyKind[] {
             PropertyKind.UNION_TYPE_ALTERNATIVE_TYPES,

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelKind.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelKind.java
@@ -21,6 +21,8 @@ import java.util.List;
 
 /**
  * Represents a kind of {@link Model}.
+ * @since 0.1.0
+ * @version 0.9.0
  */
 public enum ModelKind {
 
@@ -431,6 +433,15 @@ public enum ModelKind {
     LABELED_STATEMENT(LabeledStatement.class, new PropertyKind[] {
         PropertyKind.LABELED_STATEMENT_LABEL,
         PropertyKind.LABELED_STATEMENT_BODY,
+    }),
+
+    /**
+     * Represents {@link LambdaExpression}.
+     * @since 0.9.0
+     */
+    LAMBDA_EXPRESSION(LabeledStatement.class, new PropertyKind[] {
+        PropertyKind.LAMBDA_EXPRESSION_PARAMETERS,
+        PropertyKind.LAMBDA_EXPRESSION_BODY,
     }),
 
     /**

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelKind.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelKind.java
@@ -690,6 +690,13 @@ public enum ModelKind {
     }),
 
     /**
+     * Represents {@link UnionType}.
+     */
+    UNION_TYPE(UnaryExpression.class, new PropertyKind[] {
+            PropertyKind.UNION_TYPE_ALTERNATIVE_TYPES,
+    }),
+
+    /**
      * Represents {@link VariableDeclarator}.
      */
     VARIABLE_DECLARATOR(VariableDeclarator.class, new PropertyKind[] {

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModifierKind.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModifierKind.java
@@ -22,152 +22,103 @@ import static com.asakusafw.utils.java.model.syntax.ObjectTypeKind.*;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
  * Represents a kind of declaration modifiers.
+ * @since 0.1.0
+ * @version 0.2.0
  */
 public enum ModifierKind {
 
     /**
      * {@code public}.
      */
-    PUBLIC(
-        of(CLASS, INTERFACE, ENUM, ANNOTATION, FIELD, CONSTRUCTOR, METHOD),
-        of(ANNOTATION_ELEMENT, ENUM_CONSTANT)
-    ),
+    PUBLIC(CLASS, INTERFACE, ENUM, ANNOTATION, FIELD, CONSTRUCTOR, METHOD),
 
     /**
      * {@code protected}.
      */
-    PROTECTED(
-        of(CLASS, INTERFACE, ENUM, ANNOTATION, FIELD, CONSTRUCTOR, METHOD),
-        Collections.emptySet()
-    ),
+    PROTECTED(CLASS, INTERFACE, ENUM, ANNOTATION, FIELD, CONSTRUCTOR, METHOD),
 
     /**
      * {@code private}.
      */
-    PRIVATE(
-        of(CLASS, INTERFACE, ENUM, ANNOTATION, FIELD, CONSTRUCTOR, METHOD),
-        Collections.emptySet()
-    ),
+    PRIVATE(CLASS, INTERFACE, ENUM, ANNOTATION, FIELD, CONSTRUCTOR, METHOD),
 
     /**
      * {@code static}.
      */
-    STATIC(
-        of(CLASS, INTERFACE, ENUM, ANNOTATION, FIELD, METHOD),
-        of(ENUM_CONSTANT)
-    ),
+    STATIC(CLASS, INTERFACE, ENUM, ANNOTATION, FIELD, METHOD),
 
     /**
      * {@code abstract}.
      */
-    ABSTRACT(
-        of(CLASS, INTERFACE, ENUM, ANNOTATION, FIELD, METHOD),
-        of(ANNOTATION_ELEMENT)
-    ),
+    ABSTRACT(CLASS, INTERFACE, ENUM, ANNOTATION, FIELD, METHOD),
+
+    /**
+     * {@code default}.
+     * @since 0.9.0
+     */
+    DEFAULT(METHOD),
 
     /**
      * {@code native}.
      */
-    NATIVE(
-        of(METHOD),
-        Collections.emptySet()
-    ),
+    NATIVE(METHOD),
 
     /**
      * {@code final}.
      */
-    FINAL(
-        of(CLASS, FIELD, METHOD),
-        of(ENUM, ENUM_CONSTANT)
-    ),
+    FINAL(CLASS, FIELD, METHOD),
 
     /**
      * {@code synchronized}.
      */
-    SYNCHRONIZED(
-        of(METHOD),
-        Collections.emptySet()
-    ),
+    SYNCHRONIZED(METHOD),
 
     /**
      * {@code transient}.
      */
-    TRANSIENT(
-        of(FIELD),
-        Collections.emptySet()
-    ),
+    TRANSIENT(FIELD),
 
     /**
      * {@code volatile}.
      */
-    VOLATILE(
-        of(FIELD),
-        Collections.emptySet()
-    ),
+    VOLATILE(FIELD),
 
     /**
      * {@code strictfp}.
      */
-    STRICTFP(
-        of(CLASS, INTERFACE, ENUM, ANNOTATION, METHOD),
-        Collections.emptySet()
-    ),
+    STRICTFP(CLASS, INTERFACE, ENUM, ANNOTATION, METHOD),
 
     /**
      * {@code ACC_SUPER}.
      */
-    SUPER(
-        Collections.emptySet(),
-        of(CLASS, INTERFACE, ENUM, ANNOTATION)
-    ),
+    SUPER(),
 
     /**
      * {@code ACC_BRIDGE}.
      */
-    BRIDGE(
-        Collections.emptySet(),
-        of(METHOD)
-    ),
+    BRIDGE(),
 
     /**
      * {@code ACC_VARARGS}.
      */
-    VARARGS(
-        Collections.emptySet(),
-        of(METHOD, CONSTRUCTOR)
-    ),
+    VARARGS(),
 
     /**
      * {@code ACC_SYNTHETIC}.
      */
-    SYNTHETIC(
-        Collections.emptySet(),
-        of(CLASS, INTERFACE, ENUM, ANNOTATION, FIELD, CONSTRUCTOR, METHOD, ANNOTATION_ELEMENT, ENUM_CONSTANT)
-    ),
+    SYNTHETIC(),
     ;
 
     private final Set<DeclarationKind> declarable;
-    private final Set<DeclarationKind> grantable;
 
-    ModifierKind(Set<DeclarationKind> declarable, Set<DeclarationKind> grant) {
+    ModifierKind(DeclarationKind... declarable) {
         assert declarable != null;
-        assert grant != null;
-        this.declarable = Collections.unmodifiableSet(declarable);
-        Set<DeclarationKind> allGrants;
-        if (grant.isEmpty()) {
-            allGrants = declarable;
-        } else {
-            allGrants = new HashSet<>(grant);
-            allGrants.addAll(declarable);
-        }
-        this.grantable = Collections.unmodifiableSet(allGrants);
+        this.declarable = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(declarable)));
     }
 
     /**
@@ -189,69 +140,6 @@ public enum ModifierKind {
     }
 
     /**
-     * Returns whether this modifier can be implicitly declared on the target declaration or not.
-     * For example, the {@code public} modifier cannot be explicitly declared on enum constants,
-     * but it modifier is implicitly declared on their enum constants in class files.
-     * @param kind the target declaration kind
-     * @return {@code true} if this modifier can be declared on the target declaration, otherwise {@code false}
-     */
-    public boolean canBeGrantedIn(DeclarationKind kind) {
-        return grantable.contains(kind);
-    }
-
-    /**
-     * Returns a string representation of the set of modifier kinds.
-     * @param modifiers the target modifier kinds
-     * @return the string representation
-     * @throws IllegalArgumentException if the parameter is {@code null}
-     */
-    public static String toStringAll(Set<ModifierKind> modifiers) {
-        if (modifiers == null) {
-            throw new IllegalArgumentException("modifiers must not be null"); //$NON-NLS-1$
-        }
-        StringBuilder buf = new StringBuilder();
-        Iterator<ModifierKind> iter = modifiers.iterator();
-        if (iter.hasNext()) {
-            buf.append(iter.next().name());
-            while (iter.hasNext()) {
-                buf.append(',');
-                buf.append(iter.next().name());
-            }
-        }
-        return buf.toString();
-    }
-
-    /**
-     * Restores modifier kinds from its string representation.
-     * @param values the string representation of modifier kinds (in form of {@link #toStringAll(Set)})
-     * @return a set of the restored modifier kinds
-     * @throws IllegalArgumentException if the string representation is malformed
-     * @throws IllegalArgumentException if the parameter is {@code null}
-     * @see #toStringAll(Set)
-     */
-    public static Set<ModifierKind> allValueOf(String values) {
-        if (values == null) {
-            throw new IllegalArgumentException("values must not be null"); //$NON-NLS-1$
-        }
-        if (values.length() == 0) {
-            return Collections.emptySet();
-        }
-        EnumSet<ModifierKind> results = EnumSet.noneOf(ModifierKind.class);
-        int start = 0;
-        while (true) {
-            int index = values.indexOf(',', start);
-            if (index < 0) {
-                break;
-            }
-            String token = values.substring(start, index);
-            results.add(ModifierKind.valueOf(token));
-            start = index + 1;
-        }
-        results.add(ModifierKind.valueOf(values.substring(start)));
-        return results;
-    }
-
-    /**
      * Returns the keyword of this modifier.
      * @return the modifier keyword, or a special keyword if this modifier kind {@link #isImplicit() is implicit}
      */
@@ -266,9 +154,5 @@ public enum ModifierKind {
     @Override
     public String toString() {
         return getKeyword();
-    }
-
-    private static Set<DeclarationKind> of(DeclarationKind...kinds) {
-        return new HashSet<>(Arrays.asList(kinds));
     }
 }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/PropertyKind.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/PropertyKind.java
@@ -1161,6 +1161,30 @@ public enum PropertyKind {
     ),
 
     /**
+     * Represents {@link TryResource#getParameter()}.
+     */
+    TRY_RESOURCE_PARAMETER(
+        TryResource.class,
+        "parameter" //$NON-NLS-1$
+    ),
+
+    /**
+     * Represents {@link TryResource#getInitializer()}.
+     */
+    TRY_RESOURCE_INITIALIZER(
+        TryResource.class,
+        "initializer" //$NON-NLS-1$
+    ),
+
+    /**
+     * Represents {@link TryStatement#getResources()}.
+     */
+    TRY_STATEMENT_RESOURCES(
+        TryStatement.class,
+        "resources" //$NON-NLS-1$
+    ),
+
+    /**
      * Represents {@link TryStatement#getTryBlock()}.
      */
     TRY_STATEMENT_TRY_BLOCK(

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/PropertyKind.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/PropertyKind.java
@@ -17,6 +17,8 @@ package com.asakusafw.utils.java.model.syntax;
 
 /**
  * Represents a kind of properties in {@link Model}.
+ * @since 0.1.0
+ * @version 0.9.0
  */
 public enum PropertyKind {
 
@@ -25,7 +27,7 @@ public enum PropertyKind {
      */
     ANNOTATION_TYPE(
         Annotation.class,
-        "type" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "type" //$NON-NLS-1$
     ),
 
     /**
@@ -33,7 +35,7 @@ public enum PropertyKind {
      */
     ANNOTATION_ELEMENT_NAME(
         AnnotationElement.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -41,7 +43,7 @@ public enum PropertyKind {
      */
     ANNOTATION_ELEMENT_EXPRESSION(
         AnnotationElement.class,
-        "expression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "expression" //$NON-NLS-1$
     ),
 
     /**
@@ -49,7 +51,7 @@ public enum PropertyKind {
      */
     ANNOTATION_ELEMENT_DECLARATION_TYPE(
         AnnotationElementDeclaration.class,
-        "type" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "type" //$NON-NLS-1$
     ),
 
     /**
@@ -57,7 +59,7 @@ public enum PropertyKind {
      */
     ANNOTATION_ELEMENT_DECLARATION_NAME(
         AnnotationElementDeclaration.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -65,7 +67,7 @@ public enum PropertyKind {
      */
     ANNOTATION_ELEMENT_DECLARATION_DEFAULT_EXPRESSION(
         AnnotationElementDeclaration.class,
-        "defaultExpression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "defaultExpression" //$NON-NLS-1$
     ),
 
     /**
@@ -73,7 +75,7 @@ public enum PropertyKind {
      */
     ARRAY_ACCESS_EXPRESSION_ARRAY(
         ArrayAccessExpression.class,
-        "array" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "array" //$NON-NLS-1$
     ),
 
     /**
@@ -81,7 +83,7 @@ public enum PropertyKind {
      */
     ARRAY_ACCESS_EXPRESSION_INDEX(
         ArrayAccessExpression.class,
-        "index" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "index" //$NON-NLS-1$
     ),
 
     /**
@@ -89,7 +91,7 @@ public enum PropertyKind {
      */
     ARRAY_CREATION_EXPRESSION_TYPE(
         ArrayCreationExpression.class,
-        "type" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "type" //$NON-NLS-1$
     ),
 
     /**
@@ -97,7 +99,7 @@ public enum PropertyKind {
      */
     ARRAY_CREATION_EXPRESSION_DIMENSION_EXPRESSIONS(
         ArrayCreationExpression.class,
-        "dimensionExpressions" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "dimensionExpressions" //$NON-NLS-1$
     ),
 
     /**
@@ -105,7 +107,7 @@ public enum PropertyKind {
      */
     ARRAY_CREATION_EXPRESSION_ARRAY_INITIALIZER(
         ArrayCreationExpression.class,
-        "arrayInitializer" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "arrayInitializer" //$NON-NLS-1$
     ),
 
     /**
@@ -113,7 +115,7 @@ public enum PropertyKind {
      */
     ARRAY_INITIALIZER_ELEMENTS(
         ArrayInitializer.class,
-        "elements" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "elements" //$NON-NLS-1$
     ),
 
     /**
@@ -121,7 +123,7 @@ public enum PropertyKind {
      */
     ARRAY_TYPE_COMPONENT_TYPE(
         ArrayType.class,
-        "componentType" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "componentType" //$NON-NLS-1$
     ),
 
     /**
@@ -129,7 +131,7 @@ public enum PropertyKind {
      */
     ASSERT_STATEMENT_EXPRESSION(
         AssertStatement.class,
-        "expression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "expression" //$NON-NLS-1$
     ),
 
     /**
@@ -137,7 +139,7 @@ public enum PropertyKind {
      */
     ASSERT_STATEMENT_MESSAGE(
         AssertStatement.class,
-        "message" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "message" //$NON-NLS-1$
     ),
 
     /**
@@ -145,7 +147,7 @@ public enum PropertyKind {
      */
     ASSIGNMENT_EXPRESSION_LEFT_HAND_SIDE(
         AssignmentExpression.class,
-        "leftHandSide" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "leftHandSide" //$NON-NLS-1$
     ),
 
     /**
@@ -153,7 +155,7 @@ public enum PropertyKind {
      */
     ASSIGNMENT_EXPRESSION_OPERATOR(
         AssignmentExpression.class,
-        "operator" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "operator" //$NON-NLS-1$
     ),
 
     /**
@@ -161,7 +163,7 @@ public enum PropertyKind {
      */
     ASSIGNMENT_EXPRESSION_RIGHT_HAND_SIDE(
         AssignmentExpression.class,
-        "rightHandSide" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "rightHandSide" //$NON-NLS-1$
     ),
 
     /**
@@ -169,7 +171,7 @@ public enum PropertyKind {
      */
     BASIC_TYPE_TYPE_KIND(
         BasicType.class,
-        "typeKind" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "typeKind" //$NON-NLS-1$
     ),
 
     /**
@@ -177,7 +179,7 @@ public enum PropertyKind {
      */
     BLOCK_STATEMENTS(
         Block.class,
-        "statements" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "statements" //$NON-NLS-1$
     ),
 
     /**
@@ -185,7 +187,7 @@ public enum PropertyKind {
      */
     BLOCK_COMMENT_STRING(
         BlockComment.class,
-        "string" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "string" //$NON-NLS-1$
     ),
 
     /**
@@ -193,7 +195,7 @@ public enum PropertyKind {
      */
     BRANCH_STATEMENT_TARGET(
         BranchStatement.class,
-        "target" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "target" //$NON-NLS-1$
     ),
 
     /**
@@ -201,7 +203,7 @@ public enum PropertyKind {
      */
     CAST_EXPRESSION_TYPE(
         CastExpression.class,
-        "type" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "type" //$NON-NLS-1$
     ),
 
     /**
@@ -209,7 +211,7 @@ public enum PropertyKind {
      */
     CAST_EXPRESSION_EXPRESSION(
         CastExpression.class,
-        "expression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "expression" //$NON-NLS-1$
     ),
 
     /**
@@ -217,7 +219,7 @@ public enum PropertyKind {
      */
     CATCH_CLAUSE_PARAMETER(
         CatchClause.class,
-        "parameter" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "parameter" //$NON-NLS-1$
     ),
 
     /**
@@ -225,7 +227,7 @@ public enum PropertyKind {
      */
     CATCH_CLAUSE_BODY(
         CatchClause.class,
-        "body" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "body" //$NON-NLS-1$
     ),
 
     /**
@@ -233,7 +235,7 @@ public enum PropertyKind {
      */
     CLASS_BODY_BODY_DECLARATIONS(
         ClassBody.class,
-        "bodyDeclarations" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "bodyDeclarations" //$NON-NLS-1$
     ),
 
     /**
@@ -241,7 +243,7 @@ public enum PropertyKind {
      */
     CLASS_DECLARATION_TYPE_PARAMETERS(
         ClassDeclaration.class,
-        "typeParameters" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "typeParameters" //$NON-NLS-1$
     ),
 
     /**
@@ -249,7 +251,7 @@ public enum PropertyKind {
      */
     CLASS_DECLARATION_SUPER_CLASS(
         ClassDeclaration.class,
-        "superClass" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "superClass" //$NON-NLS-1$
     ),
 
     /**
@@ -257,7 +259,7 @@ public enum PropertyKind {
      */
     CLASS_DECLARATION_SUPER_INTERFACE_TYPES(
         ClassDeclaration.class,
-        "superInterfaceTypes" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "superInterfaceTypes" //$NON-NLS-1$
     ),
 
     /**
@@ -265,7 +267,7 @@ public enum PropertyKind {
      */
     CLASS_INSTANCE_CREATION_EXPRESSION_QUALIFIER(
         ClassInstanceCreationExpression.class,
-        "qualifier" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "qualifier" //$NON-NLS-1$
     ),
 
     /**
@@ -273,7 +275,7 @@ public enum PropertyKind {
      */
     CLASS_INSTANCE_CREATION_EXPRESSION_TYPE_ARGUMENTS(
         ClassInstanceCreationExpression.class,
-        "typeArguments" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "typeArguments" //$NON-NLS-1$
     ),
 
     /**
@@ -281,7 +283,7 @@ public enum PropertyKind {
      */
     CLASS_INSTANCE_CREATION_EXPRESSION_TYPE(
         ClassInstanceCreationExpression.class,
-        "type" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "type" //$NON-NLS-1$
     ),
 
     /**
@@ -289,7 +291,7 @@ public enum PropertyKind {
      */
     CLASS_INSTANCE_CREATION_EXPRESSION_ARGUMENTS(
         ClassInstanceCreationExpression.class,
-        "arguments" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "arguments" //$NON-NLS-1$
     ),
 
     /**
@@ -297,7 +299,7 @@ public enum PropertyKind {
      */
     CLASS_INSTANCE_CREATION_EXPRESSION_BODY(
         ClassInstanceCreationExpression.class,
-        "body" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "body" //$NON-NLS-1$
     ),
 
     /**
@@ -305,7 +307,7 @@ public enum PropertyKind {
      */
     CLASS_LITERAL_TYPE(
         ClassLiteral.class,
-        "type" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "type" //$NON-NLS-1$
     ),
 
     /**
@@ -313,7 +315,7 @@ public enum PropertyKind {
      */
     COMPILATION_UNIT_PACKAGE_DECLARATION(
         CompilationUnit.class,
-        "packageDeclaration" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "packageDeclaration" //$NON-NLS-1$
     ),
 
     /**
@@ -321,7 +323,7 @@ public enum PropertyKind {
      */
     COMPILATION_UNIT_IMPORT_DECLARATIONS(
         CompilationUnit.class,
-        "importDeclarations" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "importDeclarations" //$NON-NLS-1$
     ),
 
     /**
@@ -329,7 +331,7 @@ public enum PropertyKind {
      */
     COMPILATION_UNIT_TYPE_DECLARATIONS(
         CompilationUnit.class,
-        "typeDeclarations" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "typeDeclarations" //$NON-NLS-1$
     ),
 
     /**
@@ -337,7 +339,7 @@ public enum PropertyKind {
      */
     COMPILATION_UNIT_COMMENTS(
         CompilationUnit.class,
-        "comments" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "comments" //$NON-NLS-1$
     ),
 
     /**
@@ -345,7 +347,7 @@ public enum PropertyKind {
      */
     CONDITIONAL_EXPRESSION_CONDITION(
         ConditionalExpression.class,
-        "condition" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "condition" //$NON-NLS-1$
     ),
 
     /**
@@ -353,7 +355,7 @@ public enum PropertyKind {
      */
     CONDITIONAL_EXPRESSION_THEN_EXPRESSION(
         ConditionalExpression.class,
-        "thenExpression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "thenExpression" //$NON-NLS-1$
     ),
 
     /**
@@ -361,7 +363,7 @@ public enum PropertyKind {
      */
     CONDITIONAL_EXPRESSION_ELSE_EXPRESSION(
         ConditionalExpression.class,
-        "elseExpression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "elseExpression" //$NON-NLS-1$
     ),
 
     /**
@@ -369,7 +371,7 @@ public enum PropertyKind {
      */
     CONSTRUCTOR_INVOCATION_TYPE_ARGUMENTS(
         ConstructorInvocation.class,
-        "typeArguments" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "typeArguments" //$NON-NLS-1$
     ),
 
     /**
@@ -377,7 +379,7 @@ public enum PropertyKind {
      */
     CONSTRUCTOR_INVOCATION_ARGUMENTS(
         ConstructorInvocation.class,
-        "arguments" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "arguments" //$NON-NLS-1$
     ),
 
     /**
@@ -385,7 +387,7 @@ public enum PropertyKind {
      */
     DO_STATEMENT_BODY(
         DoStatement.class,
-        "body" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "body" //$NON-NLS-1$
     ),
 
     /**
@@ -393,7 +395,7 @@ public enum PropertyKind {
      */
     DO_STATEMENT_CONDITION(
         DoStatement.class,
-        "condition" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "condition" //$NON-NLS-1$
     ),
 
     /**
@@ -401,7 +403,7 @@ public enum PropertyKind {
      */
     DOC_BLOCK_TAG(
         DocBlock.class,
-        "tag" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "tag" //$NON-NLS-1$
     ),
 
     /**
@@ -409,7 +411,7 @@ public enum PropertyKind {
      */
     DOC_BLOCK_ELEMENTS(
         DocBlock.class,
-        "elements" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "elements" //$NON-NLS-1$
     ),
 
     /**
@@ -417,7 +419,7 @@ public enum PropertyKind {
      */
     DOC_FIELD_TYPE(
         DocField.class,
-        "type" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "type" //$NON-NLS-1$
     ),
 
     /**
@@ -425,7 +427,7 @@ public enum PropertyKind {
      */
     DOC_FIELD_NAME(
         DocField.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -433,7 +435,7 @@ public enum PropertyKind {
      */
     DOC_METHOD_TYPE(
         DocMethod.class,
-        "type" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "type" //$NON-NLS-1$
     ),
 
     /**
@@ -441,7 +443,7 @@ public enum PropertyKind {
      */
     DOC_METHOD_NAME(
         DocMethod.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -449,7 +451,7 @@ public enum PropertyKind {
      */
     DOC_METHOD_FORMAL_PARAMETERS(
         DocMethod.class,
-        "formalParameters" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "formalParameters" //$NON-NLS-1$
     ),
 
     /**
@@ -457,7 +459,7 @@ public enum PropertyKind {
      */
     DOC_METHOD_PARAMETER_TYPE(
         DocMethodParameter.class,
-        "type" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "type" //$NON-NLS-1$
     ),
 
     /**
@@ -465,7 +467,7 @@ public enum PropertyKind {
      */
     DOC_METHOD_PARAMETER_NAME(
         DocMethodParameter.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -473,7 +475,7 @@ public enum PropertyKind {
      */
     DOC_METHOD_PARAMETER_VARIABLE_ARITY(
         DocMethodParameter.class,
-        "variableArity" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "variableArity" //$NON-NLS-1$
     ),
 
     /**
@@ -481,7 +483,7 @@ public enum PropertyKind {
      */
     DOC_TEXT_STRING(
         DocText.class,
-        "string" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "string" //$NON-NLS-1$
     ),
 
     /**
@@ -489,7 +491,7 @@ public enum PropertyKind {
      */
     ENHANCED_FOR_STATEMENT_PARAMETER(
         EnhancedForStatement.class,
-        "parameter" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "parameter" //$NON-NLS-1$
     ),
 
     /**
@@ -497,7 +499,7 @@ public enum PropertyKind {
      */
     ENHANCED_FOR_STATEMENT_EXPRESSION(
         EnhancedForStatement.class,
-        "expression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "expression" //$NON-NLS-1$
     ),
 
     /**
@@ -505,7 +507,7 @@ public enum PropertyKind {
      */
     ENHANCED_FOR_STATEMENT_BODY(
         EnhancedForStatement.class,
-        "body" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "body" //$NON-NLS-1$
     ),
 
     /**
@@ -513,7 +515,7 @@ public enum PropertyKind {
      */
     ENUM_CONSTANT_DECLARATION_NAME(
         EnumConstantDeclaration.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -521,7 +523,7 @@ public enum PropertyKind {
      */
     ENUM_CONSTANT_DECLARATION_ARGUMENTS(
         EnumConstantDeclaration.class,
-        "arguments" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "arguments" //$NON-NLS-1$
     ),
 
     /**
@@ -529,7 +531,7 @@ public enum PropertyKind {
      */
     ENUM_CONSTANT_DECLARATION_BODY(
         EnumConstantDeclaration.class,
-        "body" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "body" //$NON-NLS-1$
     ),
 
     /**
@@ -537,7 +539,7 @@ public enum PropertyKind {
      */
     ENUM_DECLARATION_SUPER_INTERFACE_TYPES(
         EnumDeclaration.class,
-        "superInterfaceTypes" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "superInterfaceTypes" //$NON-NLS-1$
     ),
 
     /**
@@ -545,7 +547,7 @@ public enum PropertyKind {
      */
     ENUM_DECLARATION_CONSTANT_DECLARATIONS(
         EnumDeclaration.class,
-        "constantDeclarations" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "constantDeclarations" //$NON-NLS-1$
     ),
 
     /**
@@ -553,7 +555,7 @@ public enum PropertyKind {
      */
     EXPRESSION_STATEMENT_EXPRESSION(
         ExpressionStatement.class,
-        "expression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "expression" //$NON-NLS-1$
     ),
 
     /**
@@ -561,7 +563,7 @@ public enum PropertyKind {
      */
     FIELD_ACCESS_EXPRESSION_QUALIFIER(
         FieldAccessExpression.class,
-        "qualifier" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "qualifier" //$NON-NLS-1$
     ),
 
     /**
@@ -569,7 +571,7 @@ public enum PropertyKind {
      */
     FIELD_ACCESS_EXPRESSION_NAME(
         FieldAccessExpression.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -577,7 +579,7 @@ public enum PropertyKind {
      */
     FIELD_DECLARATION_TYPE(
         FieldDeclaration.class,
-        "type" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "type" //$NON-NLS-1$
     ),
 
     /**
@@ -585,7 +587,7 @@ public enum PropertyKind {
      */
     FIELD_DECLARATION_VARIABLE_DECLARATORS(
         FieldDeclaration.class,
-        "variableDeclarators" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "variableDeclarators" //$NON-NLS-1$
     ),
 
     /**
@@ -593,7 +595,7 @@ public enum PropertyKind {
      */
     FOR_STATEMENT_INITIALIZATION(
         ForStatement.class,
-        "initialization" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "initialization" //$NON-NLS-1$
     ),
 
     /**
@@ -601,7 +603,7 @@ public enum PropertyKind {
      */
     FOR_STATEMENT_CONDITION(
         ForStatement.class,
-        "condition" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "condition" //$NON-NLS-1$
     ),
 
     /**
@@ -609,7 +611,7 @@ public enum PropertyKind {
      */
     FOR_STATEMENT_UPDATE(
         ForStatement.class,
-        "update" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "update" //$NON-NLS-1$
     ),
 
     /**
@@ -617,7 +619,7 @@ public enum PropertyKind {
      */
     FOR_STATEMENT_BODY(
         ForStatement.class,
-        "body" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "body" //$NON-NLS-1$
     ),
 
     /**
@@ -625,7 +627,7 @@ public enum PropertyKind {
      */
     FORMAL_PARAMETER_DECLARATION_MODIFIERS(
         FormalParameterDeclaration.class,
-        "modifiers" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "modifiers" //$NON-NLS-1$
     ),
 
     /**
@@ -633,7 +635,7 @@ public enum PropertyKind {
      */
     FORMAL_PARAMETER_DECLARATION_TYPE(
         FormalParameterDeclaration.class,
-        "type" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "type" //$NON-NLS-1$
     ),
 
     /**
@@ -641,7 +643,7 @@ public enum PropertyKind {
      */
     FORMAL_PARAMETER_DECLARATION_VARIABLE_ARITY(
         FormalParameterDeclaration.class,
-        "variableArity" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "variableArity" //$NON-NLS-1$
     ),
 
     /**
@@ -649,7 +651,7 @@ public enum PropertyKind {
      */
     FORMAL_PARAMETER_DECLARATION_NAME(
         FormalParameterDeclaration.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -657,7 +659,7 @@ public enum PropertyKind {
      */
     FORMAL_PARAMETER_DECLARATION_EXTRA_DIMENSIONS(
         FormalParameterDeclaration.class,
-        "extraDimensions" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "extraDimensions" //$NON-NLS-1$
     ),
 
     /**
@@ -665,7 +667,7 @@ public enum PropertyKind {
      */
     IF_STATEMENT_CONDITION(
         IfStatement.class,
-        "condition" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "condition" //$NON-NLS-1$
     ),
 
     /**
@@ -673,7 +675,7 @@ public enum PropertyKind {
      */
     IF_STATEMENT_THEN_STATEMENT(
         IfStatement.class,
-        "thenStatement" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "thenStatement" //$NON-NLS-1$
     ),
 
     /**
@@ -681,7 +683,7 @@ public enum PropertyKind {
      */
     IF_STATEMENT_ELSE_STATEMENT(
         IfStatement.class,
-        "elseStatement" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "elseStatement" //$NON-NLS-1$
     ),
 
     /**
@@ -689,7 +691,7 @@ public enum PropertyKind {
      */
     IMPORT_DECLARATION_IMPORT_KIND(
         ImportDeclaration.class,
-        "importKind" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "importKind" //$NON-NLS-1$
     ),
 
     /**
@@ -697,7 +699,7 @@ public enum PropertyKind {
      */
     IMPORT_DECLARATION_NAME(
         ImportDeclaration.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -705,7 +707,7 @@ public enum PropertyKind {
      */
     INFIX_EXPRESSION_LEFT_OPERAND(
         InfixExpression.class,
-        "leftOperand" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "leftOperand" //$NON-NLS-1$
     ),
 
     /**
@@ -713,7 +715,7 @@ public enum PropertyKind {
      */
     INFIX_EXPRESSION_OPERATOR(
         InfixExpression.class,
-        "operator" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "operator" //$NON-NLS-1$
     ),
 
     /**
@@ -721,7 +723,7 @@ public enum PropertyKind {
      */
     INFIX_EXPRESSION_RIGHT_OPERAND(
         InfixExpression.class,
-        "rightOperand" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "rightOperand" //$NON-NLS-1$
     ),
 
     /**
@@ -729,7 +731,7 @@ public enum PropertyKind {
      */
     INITIALIZER_DECLARATION_BODY(
         InitializerDeclaration.class,
-        "body" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "body" //$NON-NLS-1$
     ),
 
     /**
@@ -737,7 +739,7 @@ public enum PropertyKind {
      */
     INSTANCEOF_EXPRESSION_EXPRESSION(
         InstanceofExpression.class,
-        "expression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "expression" //$NON-NLS-1$
     ),
 
     /**
@@ -745,7 +747,7 @@ public enum PropertyKind {
      */
     INSTANCEOF_EXPRESSION_TYPE(
         InstanceofExpression.class,
-        "type" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "type" //$NON-NLS-1$
     ),
 
     /**
@@ -753,7 +755,7 @@ public enum PropertyKind {
      */
     INTERFACE_DECLARATION_TYPE_PARAMETERS(
         InterfaceDeclaration.class,
-        "typeParameters" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "typeParameters" //$NON-NLS-1$
     ),
 
     /**
@@ -761,7 +763,7 @@ public enum PropertyKind {
      */
     INTERFACE_DECLARATION_SUPER_INTERFACE_TYPES(
         InterfaceDeclaration.class,
-        "superInterfaceTypes" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "superInterfaceTypes" //$NON-NLS-1$
     ),
 
     /**
@@ -769,7 +771,7 @@ public enum PropertyKind {
      */
     JAVADOC_BLOCKS(
         Javadoc.class,
-        "blocks" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "blocks" //$NON-NLS-1$
     ),
 
     /**
@@ -777,7 +779,7 @@ public enum PropertyKind {
      */
     KEYWORD_QUALIFIER(
         Keyword.class,
-        "qualifier" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "qualifier" //$NON-NLS-1$
     ),
 
     /**
@@ -785,7 +787,7 @@ public enum PropertyKind {
      */
     LABELED_STATEMENT_LABEL(
         LabeledStatement.class,
-        "label" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "label" //$NON-NLS-1$
     ),
 
     /**
@@ -793,7 +795,25 @@ public enum PropertyKind {
      */
     LABELED_STATEMENT_BODY(
         LabeledStatement.class,
-        "body" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "body" //$NON-NLS-1$
+    ),
+
+    /**
+     * Represents {@link LambdaExpression#getParameters()}.
+     * @since 0.9.0
+     */
+    LAMBDA_EXPRESSION_PARAMETERS(
+        LambdaParameter.class,
+        "parameters" //$NON-NLS-1$
+    ),
+
+    /**
+     * Represents {@link LambdaExpression#getBody()}.
+     * @since 0.9.0
+     */
+    LAMBDA_EXPRESSION_BODY(
+        LambdaBody.class,
+        "body" //$NON-NLS-1$
     ),
 
     /**
@@ -801,7 +821,7 @@ public enum PropertyKind {
      */
     LINE_COMMENT_STRING(
         LineComment.class,
-        "string" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "string" //$NON-NLS-1$
     ),
 
     /**
@@ -809,7 +829,7 @@ public enum PropertyKind {
      */
     LITERAL_TOKEN(
         Literal.class,
-        "token" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "token" //$NON-NLS-1$
     ),
 
     /**
@@ -817,7 +837,7 @@ public enum PropertyKind {
      */
     LOCAL_CLASS_DECLARATION_DECLARATION(
         LocalClassDeclaration.class,
-        "declaration" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "declaration" //$NON-NLS-1$
     ),
 
     /**
@@ -825,7 +845,7 @@ public enum PropertyKind {
      */
     LOCAL_VARIABLE_DECLARATION_MODIFIERS(
         LocalVariableDeclaration.class,
-        "modifiers" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "modifiers" //$NON-NLS-1$
     ),
 
     /**
@@ -833,7 +853,7 @@ public enum PropertyKind {
      */
     LOCAL_VARIABLE_DECLARATION_TYPE(
         LocalVariableDeclaration.class,
-        "type" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "type" //$NON-NLS-1$
     ),
 
     /**
@@ -841,7 +861,7 @@ public enum PropertyKind {
      */
     LOCAL_VARIABLE_DECLARATION_VARIABLE_DECLARATORS(
         LocalVariableDeclaration.class,
-        "variableDeclarators" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "variableDeclarators" //$NON-NLS-1$
     ),
 
     /**
@@ -849,7 +869,7 @@ public enum PropertyKind {
      */
     METHOD_DECLARATION_RETURN_TYPE(
         MethodDeclaration.class,
-        "returnType" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "returnType" //$NON-NLS-1$
     ),
 
     /**
@@ -857,7 +877,7 @@ public enum PropertyKind {
      */
     METHOD_DECLARATION_EXTRA_DIMENSIONS(
         MethodDeclaration.class,
-        "extraDimensions" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "extraDimensions" //$NON-NLS-1$
     ),
 
     /**
@@ -865,7 +885,7 @@ public enum PropertyKind {
      */
     METHOD_INVOCATION_EXPRESSION_QUALIFIER(
         MethodInvocationExpression.class,
-        "qualifier" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "qualifier" //$NON-NLS-1$
     ),
 
     /**
@@ -873,7 +893,7 @@ public enum PropertyKind {
      */
     METHOD_INVOCATION_EXPRESSION_TYPE_ARGUMENTS(
         MethodInvocationExpression.class,
-        "typeArguments" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "typeArguments" //$NON-NLS-1$
     ),
 
     /**
@@ -881,7 +901,7 @@ public enum PropertyKind {
      */
     METHOD_INVOCATION_EXPRESSION_NAME(
         MethodInvocationExpression.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -889,7 +909,7 @@ public enum PropertyKind {
      */
     METHOD_INVOCATION_EXPRESSION_ARGUMENTS(
         MethodInvocationExpression.class,
-        "arguments" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "arguments" //$NON-NLS-1$
     ),
 
     /**
@@ -897,7 +917,7 @@ public enum PropertyKind {
      */
     METHOD_OR_CONSTRUCTOR_DECLARATION_TYPE_PARAMETERS(
         MethodOrConstructorDeclaration.class,
-        "typeParameters" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "typeParameters" //$NON-NLS-1$
     ),
 
     /**
@@ -905,7 +925,7 @@ public enum PropertyKind {
      */
     METHOD_OR_CONSTRUCTOR_DECLARATION_NAME(
         MethodOrConstructorDeclaration.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -913,7 +933,7 @@ public enum PropertyKind {
      */
     METHOD_OR_CONSTRUCTOR_DECLARATION_FORMAL_PARAMETERS(
         MethodOrConstructorDeclaration.class,
-        "formalParameters" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "formalParameters" //$NON-NLS-1$
     ),
 
     /**
@@ -921,7 +941,7 @@ public enum PropertyKind {
      */
     METHOD_OR_CONSTRUCTOR_DECLARATION_EXCEPTION_TYPES(
         MethodOrConstructorDeclaration.class,
-        "exceptionTypes" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "exceptionTypes" //$NON-NLS-1$
     ),
 
     /**
@@ -929,7 +949,7 @@ public enum PropertyKind {
      */
     METHOD_OR_CONSTRUCTOR_DECLARATION_BODY(
         MethodOrConstructorDeclaration.class,
-        "body" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "body" //$NON-NLS-1$
     ),
 
     /**
@@ -937,7 +957,7 @@ public enum PropertyKind {
      */
     MODIFIER_MODIFIER_KIND(
         Modifier.class,
-        "modifierKind" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "modifierKind" //$NON-NLS-1$
     ),
 
     /**
@@ -945,7 +965,7 @@ public enum PropertyKind {
      */
     NAMED_TYPE_NAME(
         NamedType.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -953,7 +973,7 @@ public enum PropertyKind {
      */
     NORMAL_ANNOTATION_ELEMENTS(
         NormalAnnotation.class,
-        "elements" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "elements" //$NON-NLS-1$
     ),
 
     /**
@@ -961,7 +981,7 @@ public enum PropertyKind {
      */
     PACKAGE_DECLARATION_JAVADOC(
         PackageDeclaration.class,
-        "javadoc" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "javadoc" //$NON-NLS-1$
     ),
 
     /**
@@ -969,7 +989,7 @@ public enum PropertyKind {
      */
     PACKAGE_DECLARATION_ANNOTATIONS(
         PackageDeclaration.class,
-        "annotations" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "annotations" //$NON-NLS-1$
     ),
 
     /**
@@ -977,7 +997,7 @@ public enum PropertyKind {
      */
     PACKAGE_DECLARATION_NAME(
         PackageDeclaration.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -985,7 +1005,7 @@ public enum PropertyKind {
      */
     PARAMETERIZED_TYPE_TYPE(
         ParameterizedType.class,
-        "type" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "type" //$NON-NLS-1$
     ),
 
     /**
@@ -993,7 +1013,7 @@ public enum PropertyKind {
      */
     PARAMETERIZED_TYPE_TYPE_ARGUMENTS(
         ParameterizedType.class,
-        "typeArguments" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "typeArguments" //$NON-NLS-1$
     ),
 
     /**
@@ -1001,7 +1021,7 @@ public enum PropertyKind {
      */
     PARENTHESIZED_EXPRESSION_EXPRESSION(
         ParenthesizedExpression.class,
-        "expression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "expression" //$NON-NLS-1$
     ),
 
     /**
@@ -1009,7 +1029,7 @@ public enum PropertyKind {
      */
     POSTFIX_EXPRESSION_OPERAND(
         PostfixExpression.class,
-        "operand" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "operand" //$NON-NLS-1$
     ),
 
     /**
@@ -1017,7 +1037,7 @@ public enum PropertyKind {
      */
     POSTFIX_EXPRESSION_OPERATOR(
         PostfixExpression.class,
-        "operator" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "operator" //$NON-NLS-1$
     ),
 
     /**
@@ -1025,7 +1045,7 @@ public enum PropertyKind {
      */
     QUALIFIED_NAME_QUALIFIER(
         QualifiedName.class,
-        "qualifier" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "qualifier" //$NON-NLS-1$
     ),
 
     /**
@@ -1033,7 +1053,7 @@ public enum PropertyKind {
      */
     QUALIFIED_NAME_SIMPLE_NAME(
         QualifiedName.class,
-        "simpleName" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "simpleName" //$NON-NLS-1$
     ),
 
     /**
@@ -1041,7 +1061,7 @@ public enum PropertyKind {
      */
     QUALIFIED_TYPE_QUALIFIER(
         QualifiedType.class,
-        "qualifier" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "qualifier" //$NON-NLS-1$
     ),
 
     /**
@@ -1049,7 +1069,7 @@ public enum PropertyKind {
      */
     QUALIFIED_TYPE_SIMPLE_NAME(
         QualifiedType.class,
-        "simpleName" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "simpleName" //$NON-NLS-1$
     ),
 
     /**
@@ -1057,7 +1077,7 @@ public enum PropertyKind {
      */
     RETURN_STATEMENT_EXPRESSION(
         ReturnStatement.class,
-        "expression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "expression" //$NON-NLS-1$
     ),
 
     /**
@@ -1065,7 +1085,7 @@ public enum PropertyKind {
      */
     SIMPLE_NAME_STRING(
         SimpleName.class,
-        "token" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "token" //$NON-NLS-1$
     ),
 
     /**
@@ -1073,7 +1093,7 @@ public enum PropertyKind {
      */
     SINGLE_ELEMENT_ANNOTATION_EXPRESSION(
         SingleElementAnnotation.class,
-        "expression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "expression" //$NON-NLS-1$
     ),
 
     /**
@@ -1081,7 +1101,7 @@ public enum PropertyKind {
      */
     STATEMENT_EXPRESSION_LIST_EXPRESSIONS(
         StatementExpressionList.class,
-        "expressions" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "expressions" //$NON-NLS-1$
     ),
 
     /**
@@ -1089,7 +1109,7 @@ public enum PropertyKind {
      */
     SUPER_CONSTRUCTOR_INVOCATION_QUALIFIER(
         SuperConstructorInvocation.class,
-        "qualifier" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "qualifier" //$NON-NLS-1$
     ),
 
     /**
@@ -1097,7 +1117,7 @@ public enum PropertyKind {
      */
     SWITCH_CASE_LABEL_EXPRESSION(
         SwitchCaseLabel.class,
-        "expression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "expression" //$NON-NLS-1$
     ),
 
     /**
@@ -1105,7 +1125,7 @@ public enum PropertyKind {
      */
     SWITCH_STATEMENT_EXPRESSION(
         SwitchStatement.class,
-        "expression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "expression" //$NON-NLS-1$
     ),
 
     /**
@@ -1113,7 +1133,7 @@ public enum PropertyKind {
      */
     SWITCH_STATEMENT_STATEMENTS(
         SwitchStatement.class,
-        "statements" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "statements" //$NON-NLS-1$
     ),
 
     /**
@@ -1121,7 +1141,7 @@ public enum PropertyKind {
      */
     SYNCHRONIZED_STATEMENT_EXPRESSION(
         SynchronizedStatement.class,
-        "expression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "expression" //$NON-NLS-1$
     ),
 
     /**
@@ -1129,7 +1149,7 @@ public enum PropertyKind {
      */
     SYNCHRONIZED_STATEMENT_BODY(
         SynchronizedStatement.class,
-        "body" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "body" //$NON-NLS-1$
     ),
 
     /**
@@ -1137,7 +1157,7 @@ public enum PropertyKind {
      */
     THROW_STATEMENT_EXPRESSION(
         ThrowStatement.class,
-        "expression" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "expression" //$NON-NLS-1$
     ),
 
     /**
@@ -1145,7 +1165,7 @@ public enum PropertyKind {
      */
     TRY_STATEMENT_TRY_BLOCK(
         TryStatement.class,
-        "tryBlock" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "tryBlock" //$NON-NLS-1$
     ),
 
     /**
@@ -1153,7 +1173,7 @@ public enum PropertyKind {
      */
     TRY_STATEMENT_CATCH_CLAUSES(
         TryStatement.class,
-        "catchClauses" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "catchClauses" //$NON-NLS-1$
     ),
 
     /**
@@ -1161,7 +1181,7 @@ public enum PropertyKind {
      */
     TRY_STATEMENT_FINALLY_BLOCK(
         TryStatement.class,
-        "finallyBlock" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "finallyBlock" //$NON-NLS-1$
     ),
 
     /**
@@ -1169,7 +1189,7 @@ public enum PropertyKind {
      */
     TYPE_BODY_DECLARATION_JAVADOC(
         TypeBodyDeclaration.class,
-        "javadoc" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "javadoc" //$NON-NLS-1$
     ),
 
     /**
@@ -1177,7 +1197,7 @@ public enum PropertyKind {
      */
     TYPE_BODY_DECLARATION_MODIFIERS(
         TypeBodyDeclaration.class,
-        "modifiers" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "modifiers" //$NON-NLS-1$
     ),
 
     /**
@@ -1185,7 +1205,7 @@ public enum PropertyKind {
      */
     TYPE_DECLARATION_NAME(
         TypeDeclaration.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -1193,7 +1213,7 @@ public enum PropertyKind {
      */
     TYPE_DECLARATION_BODY_DECLARATIONS(
         TypeDeclaration.class,
-        "bodyDeclarations" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "bodyDeclarations" //$NON-NLS-1$
     ),
 
     /**
@@ -1201,7 +1221,7 @@ public enum PropertyKind {
      */
     TYPE_PARAMETER_DECLARATION_NAME(
         TypeParameterDeclaration.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -1209,7 +1229,7 @@ public enum PropertyKind {
      */
     TYPE_PARAMETER_DECLARATION_TYPE_BOUNDS(
         TypeParameterDeclaration.class,
-        "typeBounds" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "typeBounds" //$NON-NLS-1$
     ),
 
     /**
@@ -1217,7 +1237,7 @@ public enum PropertyKind {
      */
     UNARY_EXPRESSION_OPERATOR(
         UnaryExpression.class,
-        "operator" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "operator" //$NON-NLS-1$
     ),
 
     /**
@@ -1225,7 +1245,7 @@ public enum PropertyKind {
      */
     UNARY_EXPRESSION_OPERAND(
         UnaryExpression.class,
-        "operand" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "operand" //$NON-NLS-1$
     ),
 
     /**
@@ -1233,7 +1253,7 @@ public enum PropertyKind {
      */
     VARIABLE_DECLARATOR_NAME(
         VariableDeclarator.class,
-        "name" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "name" //$NON-NLS-1$
     ),
 
     /**
@@ -1241,7 +1261,7 @@ public enum PropertyKind {
      */
     VARIABLE_DECLARATOR_EXTRA_DIMENSIONS(
         VariableDeclarator.class,
-        "extraDimensions" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "extraDimensions" //$NON-NLS-1$
     ),
 
     /**
@@ -1249,7 +1269,7 @@ public enum PropertyKind {
      */
     VARIABLE_DECLARATOR_INITIALIZER(
         VariableDeclarator.class,
-        "initializer" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "initializer" //$NON-NLS-1$
     ),
 
     /**
@@ -1257,7 +1277,7 @@ public enum PropertyKind {
      */
     WHILE_STATEMENT_CONDITION(
         WhileStatement.class,
-        "condition" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "condition" //$NON-NLS-1$
     ),
 
     /**
@@ -1265,7 +1285,7 @@ public enum PropertyKind {
      */
     WHILE_STATEMENT_BODY(
         WhileStatement.class,
-        "body" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "body" //$NON-NLS-1$
     ),
 
     /**
@@ -1273,7 +1293,7 @@ public enum PropertyKind {
      */
     WILDCARD_BOUND_KIND(
         Wildcard.class,
-        "boundKind" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "boundKind" //$NON-NLS-1$
     ),
 
     /**
@@ -1281,7 +1301,7 @@ public enum PropertyKind {
      */
     WILDCARD_TYPE_BOUND(
         Wildcard.class,
-        "typeBound" //$$NON-NLS-1$$ //$NON-NLS-1$
+        "typeBound" //$NON-NLS-1$
     ),
     ;
 

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/PropertyKind.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/PropertyKind.java
@@ -1249,6 +1249,14 @@ public enum PropertyKind {
     ),
 
     /**
+     * Represents {@link UnionType#getAlternativeTypes()}.
+     */
+    UNION_TYPE_ALTERNATIVE_TYPES(
+        UnionType.class,
+        "alternativeTypes" //$NON-NLS-1$
+    ),
+
+    /**
      * Represents {@link VariableDeclarator#getName()}.
      */
     VARIABLE_DECLARATOR_NAME(

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/StrictVisitor.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/StrictVisitor.java
@@ -578,6 +578,13 @@ public abstract class StrictVisitor<R, C, E extends Throwable>
     }
 
     @Override
+    public R visitUnionType(
+            UnionType elem,
+            C context) throws E {
+        throw new UnsupportedOperationException("UnionType"); //$NON-NLS-1$
+    }
+
+    @Override
     public R visitVariableDeclarator(
             VariableDeclarator elem,
             C context) throws E {

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/StrictVisitor.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/StrictVisitor.java
@@ -557,6 +557,13 @@ public abstract class StrictVisitor<R, C, E extends Throwable>
     }
 
     @Override
+    public R visitTryResource(
+            TryResource elem,
+            C context) throws E {
+        throw new UnsupportedOperationException("TryResource"); //$NON-NLS-1$
+    }
+
+    @Override
     public R visitTryStatement(
             TryStatement elem,
             C context) throws E {

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/StrictVisitor.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/StrictVisitor.java
@@ -354,6 +354,13 @@ public abstract class StrictVisitor<R, C, E extends Throwable>
     }
 
     @Override
+    public R visitLambdaExpression(
+            LambdaExpression elem,
+            C context) throws E {
+        throw new UnsupportedOperationException("LambdaExpression"); //$NON-NLS-1$
+    }
+
+    @Override
     public R visitLineComment(
             LineComment elem,
             C context) throws E {

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/TryResource.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/TryResource.java
@@ -15,44 +15,27 @@
  */
 package com.asakusafw.utils.java.model.syntax;
 
-import java.util.List;
-
 /**
- * An interface which represents try statement.
+ * An interface which represents try resources.
  * <ul>
  *   <li> Specified In: <ul>
- *     <li> {@code [JLS3:14.20] The try statement} </li>
  *     <li> {@code [JLS8:14.20.3] try-with-resources} </li>
  *   </ul> </li>
  * </ul>
  * @since 0.1.0
  * @version 0.9.0
  */
-public interface TryStatement
-        extends Statement {
+public interface TryResource extends TypedElement {
 
     /**
-     * Returns the resource statements.
-     * @return the resource statements
-     * @since 0.9.0
+     * Returns the resource variable declaration.
+     * @return the resource variable declaration
      */
-    List<? extends TryResource> getResources();
+    FormalParameterDeclaration getParameter();
 
     /**
-     * Returns the body block of {@code try} clause.
-     * @return the body block of {@code try} clause
+     * Returns the resource expression.
+     * @return the resource expression
      */
-    Block getTryBlock();
-
-    /**
-     * Returns the {@code catch} clauses.
-     * @return the {@code catch} clauses, or an empty list if there is no cache clauses
-     */
-    List<? extends CatchClause> getCatchClauses();
-
-    /**
-     * Returns the body block of {@code finally} clause.
-     * @return the body block of {@code finally} clause, or {@code null} if it is not specified
-     */
-    Block getFinallyBlock();
+    Expression getInitializer();
 }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/UnionType.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/UnionType.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.utils.java.model.syntax;
+
+import java.util.List;
+
+/**
+ * An interface which represents union types.
+ * In JLS8, this is only for cache clauses.
+ * <ul>
+ *   <li> Specified In: <ul>
+ *     <li> {@code [JLS8:14.20] The try statement} </li>
+ *   </ul> </li>
+ * </ul>
+ * @since 0.9.0
+ */
+public interface UnionType
+        extends Type {
+
+    /**
+     * Returns the alternative types.
+     * @return the alternative types
+     */
+    List<? extends Type> getAlternativeTypes();
+}

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/Visitor.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/Visitor.java
@@ -636,6 +636,19 @@ public abstract class Visitor<R, C, E extends Throwable> {
     }
 
     /**
+     * Processes {@link LambdaExpression} using this visitor.
+     * @param elem the target element
+     * @param context the current context (nullable)
+     * @return the processing result
+     * @throws E if error was occurred while processing the target element
+     */
+    public R visitLambdaExpression(
+            LambdaExpression elem,
+            C context) throws E {
+        return null;
+    }
+
+    /**
      * Processes {@link LineComment} using this visitor.
      * @param elem the target element
      * @param context the current context (nullable)

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/Visitor.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/Visitor.java
@@ -1016,6 +1016,19 @@ public abstract class Visitor<R, C, E extends Throwable> {
     }
 
     /**
+     * Processes {@link TryResource} using this visitor.
+     * @param elem the target element
+     * @param context the current context (nullable)
+     * @return the processing result
+     * @throws E if error was occurred while processing the target element
+     */
+    public R visitTryResource(
+            TryResource elem,
+            C context) throws E {
+        return null;
+    }
+
+    /**
      * Processes {@link TryStatement} using this visitor.
      * @param elem the target element
      * @param context the current context (nullable)

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/Visitor.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/Visitor.java
@@ -21,6 +21,8 @@ package com.asakusafw.utils.java.model.syntax;
  * @param <C> type of visitor context
  * @param <R> type of visitor result
  * @param <E> type of visitor exception
+ * @since 0.1.0
+ * @version 0.9.0
  */
 public abstract class Visitor<R, C, E extends Throwable> {
 
@@ -641,6 +643,7 @@ public abstract class Visitor<R, C, E extends Throwable> {
      * @param context the current context (nullable)
      * @return the processing result
      * @throws E if error was occurred while processing the target element
+     * @since 0.9.0
      */
     public R visitLambdaExpression(
             LambdaExpression elem,
@@ -1047,6 +1050,20 @@ public abstract class Visitor<R, C, E extends Throwable> {
      */
     public R visitUnaryExpression(
             UnaryExpression elem,
+            C context) throws E {
+        return null;
+    }
+
+    /**
+     * Processes {@link UnionType} using this visitor.
+     * @param elem the target element
+     * @param context the current context (nullable)
+     * @return the processing result
+     * @throws E if error was occurred while processing the target element
+     * @since 0.9.0
+     */
+    public R visitUnionType(
+            UnionType elem,
             C context) throws E {
         return null;
     }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/util/AttributeBuilder.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/util/AttributeBuilder.java
@@ -34,7 +34,7 @@ import com.asakusafw.utils.java.model.syntax.Type;
 /**
  * A builder for building attributes of declarations.
  * @since 0.1.0
- * @version 0.5.1
+ * @version 0.9.0
  */
 public class AttributeBuilder {
 
@@ -143,6 +143,15 @@ public class AttributeBuilder {
      */
     public AttributeBuilder Abstract() {
         return modifier(ModifierKind.ABSTRACT);
+    }
+
+    /**
+     * Appends {@code default} modifier to this builder.
+     * @return this
+     * @since 0.9.0
+     */
+    public AttributeBuilder Default() {
+        return modifier(ModifierKind.DEFAULT);
     }
 
     /**

--- a/utils-project/java-dom/src/test/java/com/asakusafw/utils/java/internal/model/util/ModelEmitterTest.java
+++ b/utils-project/java-dom/src/test/java/com/asakusafw/utils/java/internal/model/util/ModelEmitterTest.java
@@ -1543,6 +1543,32 @@ public class ModelEmitterTest {
     }
 
     /**
+     * interface declaration w/ default method.
+     * @throws Exception if failed
+     */
+    @Test
+    public void InterfaceDeclaration_default() throws Exception {
+        Class<?> klass = getTypeDeclaration(
+                f.newInterfaceDeclaration(
+                        null,
+                        Arrays.asList(f.newModifier(ModifierKind.PUBLIC)),
+                        f.newSimpleName("Testing"),
+                        Collections.emptyList(),
+                        Arrays.asList(f.newMethodDeclaration(
+                                null,
+                                Arrays.asList(f.newModifier(ModifierKind.DEFAULT)),
+                                Models.toType(f, String.class),
+                                f.newSimpleName("f"),
+                                Collections.emptyList(),
+                                Arrays.asList(f.newReturnStatement(Models.toLiteral(f, "OK")))))));
+
+        assertThat(klass.isInterface(), is(true));
+        assertThat(klass.getName(), equalTo("Testing"));
+
+        assertThat(klass.getMethod("f").isDefault(), is(true));
+    }
+
+    /**
      * enum declaration.
      * @throws Exception if error occurred
      */

--- a/utils-project/java-dom/src/test/java/com/asakusafw/utils/java/internal/model/util/ModelEmitterTest.java
+++ b/utils-project/java-dom/src/test/java/com/asakusafw/utils/java/internal/model/util/ModelEmitterTest.java
@@ -18,6 +18,7 @@ package com.asakusafw.utils.java.internal.model.util;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.annotation.Retention;
@@ -69,6 +70,7 @@ import com.asakusafw.utils.java.model.syntax.PackageDeclaration;
 import com.asakusafw.utils.java.model.syntax.PostfixOperator;
 import com.asakusafw.utils.java.model.syntax.ReturnStatement;
 import com.asakusafw.utils.java.model.syntax.Statement;
+import com.asakusafw.utils.java.model.syntax.TryResource;
 import com.asakusafw.utils.java.model.syntax.Type;
 import com.asakusafw.utils.java.model.syntax.TypeBodyDeclaration;
 import com.asakusafw.utils.java.model.syntax.TypeDeclaration;
@@ -1287,8 +1289,7 @@ public class ModelEmitterTest {
                                     f.newSimpleName("getMessage"),
                                     Collections.emptyList()))
                             })))
-                    }),
-                    null),
+                    })),
                 returnAsString(f.newSimpleName("buf"))),
             "Hello",
             "OK");
@@ -1334,8 +1335,7 @@ public class ModelEmitterTest {
                                     f.newSimpleName("getMessage"),
                                     Collections.emptyList()))
                             })))
-                    }),
-                    null),
+                    })),
                 returnAsString(f.newSimpleName("buf"))),
             "Hello",
             "OK");
@@ -1385,6 +1385,58 @@ public class ModelEmitterTest {
                 returnAsString(f.newSimpleName("buf"))),
             "Hello",
             "OKfin");
+    }
+
+    /**
+     * try with resources.
+     */
+    @Test
+    public void Try_with_resources() {
+        assertToString(
+            fromStmt("Hello",
+                f.newTryStatement(
+                    Arrays.asList(f.newTryResource(
+                        Models.toType(f, ByteArrayOutputStream.class),
+                        f.newSimpleName("out"),
+                        f.newClassInstanceCreationExpression(Models.toType(f, ByteArrayOutputStream.class)))),
+                    f.newBlock(f.newReturnStatement(Models.toLiteral(f, "OK"))),
+                    Arrays.asList(f.newCatchClause(
+                            Models.toType(f, IOException.class),
+                            f.newSimpleName("e"),
+                            e -> f.newBlock(f.newReturnStatement(Models.toLiteral(f, "NG"))))))),
+            "Hello",
+            "OK");
+    }
+
+    /**
+     * try with resources.
+     */
+    @Test
+    public void Try_with_resources_multiple() {
+        assertToString(
+                fromStmt("Hello",
+                    f.newTryStatement(
+                        Arrays.asList(new TryResource[] {
+                            f.newTryResource(
+                                Models.toType(f, ByteArrayOutputStream.class),
+                                f.newSimpleName("a"),
+                                f.newClassInstanceCreationExpression(Models.toType(f, ByteArrayOutputStream.class))),
+                            f.newTryResource(
+                                Models.toType(f, ByteArrayOutputStream.class),
+                                f.newSimpleName("b"),
+                                f.newClassInstanceCreationExpression(Models.toType(f, ByteArrayOutputStream.class))),
+                            f.newTryResource(
+                                Models.toType(f, ByteArrayOutputStream.class),
+                                f.newSimpleName("c"),
+                                f.newClassInstanceCreationExpression(Models.toType(f, ByteArrayOutputStream.class))),
+                        }),
+                        f.newBlock(f.newReturnStatement(Models.toLiteral(f, "OK"))),
+                        Arrays.asList(f.newCatchClause(
+                            Models.toType(f, IOException.class),
+                            f.newSimpleName("e"),
+                            e -> f.newBlock(f.newReturnStatement(Models.toLiteral(f, "NG"))))))),
+                "Hello",
+                "OK");
     }
 
     /**

--- a/utils-project/java-dom/src/test/java/com/asakusafw/utils/java/internal/model/util/ModelEmitterTest.java
+++ b/utils-project/java-dom/src/test/java/com/asakusafw/utils/java/internal/model/util/ModelEmitterTest.java
@@ -1242,7 +1242,7 @@ public class ModelEmitterTest {
     }
 
     /**
-     * switch-case statement.
+     * try-catch statement.
      */
     @Test
     public void Try_Catch() {
@@ -1295,7 +1295,54 @@ public class ModelEmitterTest {
     }
 
     /**
-     * switch-case statement.
+     * try with multi-catch.
+     */
+    @Test
+    public void Try_Catch_multi() {
+        assertToString(
+            fromStmt("Hello",
+                newStringBuilder("buf"),
+                f.newTryStatement(
+                    f.newBlock(Arrays.asList(new Statement[] {
+                        f.newThrowStatement(
+                            f.newClassInstanceCreationExpression(
+                                null,
+                                Collections.emptyList(),
+                                f.newNamedType(Models.toName(f, "UnsupportedOperationException")),
+                                Arrays.asList(new Expression[] {
+                                    Models.toLiteral(f, "OK")
+                                }),
+                                null))
+                    })),
+                    Arrays.asList(new CatchClause[] {
+                        f.newCatchClause(
+                            f.newFormalParameterDeclaration(
+                                Collections.emptyList(),
+                                f.newUnionType(new Type[] {
+                                        f.newNamedType(f.newSimpleName("IllegalArgumentException")),
+                                        f.newNamedType(f.newSimpleName("UnsupportedOperationException")),
+                                }),
+                                false,
+                                f.newSimpleName("e"),
+                                0),
+                            f.newBlock(Arrays.asList(new Statement[] {
+                                append(
+                                "buf",
+                                f.newMethodInvocationExpression(
+                                    f.newSimpleName("e"),
+                                    Collections.emptyList(),
+                                    f.newSimpleName("getMessage"),
+                                    Collections.emptyList()))
+                            })))
+                    }),
+                    null),
+                returnAsString(f.newSimpleName("buf"))),
+            "Hello",
+            "OK");
+    }
+
+    /**
+     * try-finally statement.
      */
     @Test
     public void Try_Finally() {


### PR DESCRIPTION
## Summary

This PR enables Java DOM generator library to generate source files using Java 8 features.

## Background, Problem or Goal of the patch

The latest implementation only supports Java 5/6 features.

## Design of the fix, or a new feature

This includes the following features:
* lambda expressions
* interface `default` methods
* try-with-resources
* try multi-catch

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

N/A.