### PR TITLE
Suppress WindGate exporter errors even if there are no result files.

### DIFF
--- a/windgate-project/asakusa-windgate-hadoopfs/src/main/java/com/asakusafw/windgate/hadoopfs/ssh/WindGateHadoopGet.java
+++ b/windgate-project/asakusa-windgate-hadoopfs/src/main/java/com/asakusafw/windgate/hadoopfs/ssh/WindGateHadoopGet.java
@@ -16,7 +16,6 @@
 package com.asakusafw.windgate.hadoopfs.ssh;
 
 import java.io.BufferedOutputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -215,8 +214,10 @@ public class WindGateHadoopGet extends WindGateHadoopBase {
                     }
                 }
             }
+
             if (found == false && RuntimeContext.get().isSimulation() == false) {
-                throw new FileNotFoundException(paths.toString());
+                WGLOG.info("W20001",
+                        fs.getUri(), path);
             }
         }
     }

--- a/windgate-project/asakusa-windgate-hadoopfs/src/main/java/com/asakusafw/windgate/hadoopfs/temporary/FileSystemModelInputProvider.java
+++ b/windgate-project/asakusa-windgate-hadoopfs/src/main/java/com/asakusafw/windgate/hadoopfs/temporary/FileSystemModelInputProvider.java
@@ -101,7 +101,7 @@ public class FileSystemModelInputProvider<T> implements ModelInputProvider<T> {
                         paths);
                 FileStatus[] statusList = fileSystem.globStatus(path);
                 if (statusList == null || statusList.length == 0) {
-                    WGLOG.warn("W09001",
+                    WGLOG.warn("W09002",
                             fileSystem.getUri(),
                             paths);
                     continue;

--- a/windgate-project/asakusa-windgate-hadoopfs/src/main/java/com/asakusafw/windgate/hadoopfs/temporary/FileSystemModelInputProvider.java
+++ b/windgate-project/asakusa-windgate-hadoopfs/src/main/java/com/asakusafw/windgate/hadoopfs/temporary/FileSystemModelInputProvider.java
@@ -15,9 +15,7 @@
  */
 package com.asakusafw.windgate.hadoopfs.temporary;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.text.MessageFormat;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -103,10 +101,10 @@ public class FileSystemModelInputProvider<T> implements ModelInputProvider<T> {
                         paths);
                 FileStatus[] statusList = fileSystem.globStatus(path);
                 if (statusList == null || statusList.length == 0) {
-                    throw new FileNotFoundException(MessageFormat.format(
-                            "File is not found in {1} (fs={0})",
+                    WGLOG.warn("W09001",
                             fileSystem.getUri(),
-                            paths));
+                            paths);
+                    continue;
                 }
                 for (FileStatus status : statusList) {
                     WGLOG.info("I09002",

--- a/windgate-project/asakusa-windgate-hadoopfs/src/main/resources/com/asakusafw/windgate/hadoopfs/log.properties
+++ b/windgate-project/asakusa-windgate-hadoopfs/src/main/resources/com/asakusafw/windgate/hadoopfs/log.properties
@@ -24,6 +24,7 @@ W04001=Failed to close Hadoop file system (resource={0}, process={1}, path={2})
 I09001=Resolving paths: {1} (fs={0})
 I09002=Opening intermediate file ({2} bytes): {1} (fs={0})
 W09001=Failed to close prefetched input: {1} (fs={0})
+W09002=No available files: {1} (fs={0})
 
 ## via SSH
 # Profile 10
@@ -58,6 +59,8 @@ I20002=Finalizing file list: {0}
 I20003=Resolving path: {1} (fs={0})
 I20004=Transferring file: {1} (fs={0})
 I20005=Transferred file ({2} bytes): {1} (fs={0})
+
+W20001=No available files: {1} (fs={0})
 
 E20001=Invalid arguments: {0}
 E20002=Failed to transfer files: {0}

--- a/windgate-project/asakusa-windgate-hadoopfs/src/test/java/com/asakusafw/windgate/hadoopfs/ssh/WindGateHadoopGetTest.java
+++ b/windgate-project/asakusa-windgate-hadoopfs/src/test/java/com/asakusafw/windgate/hadoopfs/ssh/WindGateHadoopGetTest.java
@@ -164,7 +164,7 @@ public class WindGateHadoopGetTest {
     }
 
     /**
-     * Attemts to get missing files.
+     * OK even if missing files.
      * @throws Exception if failed
      */
     @Test
@@ -173,7 +173,10 @@ public class WindGateHadoopGetTest {
 
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         int result = new WindGateHadoopGet(conf).execute(buffer, testing.toString());
-        assertThat(result, is(not(0)));
+        assertThat(result, is(0));
+
+        Map<String, String> contents = get(buffer.toByteArray());
+        assertThat(contents.keySet(), hasSize(0));
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR suppresses errors on WindGate exporter when the output files were not generated.

## Background, Problem or Goal of the patch

The latest implementation raises errors if input files of WindGate exporter, which generated by execution engine like MapReduce, Spark, or M3BP, even if there are no data to export (empty files are required).

## Design of the fix, or a new feature

This PR enables to raise warning logs if there are no input files without errors.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 