### PR TITLE
Fix "do not verify" behavior in Excel sheets.

### DIFF
--- a/testing-project/asakusa-test-data-provider/src/main/java/com/asakusafw/testdriver/excel/ExcelSheetRuleProvider.java
+++ b/testing-project/asakusa-test-data-provider/src/main/java/com/asakusafw/testdriver/excel/ExcelSheetRuleProvider.java
@@ -57,6 +57,7 @@ import com.asakusafw.testdriver.rule.VerifyRuleBuilder.Property;
  * </li>
  * </ul>
  * @since 0.2.0
+ * @version 0.9.0
  */
 public class ExcelSheetRuleProvider implements VerifyRuleProvider {
 
@@ -115,8 +116,15 @@ public class ExcelSheetRuleProvider implements VerifyRuleProvider {
         assert sheet != null;
         assert extractor != null;
 
-        VerifyRuleBuilder builder = new VerifyRuleBuilder(definition);
         Set<DataModelCondition> modelPredicates = extractor.extractDataModelCondition(sheet);
+        // if ignores anything, this returns special rule that accepts anything
+        if (modelPredicates.contains(DataModelCondition.IGNORE_MATCHED)
+                && modelPredicates.contains(DataModelCondition.IGNORE_ABSENT)
+                && modelPredicates.contains(DataModelCondition.IGNORE_UNEXPECTED)) {
+            return VerifyRule.NULL;
+        }
+
+        VerifyRuleBuilder builder = new VerifyRuleBuilder(definition);
         if (modelPredicates.contains(DataModelCondition.IGNORE_ABSENT)) {
             builder.acceptIfAbsent();
         }

--- a/testing-project/asakusa-test-data-provider/src/test/java/com/asakusafw/testdriver/excel/ExcelSheetRuleProviderTest.java
+++ b/testing-project/asakusa-test-data-provider/src/test/java/com/asakusafw/testdriver/excel/ExcelSheetRuleProviderTest.java
@@ -147,7 +147,7 @@ public class ExcelSheetRuleProviderTest {
     }
 
     /**
-     * {@link DataModelCondition} - ignore unexpected.
+     * {@link DataModelCondition} - ignore all.
      * @throws Exception if occur
      */
     @Test
@@ -157,6 +157,21 @@ public class ExcelSheetRuleProviderTest {
         assertThat(rule.verify(obj(1, "a"), obj(1, "b")), is(nullValue()));
         assertThat(rule.verify(null, obj(1, "a")), is(nullValue()));
         assertThat(rule.verify(obj(1, "a"), null), is(nullValue()));
+    }
+
+    /**
+     * {@link DataModelCondition} - ignore all.
+     * @throws Exception if occur
+     */
+    @Test
+    public void skip_key() throws Exception {
+        VerifyRule rule = rule("verify/skip.xls");
+        Object k0 = rule.getKey(obj(1, "a"));
+        Object k1 = rule.getKey(obj(1, "a"));
+        Object k2 = rule.getKey(obj(1, "a"));
+        assertThat(k0, not(equalTo(k1)));
+        assertThat(k0, not(equalTo(k2)));
+        assertThat(k1, not(equalTo(k2)));
     }
 
     /**

--- a/testing-project/asakusa-test-moderator/src/main/java/com/asakusafw/testdriver/core/VerifyRule.java
+++ b/testing-project/asakusa-test-moderator/src/main/java/com/asakusafw/testdriver/core/VerifyRule.java
@@ -18,8 +18,24 @@ package com.asakusafw.testdriver.core;
 /**
  * Strategy of test result verification.
  * @since 0.2.0
+ * @version 0.9.0
  */
 public interface VerifyRule extends TestRule {
+
+    /**
+     * A verify rule that accepts any data.
+     * @since 0.9.0
+     */
+    VerifyRule NULL = new VerifyRule() {
+        @Override
+        public Object getKey(DataModelReflection target) {
+            return new Object();
+        }
+        @Override
+        public Object verify(DataModelReflection expected, DataModelReflection actual) {
+            return null;
+        }
+    };
 
     /**
      * Returns the key of the target data model.
@@ -32,7 +48,4 @@ public interface VerifyRule extends TestRule {
      * @throws IllegalArgumentException if some parameters were {@code null}
      */
     Object getKey(DataModelReflection target);
-
-    @Override
-    Object verify(DataModelReflection expected, DataModelReflection actual);
 }


### PR DESCRIPTION
## Summary

This PR fixes "do not verify `[-]`" behavior in Excel test rule sheets.

## Background, Problem or Goal of the patch

The latest implementation, "do not verify `[-]`" ignores key properties. This may occur error when there are two or more expected/actual data.

## Design of the fix, or a new feature

We added a special rule for "do not verify `[-]`" that accepts any inputs.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 