### PR TITLE
Avoid reusing java.sql.{Date, Timestamp} objects.

### DIFF
--- a/windgate-project/asakusa-windgate-dmdl/src/main/java/com/asakusafw/dmdl/windgate/jdbc/driver/JdbcSupportEmitter.java
+++ b/windgate-project/asakusa-windgate-dmdl/src/main/java/com/asakusafw/dmdl/windgate/jdbc/driver/JdbcSupportEmitter.java
@@ -759,32 +759,6 @@ public class JdbcSupportEmitter extends JavaDataModelDriver {
             members.add(createPrivateField(PreparedStatement.class, preparedStatement, false));
             members.add(createPrivateField(int[].class, properties, false));
             Set<BasicTypeKind> kinds = collectTypeKinds();
-            if (kinds.contains(BasicTypeKind.DATE)) {
-                members.add(f.newFieldDeclaration(
-                        null,
-                        new AttributeBuilder(f)
-                            .Private()
-                            .Final()
-                            .toAttributes(),
-                        context.resolve(java.sql.Date.class),
-                        f.newSimpleName(NAME_DATE),
-                        new TypeBuilder(f, context.resolve(java.sql.Date.class))
-                            .newObject(Models.toLiteral(f, 0L))
-                            .toExpression()));
-            }
-            if (kinds.contains(BasicTypeKind.DATETIME)) {
-                members.add(f.newFieldDeclaration(
-                        null,
-                        new AttributeBuilder(f)
-                            .Private()
-                            .Final()
-                            .toAttributes(),
-                        context.resolve(java.sql.Timestamp.class),
-                        f.newSimpleName(NAME_DATETIME),
-                        new TypeBuilder(f, context.resolve(java.sql.Timestamp.class))
-                            .newObject(Models.toLiteral(f, 0L))
-                            .toExpression()));
-            }
             if (kinds.contains(BasicTypeKind.DATE) || kinds.contains(BasicTypeKind.DATETIME)) {
                 members.add(createCalendarBuffer());
             }
@@ -1025,9 +999,7 @@ public class JdbcSupportEmitter extends JavaDataModelDriver {
             assert position != null;
             assert property != null;
             List<Statement> statements = new ArrayList<>();
-            SimpleName date = f.newSimpleName(NAME_DATE);
             SimpleName calendar = f.newSimpleName(NAME_CALENDAR);
-            SimpleName datetime = f.newSimpleName(NAME_DATETIME);
             BasicTypeKind kind = toBasicKind(property.getType());
             switch (kind) {
             case INT:
@@ -1079,13 +1051,12 @@ public class JdbcSupportEmitter extends JavaDataModelDriver {
                                 .toExpression(),
                             calendar)
                     .toStatement());
-                statements.add(new ExpressionBuilder(f, date)
-                    .method("setTime", new ExpressionBuilder(f, calendar) //$NON-NLS-1$
-                        .method("getTimeInMillis") //$NON-NLS-1$
-                        .toExpression())
-                    .toStatement());
                 statements.add(new ExpressionBuilder(f, statement)
-                    .method("setDate", position, date) //$NON-NLS-1$
+                    .method("setDate", position, new TypeBuilder(f, context.resolve(java.sql.Date.class)) //$NON-NLS-1$
+                            .newObject(new ExpressionBuilder(f, calendar)
+                                    .method("getTimeInMillis") //$NON-NLS-1$
+                                    .toExpression())
+                            .toExpression())
                     .toStatement());
                 break;
             case DATETIME:
@@ -1097,13 +1068,12 @@ public class JdbcSupportEmitter extends JavaDataModelDriver {
                                 .toExpression(),
                             calendar)
                     .toStatement());
-                statements.add(new ExpressionBuilder(f, datetime)
-                    .method("setTime", new ExpressionBuilder(f, calendar) //$NON-NLS-1$
-                        .method("getTimeInMillis") //$NON-NLS-1$
-                        .toExpression())
-                    .toStatement());
                 statements.add(new ExpressionBuilder(f, statement)
-                    .method("setTimestamp", position, datetime) //$NON-NLS-1$
+                    .method("setTimestamp", position, new TypeBuilder(f, context.resolve(java.sql.Timestamp.class)) //$NON-NLS-1$
+                            .newObject(new ExpressionBuilder(f, calendar)
+                                    .method("getTimeInMillis") //$NON-NLS-1$
+                                    .toExpression())
+                            .toExpression())
                     .toStatement());
                 break;
             default:


### PR DESCRIPTION
## Summary

This PR stops reusing `java.sql.{Date, Timestamp}` objects used in `PreparedStatement.set{Date, Timestamp}()`.

## Background, Problem or Goal of the patch

Some JDBC driver implementations may holds `Date` or `Timestamp` objects, and the result may become different if these objects were changed after `PreparedStatement.set{Date, Timestamp}()` was invoked.

## Design of the fix, or a new feature

This implementation always creates a new `java.sql.{Date, Timestamp}` object.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 