### PR TITLE
Fix to show wrong line number when over MAX_INT

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/csv/CsvFormatException.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/csv/CsvFormatException.java
@@ -105,9 +105,9 @@ public class CsvFormatException extends RecordFormatException {
 
         private final String path;
 
-        private final int lineNumber;
+        private final long lineNumber;
 
-        private final int recordNumber;
+        private final long recordNumber;
 
         private final int columnNumber;
 
@@ -129,8 +129,8 @@ public class CsvFormatException extends RecordFormatException {
         public Status(
                 Reason reason,
                 String path,
-                int lineNumber,
-                int recordNumber,
+                long lineNumber,
+                long recordNumber,
                 int columnNumber,
                 String expected,
                 String actual) {
@@ -163,7 +163,7 @@ public class CsvFormatException extends RecordFormatException {
          * Returns the current line number (1-origin).
          * @return the line number
          */
-        public int getLineNumber() {
+        public long getLineNumber() {
             return lineNumber;
         }
 
@@ -171,7 +171,7 @@ public class CsvFormatException extends RecordFormatException {
          * Returns the current record number (1-origin).
          * @return the record number
          */
-        public int getRecordNumber() {
+        public long getRecordNumber() {
             return recordNumber;
         }
 

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/csv/CsvParser.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/csv/CsvParser.java
@@ -112,11 +112,11 @@ public class CsvParser implements RecordParser {
 
     private CharBuffer lineBuffer = CharBuffer.allocate(INPUT_BUFFER_SIZE);
 
-    private int currentRecordNumber = 0;
+    private long currentRecordNumber = 0;
 
-    private int currentPhysicalLine = 1;
+    private long currentPhysicalLine = 1;
 
-    private int currentPhysicalHeadLine = 1;
+    private long currentPhysicalHeadLine = 1;
 
     private CsvFormatException.Status exceptionStatus = null;
 
@@ -499,7 +499,7 @@ public class CsvParser implements RecordParser {
      * Lines are delimited with {@code CR}, {@code LF}, and {@code CRLF}.
      * @return the current line number
      */
-    public int getCurrentLineNumber() {
+    public long getCurrentLineNumber() {
         return currentPhysicalHeadLine;
     }
 
@@ -507,7 +507,7 @@ public class CsvParser implements RecordParser {
      * Returns the 1-origin record number.
      * @return the current record number.
      */
-    public int getCurrentRecordNumber() {
+    public long getCurrentRecordNumber() {
         return currentRecordNumber;
     }
 

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/csv/CsvParserTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/csv/CsvParserTest.java
@@ -775,8 +775,8 @@ public class CsvParserTest {
         StringOption value = new StringOption();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(2));
-        assertThat(parser.getCurrentRecordNumber(), is(1));
+        assertThat(parser.getCurrentLineNumber(), is(2L));
+        assertThat(parser.getCurrentRecordNumber(), is(1L));
         parser.fill(key);
         parser.fill(value);
         parser.endRecord();
@@ -801,8 +801,8 @@ public class CsvParserTest {
         StringOption value = new StringOption();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(1));
-        assertThat(parser.getCurrentRecordNumber(), is(1));
+        assertThat(parser.getCurrentLineNumber(), is(1L));
+        assertThat(parser.getCurrentRecordNumber(), is(1L));
         parser.fill(key);
         parser.fill(value);
         parser.endRecord();
@@ -810,8 +810,8 @@ public class CsvParserTest {
         assertThat(value.getAsString(), is("value"));
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(2));
-        assertThat(parser.getCurrentRecordNumber(), is(2));
+        assertThat(parser.getCurrentLineNumber(), is(2L));
+        assertThat(parser.getCurrentRecordNumber(), is(2L));
         parser.fill(key);
         parser.fill(value);
         parser.endRecord();
@@ -857,33 +857,33 @@ public class CsvParserTest {
                 "x\n" +
                 "");
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(1));
-        assertThat(parser.getCurrentRecordNumber(), is(1));
+        assertThat(parser.getCurrentLineNumber(), is(1L));
+        assertThat(parser.getCurrentRecordNumber(), is(1L));
         assertFill(parser, null);
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(2));
-        assertThat(parser.getCurrentRecordNumber(), is(2));
+        assertThat(parser.getCurrentLineNumber(), is(2L));
+        assertThat(parser.getCurrentRecordNumber(), is(2L));
         assertFill(parser, null);
         assertFill(parser, null);
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(3));
-        assertThat(parser.getCurrentRecordNumber(), is(3));
+        assertThat(parser.getCurrentLineNumber(), is(3L));
+        assertThat(parser.getCurrentRecordNumber(), is(3L));
         assertFill(parser, null);
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(4));
-        assertThat(parser.getCurrentRecordNumber(), is(4));
+        assertThat(parser.getCurrentLineNumber(), is(4L));
+        assertThat(parser.getCurrentRecordNumber(), is(4L));
         assertFill(parser, null);
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(5));
-        assertThat(parser.getCurrentRecordNumber(), is(5));
+        assertThat(parser.getCurrentLineNumber(), is(5L));
+        assertThat(parser.getCurrentRecordNumber(), is(5L));
         assertFill(parser, "x");
         parser.endRecord();
 
@@ -905,44 +905,44 @@ public class CsvParserTest {
                 "," +
                 "");
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(1));
-        assertThat(parser.getCurrentRecordNumber(), is(1));
+        assertThat(parser.getCurrentLineNumber(), is(1L));
+        assertThat(parser.getCurrentRecordNumber(), is(1L));
         assertFill(parser, null);
         assertFill(parser, null);
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(2));
-        assertThat(parser.getCurrentRecordNumber(), is(2));
+        assertThat(parser.getCurrentLineNumber(), is(2L));
+        assertThat(parser.getCurrentRecordNumber(), is(2L));
         assertFill(parser, null);
         assertFill(parser, null);
         assertFill(parser, null);
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(3));
-        assertThat(parser.getCurrentRecordNumber(), is(3));
+        assertThat(parser.getCurrentLineNumber(), is(3L));
+        assertThat(parser.getCurrentRecordNumber(), is(3L));
         assertFill(parser, null);
         assertFill(parser, null);
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(4));
-        assertThat(parser.getCurrentRecordNumber(), is(4));
+        assertThat(parser.getCurrentLineNumber(), is(4L));
+        assertThat(parser.getCurrentRecordNumber(), is(4L));
         assertFill(parser, null);
         assertFill(parser, null);
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(5));
-        assertThat(parser.getCurrentRecordNumber(), is(5));
+        assertThat(parser.getCurrentLineNumber(), is(5L));
+        assertThat(parser.getCurrentRecordNumber(), is(5L));
         assertFill(parser, null);
         assertFill(parser, "x");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(6));
-        assertThat(parser.getCurrentRecordNumber(), is(6));
+        assertThat(parser.getCurrentLineNumber(), is(6L));
+        assertThat(parser.getCurrentRecordNumber(), is(6L));
         assertFill(parser, null);
         assertFill(parser, null);
         parser.endRecord();
@@ -965,39 +965,39 @@ public class CsvParserTest {
                 "x" +
                 "");
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(1));
-        assertThat(parser.getCurrentRecordNumber(), is(1));
+        assertThat(parser.getCurrentLineNumber(), is(1L));
+        assertThat(parser.getCurrentRecordNumber(), is(1L));
         assertFill(parser, "x\"");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(2));
-        assertThat(parser.getCurrentRecordNumber(), is(2));
+        assertThat(parser.getCurrentLineNumber(), is(2L));
+        assertThat(parser.getCurrentRecordNumber(), is(2L));
         assertFill(parser, "x");
         assertFill(parser, null);
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(3));
-        assertThat(parser.getCurrentRecordNumber(), is(3));
+        assertThat(parser.getCurrentLineNumber(), is(3L));
+        assertThat(parser.getCurrentRecordNumber(), is(3L));
         assertFill(parser, "x");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(4));
-        assertThat(parser.getCurrentRecordNumber(), is(4));
+        assertThat(parser.getCurrentLineNumber(), is(4L));
+        assertThat(parser.getCurrentRecordNumber(), is(4L));
         assertFill(parser, "x");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(5));
-        assertThat(parser.getCurrentRecordNumber(), is(5));
+        assertThat(parser.getCurrentLineNumber(), is(5L));
+        assertThat(parser.getCurrentRecordNumber(), is(5L));
         assertFill(parser, "xy");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(6));
-        assertThat(parser.getCurrentRecordNumber(), is(6));
+        assertThat(parser.getCurrentLineNumber(), is(6L));
+        assertThat(parser.getCurrentRecordNumber(), is(6L));
         assertFill(parser, "x");
         parser.endRecord();
 
@@ -1018,32 +1018,32 @@ public class CsvParserTest {
                 "\"x\"\n" +
                 "\"");
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(1));
-        assertThat(parser.getCurrentRecordNumber(), is(1));
+        assertThat(parser.getCurrentLineNumber(), is(1L));
+        assertThat(parser.getCurrentRecordNumber(), is(1L));
         assertFill(parser, null);
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(2));
-        assertThat(parser.getCurrentRecordNumber(), is(2));
+        assertThat(parser.getCurrentLineNumber(), is(2L));
+        assertThat(parser.getCurrentRecordNumber(), is(2L));
         assertFill(parser, ",");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(3));
-        assertThat(parser.getCurrentRecordNumber(), is(3));
+        assertThat(parser.getCurrentLineNumber(), is(3L));
+        assertThat(parser.getCurrentRecordNumber(), is(3L));
         assertFill(parser, "\r");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(5));
-        assertThat(parser.getCurrentRecordNumber(), is(4));
+        assertThat(parser.getCurrentLineNumber(), is(5L));
+        assertThat(parser.getCurrentRecordNumber(), is(4L));
         assertFill(parser, "\n");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(7));
-        assertThat(parser.getCurrentRecordNumber(), is(5));
+        assertThat(parser.getCurrentLineNumber(), is(7L));
+        assertThat(parser.getCurrentRecordNumber(), is(5L));
         assertFill(parser, "x");
         parser.endRecord();
 
@@ -1074,39 +1074,39 @@ public class CsvParserTest {
                 "\"a\"" +
                 "");
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(1));
-        assertThat(parser.getCurrentRecordNumber(), is(1));
+        assertThat(parser.getCurrentLineNumber(), is(1L));
+        assertThat(parser.getCurrentRecordNumber(), is(1L));
         assertFill(parser, "a\"");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(2));
-        assertThat(parser.getCurrentRecordNumber(), is(2));
+        assertThat(parser.getCurrentLineNumber(), is(2L));
+        assertThat(parser.getCurrentRecordNumber(), is(2L));
         assertFill(parser, "a");
         assertFill(parser, null);
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(3));
-        assertThat(parser.getCurrentRecordNumber(), is(3));
+        assertThat(parser.getCurrentLineNumber(), is(3L));
+        assertThat(parser.getCurrentRecordNumber(), is(3L));
         assertFill(parser, "a");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(4));
-        assertThat(parser.getCurrentRecordNumber(), is(4));
+        assertThat(parser.getCurrentLineNumber(), is(4L));
+        assertThat(parser.getCurrentRecordNumber(), is(4L));
         assertFill(parser, "a");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(5));
-        assertThat(parser.getCurrentRecordNumber(), is(5));
+        assertThat(parser.getCurrentLineNumber(), is(5L));
+        assertThat(parser.getCurrentRecordNumber(), is(5L));
         assertFill(parser, "ax");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(6));
-        assertThat(parser.getCurrentRecordNumber(), is(6));
+        assertThat(parser.getCurrentLineNumber(), is(6L));
+        assertThat(parser.getCurrentRecordNumber(), is(6L));
         assertFill(parser, "a");
         parser.endRecord();
 
@@ -1129,64 +1129,64 @@ public class CsvParserTest {
                 "");
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(1));
-        assertThat(parser.getCurrentRecordNumber(), is(1));
+        assertThat(parser.getCurrentLineNumber(), is(1L));
+        assertThat(parser.getCurrentRecordNumber(), is(1L));
         assertFill(parser, null);
         parser.endRecord();
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(2));
-        assertThat(parser.getCurrentRecordNumber(), is(2));
+        assertThat(parser.getCurrentLineNumber(), is(2L));
+        assertThat(parser.getCurrentRecordNumber(), is(2L));
         assertFill(parser, "x");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(3));
-        assertThat(parser.getCurrentRecordNumber(), is(3));
+        assertThat(parser.getCurrentLineNumber(), is(3L));
+        assertThat(parser.getCurrentRecordNumber(), is(3L));
         assertFill(parser, null);
         parser.endRecord();
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(4));
-        assertThat(parser.getCurrentRecordNumber(), is(4));
+        assertThat(parser.getCurrentLineNumber(), is(4L));
+        assertThat(parser.getCurrentRecordNumber(), is(4L));
         assertFill(parser, null);
         assertFill(parser, "x");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(5));
-        assertThat(parser.getCurrentRecordNumber(), is(5));
+        assertThat(parser.getCurrentLineNumber(), is(5L));
+        assertThat(parser.getCurrentRecordNumber(), is(5L));
         assertFill(parser, null);
         parser.endRecord();
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(6));
-        assertThat(parser.getCurrentRecordNumber(), is(6));
+        assertThat(parser.getCurrentLineNumber(), is(6L));
+        assertThat(parser.getCurrentRecordNumber(), is(6L));
         assertFill(parser, null);
         parser.endRecord();
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(7));
-        assertThat(parser.getCurrentRecordNumber(), is(7));
+        assertThat(parser.getCurrentLineNumber(), is(7L));
+        assertThat(parser.getCurrentRecordNumber(), is(7L));
         assertFill(parser, "x");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(8));
-        assertThat(parser.getCurrentRecordNumber(), is(8));
+        assertThat(parser.getCurrentLineNumber(), is(8L));
+        assertThat(parser.getCurrentRecordNumber(), is(8L));
         assertFill(parser, null);
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(9));
-        assertThat(parser.getCurrentRecordNumber(), is(9));
+        assertThat(parser.getCurrentLineNumber(), is(9L));
+        assertThat(parser.getCurrentRecordNumber(), is(9L));
         assertFill(parser, null);
         parser.endRecord();
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(10));
-        assertThat(parser.getCurrentRecordNumber(), is(10));
+        assertThat(parser.getCurrentLineNumber(), is(10L));
+        assertThat(parser.getCurrentRecordNumber(), is(10L));
         assertFill(parser, "x");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(11));
-        assertThat(parser.getCurrentRecordNumber(), is(11));
+        assertThat(parser.getCurrentLineNumber(), is(11L));
+        assertThat(parser.getCurrentRecordNumber(), is(11L));
         assertFill(parser, null);
         parser.endRecord();
 
@@ -1208,32 +1208,32 @@ public class CsvParserTest {
                 "\"\r" +
                 "");
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(1));
-        assertThat(parser.getCurrentRecordNumber(), is(1));
+        assertThat(parser.getCurrentLineNumber(), is(1L));
+        assertThat(parser.getCurrentRecordNumber(), is(1L));
         assertFill(parser, "\r");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(3));
-        assertThat(parser.getCurrentRecordNumber(), is(2));
+        assertThat(parser.getCurrentLineNumber(), is(3L));
+        assertThat(parser.getCurrentRecordNumber(), is(2L));
         assertFill(parser, "\r,");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(5));
-        assertThat(parser.getCurrentRecordNumber(), is(3));
+        assertThat(parser.getCurrentLineNumber(), is(5L));
+        assertThat(parser.getCurrentRecordNumber(), is(3L));
         assertFill(parser, "\r\r");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(8));
-        assertThat(parser.getCurrentRecordNumber(), is(4));
+        assertThat(parser.getCurrentLineNumber(), is(8L));
+        assertThat(parser.getCurrentRecordNumber(), is(4L));
         assertFill(parser, "\r\n");
         parser.endRecord();
 
         assertThat(parser.next(), is(true));
-        assertThat(parser.getCurrentLineNumber(), is(10));
-        assertThat(parser.getCurrentRecordNumber(), is(5));
+        assertThat(parser.getCurrentLineNumber(), is(10L));
+        assertThat(parser.getCurrentRecordNumber(), is(5L));
         assertFill(parser, "\rx");
         parser.endRecord();
 

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/csv/driver/CsvFormatEmitter.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/csv/driver/CsvFormatEmitter.java
@@ -643,16 +643,16 @@ public class CsvFormatEmitter extends JavaDataModelDriver {
                     statements.add(new ExpressionBuilder(f, object)
                         .method(context.getValueSetterName(property),
                                 castIfInt(property.getType(), new ExpressionBuilder(f, parser)
-                            .method("getCurrentLineNumber") //$NON-NLS-1$
-                            .toExpression()))
+                                        .method("getCurrentLineNumber") //$NON-NLS-1$
+                                        .toExpression()))
                         .toStatement());
                     break;
                 case RECORD_NUMBER:
                     statements.add(new ExpressionBuilder(f, object)
                         .method(context.getValueSetterName(property),
                                 castIfInt(property.getType(), new ExpressionBuilder(f, parser)
-                            .method("getCurrentRecordNumber") //$NON-NLS-1$
-                            .toExpression()))
+                                        .method("getCurrentRecordNumber") //$NON-NLS-1$
+                                        .toExpression()))
                         .toStatement());
                     break;
                 default:

--- a/windgate-project/asakusa-windgate-dmdl/src/main/java/com/asakusafw/dmdl/windgate/csv/driver/CsvSupportEmitter.java
+++ b/windgate-project/asakusa-windgate-dmdl/src/main/java/com/asakusafw/dmdl/windgate/csv/driver/CsvSupportEmitter.java
@@ -481,16 +481,16 @@ public class CsvSupportEmitter extends JavaDataModelDriver {
                     statements.add(new ExpressionBuilder(f, object)
                         .method(context.getValueSetterName(property),
                                 castIfInt(property.getType(), new ExpressionBuilder(f, parser)
-                            .method("getCurrentLineNumber") //$NON-NLS-1$
-                            .toExpression()))
+                                        .method("getCurrentLineNumber") //$NON-NLS-1$
+                                        .toExpression()))
                         .toStatement());
                     break;
                 case RECORD_NUMBER:
                     statements.add(new ExpressionBuilder(f, object)
                         .method(context.getValueSetterName(property),
                                 castIfInt(property.getType(), new ExpressionBuilder(f, parser)
-                            .method("getCurrentRecordNumber") //$NON-NLS-1$
-                            .toExpression()))
+                                        .method("getCurrentRecordNumber") //$NON-NLS-1$
+                                        .toExpression()))
                         .toStatement());
                     break;
                 default:


### PR DESCRIPTION
## Summary
This PR fixes to output incorrect line number or record number when target number is greater than MAX_INTEGER.

## Background, Problem or Goal of the patch
A variable type of line number in `CSVParser` is int, so this variable may be cyclic when line number exceeds MAX_INTEGER.

## Design of the fix, or a new feature
This PR changes variable type of line number and record number from int to long.

## Related Issue, Pull Request or Code
N/A

## Wanted reviewer
@ashigeru 
