### PR TITLE
Add force quote mode for CSV outputs.

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/csv/CsvConfiguration.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/csv/CsvConfiguration.java
@@ -20,6 +20,7 @@ import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.IntStream;
 
 import com.asakusafw.runtime.value.Date;
 import com.asakusafw.runtime.value.DateTime;
@@ -27,9 +28,11 @@ import com.asakusafw.runtime.value.DateTime;
 /**
  * CSV configurations.
  * @since 0.2.4
- * @version 0.7.3
+ * @version 0.9.0
  */
 public class CsvConfiguration {
+
+    private static final int[] EMPTY_INT_ARRAY = new int[0];
 
     /**
      * The default charset encoding.
@@ -102,6 +105,8 @@ public class CsvConfiguration {
     private volatile char separatorChar = DEFAULT_SEPARATOR_CHAR;
 
     private boolean forceConsumeHeader = DEFAULT_FORCE_CONSUME_HEADER;
+
+    private int[] forceQuoteColumns = EMPTY_INT_ARRAY;
 
     /**
      * Creates a new instance.
@@ -242,5 +247,23 @@ public class CsvConfiguration {
      */
     public void setForceConsumeHeader(boolean newValue) {
         this.forceConsumeHeader = newValue;
+    }
+
+    /**
+     * Returns column indices which quoting is always required.
+     * @return the column indices
+     * @since 0.9.0
+     */
+    public int[] getForceQuoteColumns() {
+        return forceQuoteColumns.clone();
+    }
+
+    /**
+     * Sets column indices which quoting is always required.
+     * @param indices the column indices
+     * @since 0.9.0
+     */
+    public void setForceQuoteColumns(int... indices) {
+        this.forceQuoteColumns = IntStream.of(indices).sorted().distinct().toArray();
     }
 }

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/csv/CsvEmitterTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/csv/CsvEmitterTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.*;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -67,6 +68,8 @@ public class CsvEmitterTest {
 
     private String dateTimeFormat = CsvConfiguration.DEFAULT_DATE_TIME_FORMAT;
 
+    private final List<Integer> quote = new ArrayList<>();
+
     private CsvEmitter createEmitter() {
         CsvConfiguration conf = createConfiguration();
         return new CsvEmitter(output, testName.getMethodName(), conf);
@@ -85,6 +88,7 @@ public class CsvEmitterTest {
                 falseFormat,
                 dateFormat,
                 dateTimeFormat);
+        conf.setForceQuoteColumns(quote.stream().mapToInt(i -> i).toArray());
         return conf;
     }
 
@@ -143,6 +147,28 @@ public class CsvEmitterTest {
         falseFormat = "true";
         assertRestorable(new BooleanOption(true));
         assertRestorable(new BooleanOption(false));
+
+        trueFormat = "\"T\"";
+        falseFormat = "\"F\"";
+        assertRestorable(new BooleanOption(true));
+        assertRestorable(new BooleanOption(false));
+    }
+
+    /**
+     * test for boolean values.
+     * @throws Exception if failed
+     */
+    @Test
+    public void boolean_values_quote() throws Exception {
+        quote.add(0);
+        assertRestorable(new BooleanOption(true));
+        assertRestorable(new BooleanOption(false));
+        assertRestorable(new BooleanOption());
+
+        trueFormat = "\"T\"";
+        falseFormat = "\"F\"";
+        assertRestorable(new BooleanOption(true));
+        assertRestorable(new BooleanOption(false));
     }
 
     /**
@@ -158,6 +184,19 @@ public class CsvEmitterTest {
         assertRestorable(new ByteOption((byte) -50));
         assertRestorable(new ByteOption(Byte.MAX_VALUE));
         assertRestorable(new ByteOption(Byte.MIN_VALUE));
+        assertRestorable(new ByteOption());
+    }
+
+    /**
+     * test for byte values.
+     * @throws Exception if failed
+     */
+    @Test
+    public void byte_values_quote() throws Exception {
+        quote.add(0);
+        assertRestorable(new ByteOption((byte) 0));
+        assertRestorable(new ByteOption((byte) 1));
+        assertRestorable(new ByteOption((byte) -1));
         assertRestorable(new ByteOption());
     }
 
@@ -178,6 +217,18 @@ public class CsvEmitterTest {
     }
 
     /**
+     * test for short values.
+     * @throws Exception if failed
+     */
+    @Test
+    public void short_values_quote() throws Exception {
+        quote.add(0);
+        assertRestorable(new ShortOption((short) 0));
+        assertRestorable(new ShortOption((short) 1));
+        assertRestorable(new ShortOption((short) -1));
+    }
+
+    /**
      * test for int values.
      * @throws Exception if failed
      */
@@ -191,6 +242,18 @@ public class CsvEmitterTest {
         assertRestorable(new IntOption(Integer.MAX_VALUE));
         assertRestorable(new IntOption(Integer.MIN_VALUE));
         assertRestorable(new IntOption());
+    }
+
+    /**
+     * test for int values.
+     * @throws Exception if failed
+     */
+    @Test
+    public void int_values_quote() throws Exception {
+        quote.add(0);
+        assertRestorable(new IntOption(0));
+        assertRestorable(new IntOption(1));
+        assertRestorable(new IntOption(-1));
     }
 
     /**
@@ -210,6 +273,18 @@ public class CsvEmitterTest {
     }
 
     /**
+     * test for long values.
+     * @throws Exception if failed
+     */
+    @Test
+    public void long_vaules_quote() throws Exception {
+        quote.add(0);
+        assertRestorable(new LongOption(0));
+        assertRestorable(new LongOption(1));
+        assertRestorable(new LongOption(-1));
+    }
+
+    /**
      * test for float values.
      * @throws Exception if failed
      */
@@ -223,6 +298,18 @@ public class CsvEmitterTest {
         assertRestorable(new FloatOption(Float.MAX_VALUE));
         assertRestorable(new FloatOption(Float.MIN_VALUE));
         assertRestorable(new FloatOption());
+    }
+
+    /**
+     * test for float values.
+     * @throws Exception if failed
+     */
+    @Test
+    public void float_values_quote() throws Exception {
+        quote.add(0);
+        assertRestorable(new FloatOption(0));
+        assertRestorable(new FloatOption(1));
+        assertRestorable(new FloatOption(-1));
     }
 
     /**
@@ -242,6 +329,18 @@ public class CsvEmitterTest {
     }
 
     /**
+     * test for double values.
+     * @throws Exception if failed
+     */
+    @Test
+    public void double_values_quote() throws Exception {
+        quote.add(0);
+        assertRestorable(new DoubleOption(0));
+        assertRestorable(new DoubleOption(1));
+        assertRestorable(new DoubleOption(-1));
+    }
+
+    /**
      * test for decimal values.
      * @throws Exception if failed
      */
@@ -256,6 +355,19 @@ public class CsvEmitterTest {
         assertRestorable(new DecimalOption(decimal("3.1415")));
         assertRestorable(new DecimalOption(decimal("-3.1415")));
         assertRestorable(new DecimalOption());
+    }
+
+    /**
+     * test for decimal values.
+     * @throws Exception if failed
+     */
+    @Test
+    public void decimal_values_quote() throws Exception {
+        quote.add(0);
+        assertRestorable(new DecimalOption(decimal("0")));
+        assertRestorable(new DecimalOption(decimal("-100")));
+        assertRestorable(new DecimalOption(decimal("1")));
+        assertRestorable(new DecimalOption(decimal("-1")));
     }
 
     private BigDecimal decimal(String string) {
@@ -275,11 +387,51 @@ public class CsvEmitterTest {
     }
 
     /**
+     * test for text values.
+     * @throws Exception if failed
+     */
+    @Test
+    public void text_values_quote() throws Exception {
+        quote.add(0);
+        assertRestorable(new StringOption("Hello"));
+        assertRestorable(new StringOption("\u3042\u3044\u3046\u3048\u304a"));
+        assertRestorable(new StringOption("\",\r\n\t "));
+    }
+
+    /**
      * test for date values.
      * @throws Exception if failed
      */
     @Test
     public void date_values() throws Exception {
+        assertRestorable(new DateOption(new Date(2011, 3, 31)));
+        assertRestorable(new DateOption(new Date(1971, 4, 1)));
+        assertRestorable(new DateOption());
+
+        dateFormat = "yyyy-MM\"dd";
+        assertRestorable(new DateOption(new Date(2011, 3, 31)));
+        assertRestorable(new DateOption(new Date(1971, 4, 1)));
+
+        dateFormat = "yyyy-MM,dd";
+        assertRestorable(new DateOption(new Date(2011, 3, 31)));
+        assertRestorable(new DateOption(new Date(1971, 4, 1)));
+
+        dateFormat = "yyyy-MM\ndd";
+        assertRestorable(new DateOption(new Date(2011, 3, 31)));
+        assertRestorable(new DateOption(new Date(1971, 4, 1)));
+
+        dateFormat = "yyyy-MM\rdd";
+        assertRestorable(new DateOption(new Date(2011, 3, 31)));
+        assertRestorable(new DateOption(new Date(1971, 4, 1)));
+    }
+
+    /**
+     * test for date values.
+     * @throws Exception if failed
+     */
+    @Test
+    public void date_values_quote() throws Exception {
+        quote.add(0);
         assertRestorable(new DateOption(new Date(2011, 3, 31)));
         assertRestorable(new DateOption(new Date(1971, 4, 1)));
         assertRestorable(new DateOption());
@@ -319,6 +471,34 @@ public class CsvEmitterTest {
      */
     @Test
     public void datetime_values() throws Exception {
+        assertRestorable(new DateTimeOption(new DateTime(2011, 3, 31, 23, 59, 59)));
+        assertRestorable(new DateTimeOption(new DateTime(1971, 4, 1, 2 ,3, 4)));
+        assertRestorable(new DateTimeOption());
+
+        dateTimeFormat = "yyyy-MM\"dd HH:mm:ss";
+        assertRestorable(new DateTimeOption(new DateTime(2011, 3, 31, 23, 59, 59)));
+        assertRestorable(new DateTimeOption(new DateTime(1971, 4, 1, 2 ,3, 4)));
+
+        dateTimeFormat = "yyyy-MM,dd HH:mm:ss";
+        assertRestorable(new DateTimeOption(new DateTime(2011, 3, 31, 23, 59, 59)));
+        assertRestorable(new DateTimeOption(new DateTime(1971, 4, 1, 2 ,3, 4)));
+
+        dateTimeFormat = "yyyy-MM\ndd HH:mm:ss";
+        assertRestorable(new DateTimeOption(new DateTime(2011, 3, 31, 23, 59, 59)));
+        assertRestorable(new DateTimeOption(new DateTime(1971, 4, 1, 2 ,3, 4)));
+
+        dateTimeFormat = "yyyy-MM\rdd HH:mm:ss";
+        assertRestorable(new DateTimeOption(new DateTime(2011, 3, 31, 23, 59, 59)));
+        assertRestorable(new DateTimeOption(new DateTime(1971, 4, 1, 2 ,3, 4)));
+    }
+
+    /**
+     * test for date-time values.
+     * @throws Exception if failed
+     */
+    @Test
+    public void datetime_values_quote() throws Exception {
+        quote.add(0);
         assertRestorable(new DateTimeOption(new DateTime(2011, 3, 31, 23, 59, 59)));
         assertRestorable(new DateTimeOption(new DateTime(1971, 4, 1, 2 ,3, 4)));
         assertRestorable(new DateTimeOption());

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/csv/driver/CsvFieldDriver.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/csv/driver/CsvFieldDriver.java
@@ -16,7 +16,10 @@
 package com.asakusafw.dmdl.directio.csv.driver;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.asakusafw.dmdl.Diagnostic;
 import com.asakusafw.dmdl.Diagnostic.Level;
@@ -37,8 +40,10 @@ import com.asakusafw.dmdl.util.AttributeUtil;
 The attributed declaration must be:
 <ul>
 <li> with name=[string-literal] (optional, default: property name)</li>
+<li> with quote=["default"|"needed"|"always"] (optional, default: "default")</li>
 </ul>
  * @since 0.2.5
+ * @version 0.9.0
  */
 public class CsvFieldDriver  extends PropertyAttributeDriver {
 
@@ -52,6 +57,18 @@ public class CsvFieldDriver  extends PropertyAttributeDriver {
      */
     public static final String ELEMENT_NAME = "name"; //$NON-NLS-1$
 
+    /**
+     * The element name of quoting strategy.
+     * @since 0.9.0
+     */
+    public static final String ELEMENT_QUOTE = "quote"; //$NON-NLS-1$
+
+    /**
+     * The default value of {@link #ELEMENT_QUOTE}.
+     * @since 0.9.0
+     */
+    public static final String DEFAULT_QUOTE = "default"; //$NON-NLS-1$
+
     @Override
     public String getTargetName() {
         return TARGET_NAME;
@@ -61,11 +78,38 @@ public class CsvFieldDriver  extends PropertyAttributeDriver {
     public void process(DmdlSemantics environment, PropertyDeclaration declaration, AstAttribute attribute) {
         Map<String, AstAttributeElement> elements = AttributeUtil.getElementMap(attribute);
         String value = AttributeUtil.takeString(environment, attribute, elements, ELEMENT_NAME, false);
+        CsvFieldTrait.QuoteStrategy quote = CsvFieldDriver.takeQuote(environment, attribute, elements);
         environment.reportAll(AttributeUtil.reportInvalidElements(attribute, elements.values()));
         checkFieldType(environment, declaration, attribute, BasicTypeKind.values());
         if (CsvFieldDriver.checkConflict(environment, declaration, attribute)) {
-            declaration.putTrait(CsvFieldTrait.class, new CsvFieldTrait(attribute, Kind.VALUE, value));
+            declaration.putTrait(CsvFieldTrait.class, new CsvFieldTrait(attribute, Kind.VALUE, value, quote));
         }
+    }
+
+    private static CsvFieldTrait.QuoteStrategy takeQuote(
+            DmdlSemantics environment,
+            AstAttribute attribute,
+            Map<String, AstAttributeElement> elements) {
+        String symbol = AttributeUtil.takeString(environment, attribute, elements, ELEMENT_QUOTE, false);
+        if (symbol == null) {
+            return CsvFieldTrait.QuoteStrategy.getDefault();
+        }
+        return CsvFieldTrait.QuoteStrategy.fromSymbol(symbol)
+                .orElseGet(() -> {
+                    environment.report(new Diagnostic(
+                            Level.ERROR,
+                            attribute.name,
+                            "@{0} must be one of {2}: {1}",
+                            attribute.name.toString(),
+                            symbol,
+                            Stream.concat(
+                                    Stream.of(DEFAULT_QUOTE),
+                                    Stream.of(CsvFieldTrait.QuoteStrategy.values()).map(Enum::name))
+                                .map(s -> String.format("\"%s\"", s.toLowerCase(Locale.ENGLISH))) //$NON-NLS-1$
+                                .sequential()
+                                .collect(Collectors.toList())));
+                    return CsvFieldTrait.QuoteStrategy.getDefault();
+                });
     }
 
     static boolean checkConflict(DmdlSemantics environment, PropertyDeclaration declaration, AstAttribute attribute) {

--- a/directio-project/asakusa-directio-dmdl/src/test/java/com/asakusafw/dmdl/directio/csv/driver/CsvFormatEmitterTest.java
+++ b/directio-project/asakusa-directio-dmdl/src/test/java/com/asakusafw/dmdl/directio/csv/driver/CsvFormatEmitterTest.java
@@ -176,6 +176,26 @@ public class CsvFormatEmitterTest extends GeneratorTesterRoot {
     }
 
     /**
+     * quoted.
+     * @throws Exception if failed
+     */
+    @Test
+    public void quote() throws Exception {
+        ModelLoader loaded = generateJava("quote");
+        ModelWrapper model = loaded.newModel("Simple");
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("csv", "SimpleCsvFormat");
+        BinaryStreamFormat<Object> unsafe = unsafe(support);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ModelOutput<Object> writer = unsafe.createOutput(model.unwrap().getClass(), "hello", output)) {
+            model.set("value", new Text("hello-world"));
+            writer.write(model.unwrap());
+            model.set("value", new Text("hello,world"));
+            writer.write(model.unwrap());
+        }
+        assertThat(scan(output.toByteArray()), contains("\"hello-world\"", "\"hello,world\""));
+    }
+
+    /**
      * With compression.
      * @throws Exception if failed
      */

--- a/directio-project/asakusa-directio-dmdl/src/test/resources/com/asakusafw/dmdl/directio/csv/driver/quote.txt
+++ b/directio-project/asakusa-directio-dmdl/src/test/resources/com/asakusafw/dmdl/directio/csv/driver/quote.txt
@@ -1,0 +1,5 @@
+@directio.csv
+simple = {
+    @directio.csv.field(quote="always")
+    value : TEXT;
+};

--- a/windgate-project/asakusa-windgate-dmdl/src/main/java/com/asakusafw/dmdl/windgate/csv/driver/CsvFieldTrait.java
+++ b/windgate-project/asakusa-windgate-dmdl/src/main/java/com/asakusafw/dmdl/windgate/csv/driver/CsvFieldTrait.java
@@ -15,6 +15,12 @@
  */
 package com.asakusafw.dmdl.windgate.csv.driver;
 
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
 import com.asakusafw.dmdl.model.AstNode;
 import com.asakusafw.dmdl.semantics.PropertyDeclaration;
 import com.asakusafw.dmdl.semantics.Trait;
@@ -31,6 +37,8 @@ public class CsvFieldTrait implements Trait<CsvFieldTrait> {
 
     private final String name;
 
+    private final QuoteStrategy quote;
+
     /**
      * Creates a new instance.
      * @param originalAst the original AST, or {@code null} if this is an ad-hoc element
@@ -39,12 +47,26 @@ public class CsvFieldTrait implements Trait<CsvFieldTrait> {
      * @throws IllegalArgumentException if some parameters were {@code null}
      */
     public CsvFieldTrait(AstNode originalAst, Kind kind, String name) {
+        this(originalAst, kind, name, null);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param originalAst the original AST, or {@code null} if this is an ad-hoc element
+     * @param kind the field kind
+     * @param name the explicit field name (nullable)
+     * @param quote quoting strategy (nullable)
+     * @throws IllegalArgumentException if some parameters were {@code null}
+     * @since 0.9.0
+     */
+    public CsvFieldTrait(AstNode originalAst, Kind kind, String name, QuoteStrategy quote) {
         if (kind == null) {
             throw new IllegalArgumentException("kind must not be null"); //$NON-NLS-1$
         }
         this.originalAst = originalAst;
         this.kind = kind;
         this.name = name;
+        this.quote = quote;
     }
 
     @Override
@@ -61,14 +83,7 @@ public class CsvFieldTrait implements Trait<CsvFieldTrait> {
      * @throws IllegalArgumentException if some parameters were {@code null}
      */
     public static Kind getKind(PropertyDeclaration property, Kind defaultKind) {
-        if (property == null) {
-            throw new IllegalArgumentException("property must not be null"); //$NON-NLS-1$
-        }
-        CsvFieldTrait trait = property.getTrait(CsvFieldTrait.class);
-        if (trait != null) {
-            return trait.kind;
-        }
-        return defaultKind;
+        return get(property, trait -> trait.kind).orElse(defaultKind);
     }
 
     /**
@@ -79,14 +94,27 @@ public class CsvFieldTrait implements Trait<CsvFieldTrait> {
      * @throws IllegalArgumentException if some parameters were {@code null}
      */
     public static String getFieldName(PropertyDeclaration property) {
+        return get(property, trait -> trait.name).orElse(property.getName().identifier);
+    }
+
+    /**
+     * Returns the quoting strategy for the CSV field property.
+     * @param property the target property
+     * @return the quoting strategy
+     * @throws IllegalArgumentException if some parameters were {@code null}
+     * @since 0.9.0
+     */
+    public static QuoteStrategy getQuoteStrategy(PropertyDeclaration property) {
+        return get(property, trait -> trait.quote).orElse(QuoteStrategy.getDefault());
+    }
+
+    private static <T> Optional<T> get(PropertyDeclaration property, Function<CsvFieldTrait, T> getter) {
         if (property == null) {
             throw new IllegalArgumentException("property must not be null"); //$NON-NLS-1$
         }
         CsvFieldTrait trait = property.getTrait(CsvFieldTrait.class);
-        if (trait != null && trait.name != null) {
-            return trait.name;
-        }
-        return property.getName().identifier;
+        return Optional.ofNullable(trait)
+                .flatMap(t -> Optional.ofNullable(getter.apply(t)));
     }
 
     /**
@@ -119,5 +147,59 @@ public class CsvFieldTrait implements Trait<CsvFieldTrait> {
          * ignored fields.
          */
         IGNORE,
+    }
+
+    /**
+     * Column quoting strategy.
+     * @since 0.9.0
+     */
+    public enum QuoteStrategy {
+
+        /**
+         * Quotes only if needed.
+         */
+        NEEDED,
+
+        /**
+         * Quotes always.
+         */
+        ALWAYS,
+        ;
+
+        private static final String DEFAULT_SYMBOL = "default"; //$NON-NLS-1$
+
+        /**
+         * Returns the default value.
+         * @return the default value
+         */
+        public static QuoteStrategy getDefault() {
+            return QuoteStrategy.NEEDED;
+        }
+
+        /**
+         * Returns the constant from the symbol.
+         * @param symbol the symbol
+         * @return the related constant, or empty if it is not defined
+         */
+        public static Optional<QuoteStrategy> fromSymbol(String symbol) {
+            return Optional.ofNullable(Lazy.SYMBOLS.get(symbol.toLowerCase(Locale.ENGLISH)));
+        }
+
+        private static final class Lazy {
+
+            static final Map<String, QuoteStrategy> SYMBOLS;
+            static {
+                Map<String, QuoteStrategy> map = new LinkedHashMap<>();
+                map.put(DEFAULT_SYMBOL, getDefault());
+                for (QuoteStrategy v : QuoteStrategy.values()) {
+                    map.put(v.name().toLowerCase(Locale.ENGLISH), v);
+                }
+                SYMBOLS = map;
+            }
+
+            private Lazy() {
+                return;
+            }
+        }
     }
 }

--- a/windgate-project/asakusa-windgate-dmdl/src/test/java/com/asakusafw/dmdl/windgate/csv/driver/CsvSupportEmitterTest.java
+++ b/windgate-project/asakusa-windgate-dmdl/src/test/java/com/asakusafw/dmdl/windgate/csv/driver/CsvSupportEmitterTest.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.hadoop.io.Text;
 import org.junit.Before;
@@ -200,6 +202,28 @@ public class CsvSupportEmitterTest extends GeneratorTesterRoot {
                 {"value"},
                 {"Hello, world!"},
         }));
+    }
+
+    /**
+     * quoted.
+     * @throws Exception if failed
+     */
+    @Test
+    public void quote() throws Exception {
+        ModelLoader loaded = generateJava("quote");
+        DataModelStreamSupport<Object> support = unsafe(loaded.newObject("csv", "ModelCsvSupport"));
+
+        ModelWrapper r0 = loaded.newModel("Model");
+        r0.set("value", new Text("hello-world"));
+        ModelWrapper r1 = loaded.newModel("Model");
+        r1.set("value", new Text("hello,world"));
+        byte[] data = write(support, r0, r1);
+
+        List<String> results = Stream.of(new String(data, "UTF-8").split("\\s+"))
+                .map(String::trim)
+                .filter(s -> s.isEmpty() == false)
+                .collect(Collectors.toList());
+        assertThat(results, contains("\"hello-world\"", "\"hello,world\""));
     }
 
     /**

--- a/windgate-project/asakusa-windgate-dmdl/src/test/resources/com/asakusafw/dmdl/windgate/csv/driver/quote.txt
+++ b/windgate-project/asakusa-windgate-dmdl/src/test/resources/com/asakusafw/dmdl/windgate/csv/driver/quote.txt
@@ -1,0 +1,5 @@
+@windgate.csv
+model = {
+    @windgate.csv.field(quote = "always")
+    value : TEXT;
+};


### PR DESCRIPTION
## Summary

This PR enables to configure field quoting strategy of CSV outputs.

## Background, Problem or Goal of the patch

The latest implementation, Direct I/O and WindGate CSV outputs quote fields only if the field value contain meta-characters (`"`, `,`, ...), but some CSV parsers only accepts quoted fields even if it is redundant.

## Design of the fix, or a new feature

The attribute element named `quote` is now enabled to `@directio.csv.field` (Direct I/O) and `@windgate.csv.field` (WindGate). The default behavior of both is as the conventional quoting strategy. 

* `@directio.csv.field(quote="default|needed|always")`
  * configures quoting mode:
    * `default` - as `needed`
    * `needed` - quote only if needed
    * `always` - always quote
  * default: `default`
* `@windgate.csv.field(quote="default|needed|always")`
  * configures quoting mode:
    * `default` - as `needed`
    * `needed` - quote only if needed
    * `always` - always quote
  * default: `default`

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 
