### PR TITLE
Support default value of variables in WindGate profiles.

### DIFF
--- a/windgate-project/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/ParameterList.java
+++ b/windgate-project/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/ParameterList.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 /**
  * The parameter list.
  * @since 0.2.2
+ * @version 0.9.0
  */
 public class ParameterList {
 
@@ -36,6 +37,8 @@ public class ParameterList {
     static final Logger LOG = LoggerFactory.getLogger(ParameterList.class);
 
     private static final Pattern VARIABLE = Pattern.compile("\\$\\{(.*?)\\}");
+
+    private static final char SEPARATOR_DEFAULT_VALUE = '-';
 
     private final Map<String, String> parameters;
 
@@ -87,7 +90,7 @@ public class ParameterList {
         Matcher matcher = VARIABLE.matcher(string);
         while (matcher.find(start)) {
             String name = matcher.group(1);
-            String replacement = parameters.get(name);
+            String replacement = resolve(name);
             if (replacement == null) {
                 if (strict) {
                     WGLOG.error("E99001",
@@ -108,6 +111,24 @@ public class ParameterList {
         }
         buf.append(string.substring(start));
         return buf.toString();
+    }
+
+    private String resolve(String placeholder) {
+        String name;
+        String defaultValue;
+        int defaultAt = placeholder.indexOf(SEPARATOR_DEFAULT_VALUE);
+        if (defaultAt < 0) {
+            name = placeholder;
+            defaultValue = null;
+        } else {
+            name = placeholder.substring(0, defaultAt);
+            defaultValue = placeholder.substring(defaultAt + 1);
+        }
+        String replacement = parameters.get(name);
+        if (replacement != null) {
+            return replacement;
+        }
+        return defaultValue;
     }
 
     @Override

--- a/windgate-project/asakusa-windgate-core/src/test/java/com/asakusafw/windgate/core/ParameterListTest.java
+++ b/windgate-project/asakusa-windgate-core/src/test/java/com/asakusafw/windgate/core/ParameterListTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.windgate.core;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * Test for {@link ParameterList}.
+ */
+public class ParameterListTest {
+
+    /**
+     * Simple testing.
+     */
+    @Test
+    public void simple() {
+        Map<String, String> map = new HashMap<>();
+        map.put("message", "Hello, world!");
+        ParameterList resolver = new ParameterList(map);
+        assertThat(resolver.replace("${message}", true), is("Hello, world!"));
+        assertThat(resolver.getPairs(), is(map));
+    }
+
+    /**
+     * Replace a variable in line.
+     */
+    @Test
+    public void inLine() {
+        Map<String, String> map = new HashMap<>();
+        map.put("message", "Hello, world!");
+        ParameterList resolver = new ParameterList(map);
+        assertThat(resolver.replace(">>> ${message} <<<", true), is(">>> Hello, world! <<<"));
+    }
+
+    /**
+     * Replace multiple variables.
+     */
+    @Test
+    public void multiple() {
+        Map<String, String> map = new HashMap<>();
+        map.put("m1", "Hello1");
+        map.put("m2", "Hello2");
+        map.put("m3", "Hello3");
+        ParameterList resolver = new ParameterList(map);
+        assertThat(resolver.replace("${m1}, ${m2}, ${m3}!", true), is("Hello1, Hello2, Hello3!"));
+    }
+
+    /**
+     * present variable w/ default value.
+     */
+    @Test
+    public void with_default_present() {
+        Map<String, String> map = new HashMap<>();
+        map.put("message", "Hello, world!");
+        ParameterList resolver = new ParameterList(map);
+        assertThat(resolver.replace("${message-MISSING}", true), is("Hello, world!"));
+    }
+
+    /**
+     * absent variable w/ default value.
+     */
+    @Test
+    public void with_default_missing() {
+        Map<String, String> map = new HashMap<>();
+        ParameterList resolver = new ParameterList(map);
+        assertThat(resolver.replace("${message-MISSING}", true), is("MISSING"));
+    }
+
+    /**
+     * Unknown variable.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void invalid_strict() {
+        Map<String, String> map = new HashMap<>();
+        ParameterList resolver = new ParameterList(map);
+        resolver.replace("${MISSING}", true);
+    }
+
+    /**
+     * Unknown variable.
+     */
+    @Test
+    public void invalid_keep() {
+        Map<String, String> map = new HashMap<>();
+        ParameterList resolver = new ParameterList(map);
+        assertThat(resolver.replace("${MISSING}", false), is("${MISSING}"));
+    }
+}


### PR DESCRIPTION
## Summary

This PR enables default values of variables (`${variable}`) in WindGate profiles.

## Background, Problem or Goal of the patch

The latest implementation, WindGate will raise error if the environment variable in the profile script is not defined.

## Design of the fix, or a new feature

This is similar to #491, but this is for WindGate.
A placeholder `${name-default}` will be resolved as like `${name}` if the environment variable `name` is defined, or `default` if it is not defined.

## Related Issue, Pull Request or Code

* #491

## Wanted reviewer

@akirakw 