### PR TITLE
Move hadoop dependency in sdk artifact

### DIFF
--- a/sdk-project/asakusa-sdk-app-core/pom.xml
+++ b/sdk-project/asakusa-sdk-app-core/pom.xml
@@ -37,6 +37,10 @@
       <artifactId>asakusa-mapreduce-compiler-core</artifactId>
       <version>${asakusafw-mapreduce.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>${hadoop.artifact.id}</artifactId>
+    </dependency>
 
     <!-- Default Compiler Plug-ins -->
     <dependency>

--- a/sdk-project/asakusa-sdk-core/pom.xml
+++ b/sdk-project/asakusa-sdk-core/pom.xml
@@ -27,9 +27,5 @@
       <artifactId>asakusa-sdk-dmdl-core</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>${hadoop.artifact.id}</artifactId>
-    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
## Summary
This PR moves hadoop library dependency for sdk artifact from `asakusa-sdk-core` to `asakusa-sdk-app-core`

## Background, Problem or Goal of the patch
This improves dependency to more proper scope.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.

## Wanted reviewer
N/A.
