### PR TITLE
Remove unused optimization symbols in WindGate JDBC.

### DIFF
--- a/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/JdbcExporterDescription.java
+++ b/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/JdbcExporterDescription.java
@@ -127,11 +127,6 @@ public abstract class JdbcExporterDescription extends WindGateExporterDescriptio
     public enum Option implements JdbcAttribute {
 
         /**
-         * Use {@code COPY} statement instead of {@code INSERT} on postgresql.
-         */
-        POSTGRES_COPY(JdbcProcess.OptionSymbols.POSTGRES_COPY),
-
-        /**
          * Use direct path insert instead of conventional insert on Oracle.
          */
         ORACLE_DIRPATH(JdbcProcess.OptionSymbols.ORACLE_DIRPATH),

--- a/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/JdbcImporterDescription.java
+++ b/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/JdbcImporterDescription.java
@@ -115,11 +115,6 @@ public abstract class JdbcImporterDescription extends WindGateImporterDescriptio
      * @since 0.9.0
      */
     public enum Option implements JdbcAttribute {
-
-        /**
-         * Use {@code COPY} statement instead of {@code SELECT} on postgresql.
-         */
-        POSTGRES_COPY(JdbcProcess.OptionSymbols.POSTGRES_COPY),
         ;
 
         private final String symbol;


### PR DESCRIPTION
## Summary

This PR removes unused optimization symbols in WindGate JDBC.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

We just removed `POSTGRES_COPY` which will not be implemented in the next release.

## Related Issue, Pull Request or Code

* #671 

## Wanted reviewer

@akirakw 