### PR TITLE
Fix MapReduce stage planner.

### DIFF
--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/util/CoreOperatorFactory.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/util/CoreOperatorFactory.java
@@ -20,6 +20,7 @@ import static com.asakusafw.vocabulary.flow.util.PseudElementDescription.*;
 import java.lang.reflect.Type;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import com.asakusafw.vocabulary.flow.Operator;
@@ -33,7 +34,7 @@ import com.asakusafw.vocabulary.flow.graph.OperatorDescription;
 /**
  * Provides factory methods for core operators.
  * @since 0.1.0
- * @version 0.7.3
+ * @version 0.9.0
  */
 public class CoreOperatorFactory {
 
@@ -248,6 +249,24 @@ public class CoreOperatorFactory {
         }
         Type type = getPortType(input.get(0));
         return new Confluent<>(type, input);
+    }
+
+    /**
+     * Returns a new <em>confluent operator</em> instance.
+     * The resulting operator puts the data from each upstream source together and provides them as the output.
+     * @param <T> the data model type
+     * @param inputs the upstream sources
+     * @return a new instance of <em>confluent operator</em>
+     * @throws IllegalArgumentException if the parameter is {@code null}
+     * @see com.asakusafw.vocabulary.operator.Confluent
+     * @since 0.9.0
+     */
+    @SafeVarargs
+    public final <T> Confluent<T> confluent(Source<T>... inputs) {
+        if (inputs == null) {
+            throw new IllegalArgumentException("inputs must not be null"); //$NON-NLS-1$
+        }
+        return confluent(Arrays.asList(inputs));
     }
 
     /**

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/util/CoreOperators.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/util/CoreOperators.java
@@ -30,7 +30,7 @@ import com.asakusafw.vocabulary.flow.util.CoreOperatorFactory.RestructureFragmen
 /**
  * Provides factory methods for core operators.
  * @since 0.2.6
- * @version 0.7.3
+ * @version 0.9.0
  */
 public final class CoreOperators {
 
@@ -132,6 +132,21 @@ public final class CoreOperators {
      * @see CoreOperatorFactory#confluent(Iterable)
      */
     public static <T> Confluent<T> confluent(Iterable<? extends Source<T>> inputs) {
+        return FACTORY.confluent(inputs);
+    }
+
+    /**
+     * Returns a new <em>confluent operator</em> instance.
+     * The resulting operator puts the data from each upstream source together and provides them as the output.
+     * @param <T> the data model type
+     * @param inputs the upstream sources
+     * @return a new instance of <em>confluent operator</em>
+     * @throws IllegalArgumentException if the parameter is {@code null}
+     * @see CoreOperatorFactory#confluent(Iterable)
+     * @since 0.9.0
+     */
+    @SafeVarargs
+    public static <T> Confluent<T> confluent(Source<T>... inputs) {
         return FACTORY.confluent(inputs);
     }
 

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/logging/LoggingFilter.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/logging/LoggingFilter.java
@@ -58,10 +58,11 @@ public class LoggingFilter extends FlowCompilingEnvironment.Initialized implemen
         for (FlowElement element : FlowGraphUtil.collectElements(graph)) {
             if (element.getDescription().getKind() == FlowElementKind.FLOW_COMPONENT) {
                 FlowPartDescription desc = (FlowPartDescription) element.getDescription();
-                rewriteGraph(desc.getFlowGraph());
+                modified |= rewriteGraph(desc.getFlowGraph());
             } else if (isDebugLogging(element)) {
                 LOG.debug("removing debug logging operator: {}", element); //$NON-NLS-1$
                 FlowGraphUtil.skip(element);
+                modified = true;
             }
         }
         return modified;


### PR DESCRIPTION
## Summary

This PR will fix MapReduce stage planner.

## Background, Problem or Goal of the patch

In the latest implementation, Asakusa on MapReduce compiler may generate a wrong execution plan when the application includes nested `confluent` operators.

## Design of the fix, or a new feature

This reduces such nested `confluent` operators before computing stage boundaries.

This PR also includes a new overload method of `CoreOperatorFactory.confluent()` with var args.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 