### PR TITLE
Make WindGate JDBC options API more robust.

### DIFF
--- a/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/JdbcAttribute.java
+++ b/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/JdbcAttribute.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vocabulary.windgate;
+
+/**
+ * Represents an attribute about JDBC operations.
+ * @since 0.9.0
+ */
+public interface JdbcAttribute {
+
+    /**
+     * Returns the symbol of this attribute.
+     * @return the attribute symbol
+     */
+    String getSymbol();
+}

--- a/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/JdbcDescriptionUtil.java
+++ b/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/JdbcDescriptionUtil.java
@@ -18,6 +18,7 @@ package com.asakusafw.vocabulary.windgate;
 import java.text.MessageFormat;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
 
 import com.asakusafw.windgate.core.vocabulary.DataModelJdbcSupport;
 
@@ -28,10 +29,12 @@ final class JdbcDescriptionUtil {
             Class<?> modelType,
             Class<? extends DataModelJdbcSupport<?>> supportClass,
             String table,
-            List<String> columns) {
+            List<String> columns,
+            Collection<? extends JdbcAttribute> options) {
         checkTable(descriptionClass, table);
         checkColumns(descriptionClass, columns);
         checkSupportClass(descriptionClass, supportClass, modelType, columns);
+        checkOptions(descriptionClass, options);
     }
 
     private static void checkTable(String descriptionClass, String table) {
@@ -104,6 +107,15 @@ final class JdbcDescriptionUtil {
                     descriptionClass,
                     supportClass.getName(),
                     columns));
+        }
+    }
+
+    private static void checkOptions(String descriptionClass, Collection<? extends JdbcAttribute> options) {
+        if (options != null && options.stream().anyMatch(Predicate.isEqual(null))) {
+            throw new IllegalStateException(MessageFormat.format(
+                    Messages.getString("JdbcDescriptionUtil.errorNullProperty"), //$NON-NLS-1$
+                    descriptionClass,
+                    "getOptions()")); //$NON-NLS-1$
         }
     }
 

--- a/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/JdbcExporterDescription.java
+++ b/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/JdbcExporterDescription.java
@@ -78,7 +78,7 @@ public abstract class JdbcExporterDescription extends WindGateExporterDescriptio
      * @return options
      * @since 0.9.0
      */
-    public Collection<Option> getOptions() {
+    public Collection<? extends JdbcAttribute> getOptions() {
         return Collections.emptySet();
     }
 
@@ -90,9 +90,10 @@ public abstract class JdbcExporterDescription extends WindGateExporterDescriptio
         String table = getTableName();
         List<String> columns = getColumnNames();
         String customTruncate = getCustomTruncate();
-        Collection<Option> options = getOptions();
+        Collection<? extends JdbcAttribute> options = getOptions();
 
-        JdbcDescriptionUtil.checkCommonConfig(descriptionClass, modelType, supportClass, table, columns);
+        JdbcDescriptionUtil.checkCommonConfig(descriptionClass, modelType, supportClass, table, columns, options);
+
         if (customTruncate != null && customTruncate.trim().isEmpty()) {
             throw new IllegalStateException(MessageFormat.format(
                     Messages.getString("JdbcExporterDescription.errorEmptyStringProperty"), //$NON-NLS-1$
@@ -109,9 +110,9 @@ public abstract class JdbcExporterDescription extends WindGateExporterDescriptio
             configuration.put(JdbcProcess.CUSTOM_TRUNCATE.key(), customTruncate);
         }
         if (options != null && options.isEmpty() == false) {
-            configuration.put(
-                    JdbcProcess.OPTIONS.key(),
-                    JdbcDescriptionUtil.join(options.stream().map(Option::getSymbol).collect(Collectors.toList())));
+            configuration.put(JdbcProcess.OPTIONS.key(), JdbcDescriptionUtil.join(options.stream()
+                    .map(JdbcAttribute::getSymbol)
+                    .collect(Collectors.toList())));
         }
 
         Set<String> parameters = VariableTable.collectVariableNames(customTruncate);
@@ -123,7 +124,7 @@ public abstract class JdbcExporterDescription extends WindGateExporterDescriptio
      * @see JdbcExporterDescription#getOptions()
      * @since 0.9.0
      */
-    public enum Option {
+    public enum Option implements JdbcAttribute {
 
         /**
          * Use {@code COPY} statement instead of {@code INSERT} on postgresql.
@@ -142,11 +143,8 @@ public abstract class JdbcExporterDescription extends WindGateExporterDescriptio
             this.symbol = symbol;
         }
 
-        /**
-         * Returns the symbol.
-         * @return the symbol
-         */
-        String getSymbol() {
+        @Override
+        public String getSymbol() {
             return symbol;
         }
     }

--- a/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/JdbcImporterDescription.java
+++ b/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/JdbcImporterDescription.java
@@ -76,7 +76,7 @@ public abstract class JdbcImporterDescription extends WindGateImporterDescriptio
      * @return options
      * @since 0.9.0
      */
-    public Collection<Option> getOptions() {
+    public Collection<? extends JdbcAttribute> getOptions() {
         return Collections.emptySet();
     }
 
@@ -88,9 +88,9 @@ public abstract class JdbcImporterDescription extends WindGateImporterDescriptio
         String table = getTableName();
         List<String> columns = getColumnNames();
         String condition = getCondition();
-        Collection<Option> options = getOptions();
+        Collection<? extends JdbcAttribute> options = getOptions();
 
-        JdbcDescriptionUtil.checkCommonConfig(descriptionClass, modelType, supportClass, table, columns);
+        JdbcDescriptionUtil.checkCommonConfig(descriptionClass, modelType, supportClass, table, columns, options);
 
         Map<String, String> configuration = new HashMap<>();
         configuration.put(JdbcProcess.TABLE.key(), table);
@@ -100,9 +100,9 @@ public abstract class JdbcImporterDescription extends WindGateImporterDescriptio
             configuration.put(JdbcProcess.CONDITION.key(), condition);
         }
         if (options != null && options.isEmpty() == false) {
-            configuration.put(
-                    JdbcProcess.OPTIONS.key(),
-                    JdbcDescriptionUtil.join(options.stream().map(Option::getSymbol).collect(Collectors.toList())));
+            configuration.put(JdbcProcess.OPTIONS.key(), JdbcDescriptionUtil.join(options.stream()
+                    .map(JdbcAttribute::getSymbol)
+                    .collect(Collectors.toList())));
         }
 
         Set<String> parameters = VariableTable.collectVariableNames(condition);
@@ -114,7 +114,7 @@ public abstract class JdbcImporterDescription extends WindGateImporterDescriptio
      * @see JdbcImporterDescription#getOptions()
      * @since 0.9.0
      */
-    public enum Option {
+    public enum Option implements JdbcAttribute {
 
         /**
          * Use {@code COPY} statement instead of {@code SELECT} on postgresql.
@@ -128,11 +128,8 @@ public abstract class JdbcImporterDescription extends WindGateImporterDescriptio
             this.symbol = symbol;
         }
 
-        /**
-         * Returns the symbol.
-         * @return the symbol
-         */
-        String getSymbol() {
+        @Override
+        public String getSymbol() {
             return symbol;
         }
     }

--- a/windgate-project/asakusa-windgate-vocabulary/src/main/resources/com/asakusafw/vocabulary/windgate/messages.properties
+++ b/windgate-project/asakusa-windgate-vocabulary/src/main/resources/com/asakusafw/vocabulary/windgate/messages.properties
@@ -3,6 +3,7 @@ FsDescriptionUtil.errorFailedToInstantiate=Failed to instantiate {1}: {0}
 FsDescriptionUtil.errorIncompatibleDataType={1} must support {2}: {0}
 FsDescriptionUtil.errorNullProperty={1} must not be null: {0}
 JdbcDescriptionUtil.errorContainEmptyStringProperty={0} must not contain null or empty string
+JdbcDescriptionUtil.errorContainNullProperty={1} must not contain null: {0}
 JdbcDescriptionUtil.errorContainSeparatorProperty={0} must not contain separator characters (,)
 JdbcDescriptionUtil.errorEmptyProperty={1} must not be empty: {0}
 JdbcDescriptionUtil.errorFailedToInstantiate=Failed to instantiate {1}: {0}


### PR DESCRIPTION
## Summary

This PR improves API robustness of #671.

## Background, Problem or Goal of the patch

In #671, we introduced typed options into JDBC importer/exporter descriptions, but the options has less flexibility because it is declared as `enum`.

## Design of the fix, or a new feature

This PR introduces `JdbcAttribute` interface as a super type of the options. It may reduce DSL strictness but will help future extensions.

## Related Issue, Pull Request or Code

* #671

## Wanted reviewer

@akirakw 