### PR TITLE
Introduce API stub classes into Framework API.

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/api/ApiStub.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/api/ApiStub.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.core.api;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * An Asakusa Framework API stub.
+ * @param <T> the API type
+ * @since 0.9.0
+ */
+public class ApiStub<T> {
+
+    private final T defaultImplementation;
+
+    private volatile T activeImplementation;
+
+    private int referenceCount;
+
+    /**
+     * Creates a new instance without default implementation.
+     */
+    public ApiStub() {
+        this(null);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param defaultImplementation the default implementation (nullable)
+     */
+    public ApiStub(T defaultImplementation) {
+        this.defaultImplementation = defaultImplementation;
+    }
+
+    /**
+     * Returns the current active implementation on this API stub.
+     * @return the active implementation
+     * @throws IllegalStateException if there are no available implementations
+     */
+    public T get() {
+        T impl = activeImplementation;
+        if (impl != null) {
+            return impl;
+        }
+        if (defaultImplementation != null) {
+            return defaultImplementation;
+        }
+        throw new IllegalStateException(
+                "there are no available active Asakusa Framework API implementations (internal error)"); //$NON-NLS-1$
+    }
+
+    /**
+     * Activates the given API implementation on this stub.
+     * @param implementation the target implementation
+     * @return the reference of the implementation, must be closed after the API was disposed
+     * @throws IllegalStateException if another implementation has been activated
+     */
+    public Reference<T> activate(T implementation) {
+        synchronized (this) {
+            if (activeImplementation == null) {
+                activeImplementation = implementation;
+                referenceCount = 1;
+            } else if (activeImplementation == implementation) {
+                referenceCount++;
+            } else {
+                throw new IllegalStateException(MessageFormat.format(
+                        "Asakusa Framework API has conflict implementations (internal error): {0} <=> {1}",  //$NON-NLS-1$
+                        activeImplementation, implementation));
+            }
+            return new Reference<>(this, implementation);
+        }
+    }
+
+    void release(T implementation) {
+        synchronized (this) {
+            if (activeImplementation == implementation && referenceCount > 0) {
+                if (--referenceCount == 0) {
+                    activeImplementation = null;
+                }
+            }
+        }
+    }
+
+    /**
+     * A reference of API implementation.
+     * @param <T> the API type
+     * @since 0.9.0
+     */
+    public static final class Reference<T> implements AutoCloseable {
+
+        private final ApiStub<T> owner;
+
+        private final AtomicReference<T> entity;
+
+        Reference(ApiStub<T> owner, T entity) {
+            Objects.requireNonNull(owner);
+            Objects.requireNonNull(entity);
+            this.owner = owner;
+            this.entity = new AtomicReference<>(entity);
+        }
+
+        /**
+         * Returns the entity.
+         * @return the entity, or {@code null} if the reference is not available
+         */
+        public AtomicReference<T> getEntity() {
+            return entity;
+        }
+
+        @Override
+        public void close() {
+            T impl = entity.getAndSet(null);
+            if (impl != null) {
+                owner.release(impl);
+            }
+        }
+    }
+}

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/api/BatchContextApi.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/api/BatchContextApi.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.core.api;
+
+/**
+ * The Batch Context API.
+ * @since 0.9.0
+ */
+public interface BatchContextApi {
+
+    /**
+     * Returns a value of the context variable (which includes batch arguments).
+     * @param name the target variable name
+     * @return the value of the target variable, or {@code null} if it is not defined in this context
+     * @throws IllegalArgumentException if the parameter is {@code null}
+     */
+    String get(String name);
+}

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/api/ReportApi.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/api/ReportApi.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.core.api;
+
+import com.asakusafw.runtime.core.Report.FailedException;
+
+/**
+ * The Report API.
+ * @since 0.1.0
+ */
+public interface ReportApi {
+
+    /**
+     * Reports an <em>informative</em> message.
+     * Clients should put <code>&#64;Sticky</code> annotation to the operator method that using this.
+     * @param message the message
+     * @throws FailedException if error was occurred while reporting the message
+     */
+    void info(String message);
+
+    /**
+     * Reports an <em>informative</em> message.
+     * Clients should put <code>&#64;Sticky</code> annotation to the operator method that using this.
+     * @param message the message
+     * @param throwable the optional exception object (nullable)
+     * @throws FailedException if error was occurred while reporting the message
+     * @since 0.5.1
+     */
+    void info(String message, Throwable throwable);
+
+    /**
+     * Reports a <em>warning</em> message.
+     * Clients should put <code>&#64;Sticky</code> annotation to the operator method that using this.
+     * @param message the message
+     * @throws FailedException if error was occurred while reporting the message
+     */
+    void warn(String message);
+
+    /**
+     * Reports a <em>warning</em> message.
+     * Clients should put <code>&#64;Sticky</code> annotation to the operator method that using this.
+     * @param message the message
+     * @param throwable the optional exception object (nullable)
+     * @throws FailedException if error was occurred while reporting the message
+     */
+    void warn(String message, Throwable throwable);
+
+    /**
+     * Reports an <em>error</em> message.
+     * Clients should put <code>&#64;Sticky</code> annotation to the operator method that using this.
+     * Please be careful that this method will <em>NOT</em> shutdown the running batch.
+     * To shutdown the batch, throw an exception ({@link RuntimeException}) in operator methods.
+     * @param message the message
+     * @throws FailedException if error was occurred while reporting the message
+     */
+    void error(String message);
+
+    /**
+     * Reports an <em>error</em> message.
+     * Clients should put <code>&#64;Sticky</code> annotation to the operator method that using this.
+     * Please be careful that this method will <em>NOT</em> shutdown the running batch.
+     * To shutdown the batch, throw an exception ({@link RuntimeException}) in operator methods.
+     * @param message the message
+     * @param throwable the optional exception object (nullable)
+     * @throws FailedException if error was occurred while reporting the message
+     */
+    void error(String message, Throwable throwable);
+}

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/api/package-info.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/api/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Meta API of Asakusa Framework APIs.
+ */
+package com.asakusafw.runtime.core.api;

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/legacy/LegacyBatchContext.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/legacy/LegacyBatchContext.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.core.legacy;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.asakusafw.runtime.core.BatchContext;
+import com.asakusafw.runtime.core.ResourceConfiguration;
+import com.asakusafw.runtime.core.api.BatchContextApi;
+import com.asakusafw.runtime.stage.StageConstants;
+import com.asakusafw.runtime.util.VariableTable;
+
+/**
+ * A legacy implementation of context API entry class.
+ * @since 0.9.0
+ * @see BatchContext
+ */
+public class LegacyBatchContext {
+
+    /**
+     * The API of this implementation.
+     */
+    public static final BatchContextApi API = new BatchContextApi() {
+        @Override
+        public String get(String name) {
+            return LegacyBatchContext.get(name);
+        }
+    };
+
+    static final ThreadLocal<LegacyBatchContext> CONTEXTS = ThreadLocal.withInitial(() -> {
+        throw new IllegalStateException("BatchContext is not yet initialized (internal error)");
+    });
+
+    private Map<String, String> variables = new HashMap<>();
+
+    /**
+     * Creates a new instance.
+     * @param variables variable table
+     * @throws IllegalArgumentException if the parameter is {@code null}
+     */
+    protected LegacyBatchContext(Map<String, String> variables) {
+        if (variables == null) {
+            throw new IllegalArgumentException("variables must not be null"); //$NON-NLS-1$
+        }
+        this.variables = new HashMap<>(variables);
+    }
+
+    /**
+     * Returns a value of the context variable (which includes batch arguments).
+     * @param name the target variable name
+     * @return the value of the target variable, or {@code null} if it is not defined in this context
+     * @throws IllegalArgumentException if the parameter is {@code null}
+     */
+    public static String get(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("name must not be null"); //$NON-NLS-1$
+        }
+        return CONTEXTS.get().variables.get(name);
+    }
+
+    /**
+     * Initializes {@link LegacyBatchContext}.
+     */
+    public static class Initializer implements RuntimeResource {
+
+        @Override
+        public void setup(ResourceConfiguration configuration) throws IOException, InterruptedException {
+            String arguments = configuration.get(StageConstants.PROP_ASAKUSA_BATCH_ARGS, ""); //$NON-NLS-1$
+            VariableTable variables = new VariableTable(VariableTable.RedefineStrategy.IGNORE);
+            variables.defineVariables(arguments);
+            LegacyBatchContext context = new LegacyBatchContext(variables.getVariables());
+            CONTEXTS.set(context);
+        }
+
+        @Override
+        public void cleanup(ResourceConfiguration configuration) throws IOException, InterruptedException {
+            CONTEXTS.remove();
+        }
+    }
+}

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/legacy/LegacyReport.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/legacy/LegacyReport.java
@@ -1,0 +1,206 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.core.legacy;
+
+import java.io.IOException;
+
+import com.asakusafw.runtime.core.Report;
+import com.asakusafw.runtime.core.Report.Delegate;
+import com.asakusafw.runtime.core.Report.FailedException;
+import com.asakusafw.runtime.core.Report.Level;
+import com.asakusafw.runtime.core.ResourceConfiguration;
+import com.asakusafw.runtime.core.api.ReportApi;
+
+/**
+ * A legacy implementation of Report API entry class.
+ * @since 0.9.0
+ * @see Report
+ */
+public final class LegacyReport {
+
+    /**
+     * The API of this implementation.
+     */
+    public static final ReportApi API = new ReportApi() {
+        @Override
+        public void info(String message, Throwable throwable) {
+            LegacyReport.info(message, throwable);
+        }
+        @Override
+        public void info(String message) {
+            LegacyReport.info(message);
+        }
+        @Override
+        public void warn(String message, Throwable throwable) {
+            LegacyReport.warn(message, throwable);
+        }
+        @Override
+        public void warn(String message) {
+            LegacyReport.warn(message);
+        }
+        @Override
+        public void error(String message, Throwable throwable) {
+            LegacyReport.error(message, throwable);
+        }
+        @Override
+        public void error(String message) {
+            LegacyReport.error(message);
+        }
+    };
+
+    private static final ThreadLocal<Delegate> DELEGATE = ThreadLocal.withInitial(() -> {
+        throw new FailedException("Report is not initialized (report plugin may be not registered)");
+    });
+
+    /**
+     * Sets a custom implementation for the current thread.
+     * After the implementation was set, each report API method will be redirected to the implementation.
+     * Application developers should not use this method directly.
+     * @param delegate the custom implementation, or {@code null} to unregister the implementation
+     */
+    public static void setDelegate(Delegate delegate) {
+        if (delegate == null) {
+            DELEGATE.remove();
+        } else {
+            DELEGATE.set(delegate);
+        }
+    }
+
+    /**
+     * Reports an <em>informative</em> message.
+     * Clients should put <code>&#64;Sticky</code> annotation to the operator method that using this.
+     * @param message the message
+     * @throws FailedException if error was occurred while reporting the message
+     */
+    public static void info(String message) {
+        try {
+            DELEGATE.get().report(Level.INFO, message);
+        } catch (IOException e) {
+            throw new FailedException(e);
+        }
+    }
+
+    /**
+     * Reports an <em>informative</em> message.
+     * Clients should put <code>&#64;Sticky</code> annotation to the operator method that using this.
+     * @param message the message
+     * @param throwable the optional exception object (nullable)
+     * @throws FailedException if error was occurred while reporting the message
+     */
+    public static void info(String message, Throwable throwable) {
+        try {
+            DELEGATE.get().report(Level.INFO, message, throwable);
+        } catch (IOException e) {
+            throw new FailedException(e);
+        }
+    }
+
+    /**
+     * Reports a <em>warning</em> message.
+     * Clients should put <code>&#64;Sticky</code> annotation to the operator method that using this.
+     * @param message the message
+     * @throws FailedException if error was occurred while reporting the message
+     */
+    public static void warn(String message) {
+        try {
+            DELEGATE.get().report(Level.WARN, message);
+        } catch (IOException e) {
+            throw new FailedException(e);
+        }
+    }
+
+    /**
+     * Reports a <em>warning</em> message.
+     * Clients should put <code>&#64;Sticky</code> annotation to the operator method that using this.
+     * @param message the message
+     * @param throwable the optional exception object (nullable)
+     * @throws FailedException if error was occurred while reporting the message
+     */
+    public static void warn(String message, Throwable throwable) {
+        try {
+            DELEGATE.get().report(Level.WARN, message, throwable);
+        } catch (IOException e) {
+            throw new FailedException(e);
+        }
+    }
+
+    /**
+     * Reports an <em>error</em> message.
+     * Clients should put <code>&#64;Sticky</code> annotation to the operator method that using this.
+     * Please be careful that this method will <em>NOT</em> shutdown the running batch.
+     * To shutdown the batch, throw an exception ({@link RuntimeException}) in operator methods.
+     * @param message the message
+     * @throws FailedException if error was occurred while reporting the message
+     */
+    public static void error(String message) {
+        try {
+            DELEGATE.get().report(Level.ERROR, message);
+        } catch (IOException e) {
+            throw new FailedException(e);
+        }
+    }
+
+    /**
+     * Reports an <em>error</em> message.
+     * Clients should put <code>&#64;Sticky</code> annotation to the operator method that using this.
+     * Please be careful that this method will <em>NOT</em> shutdown the running batch.
+     * To shutdown the batch, throw an exception ({@link RuntimeException}) in operator methods.
+     * @param message the message
+     * @param throwable the optional exception object (nullable)
+     * @throws FailedException if error was occurred while reporting the message
+     */
+    public static void error(String message, Throwable throwable) {
+        try {
+            DELEGATE.get().report(Level.ERROR, message, throwable);
+        } catch (IOException e) {
+            throw new FailedException(e);
+        }
+    }
+
+    /**
+     * An initializer for {@link Delegate}.
+     */
+    public static class Initializer extends RuntimeResource.DelegateRegisterer<Delegate> {
+
+        @Override
+        protected String getClassNameKey() {
+            return Report.K_DELEGATE_CLASS;
+        }
+
+        @Override
+        protected Class<? extends Delegate> getInterfaceType() {
+            return Delegate.class;
+        }
+
+        @Override
+        protected void register(Delegate delegate, ResourceConfiguration configuration) throws IOException,
+                InterruptedException {
+            delegate.setup(configuration);
+            setDelegate(delegate);
+        }
+
+        @Override
+        protected void unregister(Delegate delegate, ResourceConfiguration configuration) throws IOException,
+                InterruptedException {
+            setDelegate(null);
+            delegate.cleanup(configuration);
+        }
+    }
+
+    private LegacyReport() {
+        throw new AssertionError();
+    }
+}

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/legacy/RuntimeResource.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/legacy/RuntimeResource.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.runtime.core;
+package com.asakusafw.runtime.core.legacy;
 
 import java.io.IOException;
 import java.text.MessageFormat;
@@ -21,8 +21,11 @@ import java.text.MessageFormat;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import com.asakusafw.runtime.core.ResourceConfiguration;
+
 /**
  * Runtime resource which has resource lifecycle.
+ * @since 0.9.0
  */
 public interface RuntimeResource {
 

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/legacy/package-info.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/core/legacy/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * The legacy Asakusa Framework implementations.
+ */
+package com.asakusafw.runtime.core.legacy;

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/flow/MapperWithRuntimeResource.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/flow/MapperWithRuntimeResource.java
@@ -22,7 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.mapreduce.Mapper;
 
-import com.asakusafw.runtime.core.RuntimeResource;
+import com.asakusafw.runtime.core.legacy.RuntimeResource;
 
 /**
  * An abstract super class of a mapper with {@link RuntimeResource}s.

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/flow/ReducerWithRuntimeResource.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/flow/ReducerWithRuntimeResource.java
@@ -22,7 +22,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.mapreduce.Reducer;
 
-import com.asakusafw.runtime.core.RuntimeResource;
+import com.asakusafw.runtime.core.legacy.RuntimeResource;
 
 /**
  * An abstract super class of a reducer with {@link RuntimeResource}s.

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/flow/RuntimeResourceManager.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/flow/RuntimeResourceManager.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 
 import com.asakusafw.runtime.core.HadoopConfiguration;
-import com.asakusafw.runtime.core.RuntimeResource;
+import com.asakusafw.runtime.core.legacy.RuntimeResource;
 
 /**
  * Manages lifecycle of {@link RuntimeResource} objects.

--- a/core-project/asakusa-runtime/src/main/resources/META-INF/services/com.asakusafw.runtime.core.RuntimeResource
+++ b/core-project/asakusa-runtime/src/main/resources/META-INF/services/com.asakusafw.runtime.core.RuntimeResource
@@ -1,2 +1,0 @@
-com.asakusafw.runtime.core.BatchContext$Initializer
-com.asakusafw.runtime.core.Report$Initializer

--- a/core-project/asakusa-runtime/src/main/resources/META-INF/services/com.asakusafw.runtime.core.legacy.RuntimeResource
+++ b/core-project/asakusa-runtime/src/main/resources/META-INF/services/com.asakusafw.runtime.core.legacy.RuntimeResource
@@ -1,0 +1,2 @@
+com.asakusafw.runtime.core.legacy.LegacyBatchContext$Initializer
+com.asakusafw.runtime.core.legacy.LegacyReport$Initializer

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/core/ReportTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/core/ReportTest.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.asakusafw.runtime.core.Report.Level;
+import com.asakusafw.runtime.core.legacy.LegacyReport;
 
 /**
  * Test for {@link Report}.
@@ -39,9 +40,13 @@ public class ReportTest {
      */
     @Before
     public void setUp() throws Exception {
-        Report.setDelegate(null);
+        delegate(null);
         Mock.levels.clear();
         Mock.messages.clear();
+    }
+
+    private static void delegate(Report.Delegate delegate) {
+        LegacyReport.setDelegate(delegate);
     }
 
     /**
@@ -57,7 +62,7 @@ public class ReportTest {
      */
     @Test
     public void info() {
-        Report.setDelegate(new Mock());
+        delegate(new Mock());
         Report.info("Hello");
         assertThat(Mock.levels, is(list(Level.INFO)));
         assertThat(Mock.messages, is(list("Hello")));
@@ -68,7 +73,7 @@ public class ReportTest {
      */
     @Test(expected = Report.FailedException.class)
     public void info_error() {
-        Report.setDelegate(new Report.Delegate() {
+        delegate(new Report.Delegate() {
             @Override
             public void report(Level level, String message) throws IOException {
                 throw new IOException();
@@ -82,7 +87,7 @@ public class ReportTest {
      */
     @Test
     public void warn() {
-        Report.setDelegate(new Mock());
+        delegate(new Mock());
         Report.warn("Hello");
         assertThat(Mock.levels, is(list(Level.WARN)));
         assertThat(Mock.messages, is(list("Hello")));
@@ -93,7 +98,7 @@ public class ReportTest {
      */
     @Test(expected = Report.FailedException.class)
     public void warn_error() {
-        Report.setDelegate(new Report.Delegate() {
+        delegate(new Report.Delegate() {
             @Override
             public void report(Level level, String message) throws IOException {
                 throw new IOException();
@@ -107,7 +112,7 @@ public class ReportTest {
      */
     @Test
     public void testError() {
-        Report.setDelegate(new Mock());
+        delegate(new Mock());
         Report.error("Hello");
         assertThat(Mock.levels, is(list(Level.ERROR)));
         assertThat(Mock.messages, is(list("Hello")));
@@ -118,7 +123,7 @@ public class ReportTest {
      */
     @Test(expected = Report.FailedException.class)
     public void error_error() {
-        Report.setDelegate(new Report.Delegate() {
+        delegate(new Report.Delegate() {
             @Override
             public void report(Level level, String message) throws IOException {
                 throw new IOException();
@@ -135,7 +140,7 @@ public class ReportTest {
     public void initialize() throws Exception {
         ResourceConfiguration conf = new HadoopConfiguration();
         conf.set(Report.K_DELEGATE_CLASS, Mock.class.getName());
-        Report.Initializer init = new Report.Initializer();
+        LegacyReport.Initializer init = new LegacyReport.Initializer();
         init.setup(conf);
         Report.info("hello");
         init.cleanup(conf);

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/core/api/ApiStubTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/core/api/ApiStubTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.core.api;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * Test for {@link ApiStub}.
+ */
+public class ApiStubTest {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        ApiStub<String> stub = new ApiStub<>("DEFAULT");
+        assertThat(stub.get(), is("DEFAULT"));
+        try (ApiStub.Reference<String> ref = stub.activate("ANOTHER")) {
+            assertThat(stub.get(), is("ANOTHER"));
+        }
+        assertThat(stub.get(), is("DEFAULT"));
+    }
+
+    /**
+     * nested.
+     */
+    @Test
+    public void nested() {
+        ApiStub<String> stub = new ApiStub<>("DEFAULT");
+        assertThat(stub.get(), is("DEFAULT"));
+        try (ApiStub.Reference<String> r0 = stub.activate("ANOTHER")) {
+            assertThat(stub.get(), is("ANOTHER"));
+            try (ApiStub.Reference<String> r1 = stub.activate("ANOTHER")) {
+                assertThat(stub.get(), is("ANOTHER"));
+            }
+            assertThat(stub.get(), is("ANOTHER"));
+        }
+        assertThat(stub.get(), is("DEFAULT"));
+    }
+
+    /**
+     * over close.
+     */
+    @Test
+    public void over_close() {
+        ApiStub<String> stub = new ApiStub<>("DEFAULT");
+        assertThat(stub.get(), is("DEFAULT"));
+        try (ApiStub.Reference<String> r0 = stub.activate("ANOTHER");
+                ApiStub.Reference<String> r1 = stub.activate("ANOTHER")) {
+            r1.close();
+            assertThat(stub.get(), is("ANOTHER"));
+            r1.close();
+            assertThat(stub.get(), is("ANOTHER"));
+        }
+        assertThat(stub.get(), is("DEFAULT"));
+    }
+
+    /**
+     * w/o defaults.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void no_defaults() {
+        ApiStub<String> stub = new ApiStub<>();
+        stub.get();
+    }
+
+    /**
+     * conflict implementations.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void conflict() {
+        ApiStub<String> stub = new ApiStub<>("DEFAULT");
+        try (ApiStub.Reference<String> r0 = stub.activate("ANOTHER")) {
+            try (ApiStub.Reference<String> r1 = stub.activate("CONFLICT")) {
+                fail();
+            }
+        }
+    }
+}

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/flow/RuntimeResourceManagerTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/flow/RuntimeResourceManagerTest.java
@@ -26,9 +26,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;
 
-import com.asakusafw.runtime.core.Report;
 import com.asakusafw.runtime.core.ResourceConfiguration;
-import com.asakusafw.runtime.core.RuntimeResource;
+import com.asakusafw.runtime.core.legacy.LegacyReport;
+import com.asakusafw.runtime.core.legacy.RuntimeResource;
 
 /**
  * {@link RuntimeResourceManager}.
@@ -47,7 +47,7 @@ public class RuntimeResourceManagerTest {
 
         boolean found = false;
         for (RuntimeResource resource : loaded) {
-            if (resource instanceof Report.Initializer) {
+            if (resource instanceof LegacyReport.Initializer) {
                 found = true;
                 break;
             }

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/report/CommonsLoggingReportTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/report/CommonsLoggingReportTest.java
@@ -20,6 +20,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.asakusafw.runtime.core.Report;
+import com.asakusafw.runtime.core.legacy.LegacyReport;
 
 /**
  * Test for {@link CommonsLoggingReport}.
@@ -32,7 +33,7 @@ public class CommonsLoggingReportTest {
      */
     @Before
     public void setUp() throws Exception {
-        Report.setDelegate(new CommonsLoggingReport());
+        LegacyReport.setDelegate(new CommonsLoggingReport());
     }
 
     /**
@@ -41,7 +42,7 @@ public class CommonsLoggingReportTest {
      */
     @After
     public void tearDown() throws Exception {
-        Report.setDelegate(null);
+        LegacyReport.setDelegate(null);
     }
 
     /**

--- a/mapreduce/compiler/core/src/test/java/com/asakusafw/compiler/flow/processor/LoggingFlowProcessorTest.java
+++ b/mapreduce/compiler/core/src/test/java/com/asakusafw/compiler/flow/processor/LoggingFlowProcessorTest.java
@@ -32,6 +32,7 @@ import com.asakusafw.compiler.flow.stage.StageModel.Fragment;
 import com.asakusafw.compiler.flow.testing.model.Ex1;
 import com.asakusafw.runtime.core.Report;
 import com.asakusafw.runtime.core.Result;
+import com.asakusafw.runtime.core.legacy.LegacyReport;
 import com.asakusafw.runtime.testing.MockResult;
 import com.asakusafw.utils.java.model.syntax.Name;
 
@@ -48,7 +49,7 @@ public class LoggingFlowProcessorTest extends JobflowCompilerTestRoot {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        Report.setDelegate(new Report.Default());
+        LegacyReport.setDelegate(new Report.Default());
     }
 
     /**
@@ -58,7 +59,7 @@ public class LoggingFlowProcessorTest extends JobflowCompilerTestRoot {
     @Override
     @After
     public void tearDown() throws Exception {
-        Report.setDelegate(null);
+        LegacyReport.setDelegate(null);
         super.tearDown();
     }
 

--- a/sandbox-project/asakusa-directio-runtime-ext/src/main/java/com/asakusafw/runtime/directio/api/DirectIo.java
+++ b/sandbox-project/asakusa-directio-runtime-ext/src/main/java/com/asakusafw/runtime/directio/api/DirectIo.java
@@ -17,21 +17,21 @@ package com.asakusafw.runtime.directio.api;
 
 import java.io.IOException;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.conf.Configured;
-
-import com.asakusafw.runtime.core.ResourceConfiguration;
-import com.asakusafw.runtime.core.RuntimeResource;
+import com.asakusafw.runtime.core.api.ApiStub;
 import com.asakusafw.runtime.core.util.Shared;
 import com.asakusafw.runtime.directio.DataFormat;
+import com.asakusafw.runtime.directio.api.legacy.LegacyDirectIo;
 import com.asakusafw.runtime.io.ModelInput;
 
 /**
  * A framework API for accessing Direct I/O.
  * @see Shared
  * @since 0.7.3
+ * @version 0.9.0
  */
 public final class DirectIo {
+
+    private static final ApiStub<DirectIoApi> STUB = new ApiStub<>(LegacyDirectIo.API);
 
     static final ThreadLocal<DirectIoDelegate> DELEGATE = ThreadLocal.withInitial(() -> {
         throw new IllegalStateException("Direct I/O API is not yet initialized");
@@ -80,31 +80,16 @@ try (ModelInput&lt;Hoge&gt; input = DirectIo.open(...)) {
             Class<? extends DataFormat<T>> formatClass,
             String basePath,
             String resourcePattern) throws IOException {
-        return DELEGATE.get().open(formatClass, basePath, resourcePattern);
-    }
-
-    static void set(Configuration configuration) {
-        DELEGATE.set(new DirectIoDelegate(configuration));
-    }
-
-    static void clear() {
-        DELEGATE.remove();
+        return STUB.get().open(formatClass, basePath, resourcePattern);
     }
 
     /**
-     * Initializes {@link DirectIo}.
-     * @since 0.7.3
+     * Returns the API stub.
+     * Application developer must not use this directly.
+     * @return the API stub
+     * @since 0.9.0
      */
-    public static final class Initializer extends Configured implements RuntimeResource {
-
-        @Override
-        public void setup(ResourceConfiguration configuration) {
-            DirectIo.set(getConf());
-        }
-
-        @Override
-        public void cleanup(ResourceConfiguration configuration) {
-            DirectIo.clear();
-        }
+    public static ApiStub<DirectIoApi> getStub() {
+        return STUB;
     }
 }

--- a/sandbox-project/asakusa-directio-runtime-ext/src/main/java/com/asakusafw/runtime/directio/api/DirectIoApi.java
+++ b/sandbox-project/asakusa-directio-runtime-ext/src/main/java/com/asakusafw/runtime/directio/api/DirectIoApi.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.directio.api;
+
+import java.io.IOException;
+
+import com.asakusafw.runtime.directio.DataFormat;
+import com.asakusafw.runtime.io.ModelInput;
+
+/**
+ * The Direct I/O API.
+ * @since 0.9.0
+ */
+public interface DirectIoApi {
+
+    /**
+     * Returns data model objects from Direct I/O data sources.
+     * @param <T> the data model object type
+     * @param formatClass the Direct I/O data format class
+     * @param basePath the base path (must not contain variables)
+     * @param resourcePattern the resource pattern (must not contain variables)
+     * @return the data model objects
+     * @throws IOException if failed to open data model objects on the data source
+     */
+    <T> ModelInput<T> open(
+            Class<? extends DataFormat<T>> formatClass,
+            String basePath, String resourcePattern) throws IOException;
+}

--- a/sandbox-project/asakusa-directio-runtime-ext/src/main/java/com/asakusafw/runtime/directio/api/DirectIoDelegate.java
+++ b/sandbox-project/asakusa-directio-runtime-ext/src/main/java/com/asakusafw/runtime/directio/api/DirectIoDelegate.java
@@ -39,8 +39,10 @@ import com.asakusafw.runtime.io.ModelInput;
 
 /**
  * Delegating object for {@link DirectIo}.
+ * @since 0.7.3
+ * @version 0.9.0
  */
-public class DirectIoDelegate extends Configured {
+public class DirectIoDelegate extends Configured implements DirectIoApi {
 
     private final AtomicReference<DirectDataSourceRepository> repository = new AtomicReference<>();
 
@@ -52,15 +54,7 @@ public class DirectIoDelegate extends Configured {
         super(configuration);
     }
 
-    /**
-     * Returns data model objects from Direct I/O data sources.
-     * @param <T> the data model object type
-     * @param formatClass the Direct I/O data format class
-     * @param basePath the base path (must not contain variables)
-     * @param resourcePattern the resource pattern (must not contain variables)
-     * @return the data model objects
-     * @throws IOException if failed to open data model objects on the data source
-     */
+    @Override
     public <T> ModelInput<T> open(
             Class<? extends DataFormat<T>> formatClass,
             String basePath,

--- a/sandbox-project/asakusa-directio-runtime-ext/src/main/java/com/asakusafw/runtime/directio/api/legacy/LegacyDirectIo.java
+++ b/sandbox-project/asakusa-directio-runtime-ext/src/main/java/com/asakusafw/runtime/directio/api/legacy/LegacyDirectIo.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.directio.api.legacy;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.conf.Configured;
+
+import com.asakusafw.runtime.core.ResourceConfiguration;
+import com.asakusafw.runtime.core.legacy.RuntimeResource;
+import com.asakusafw.runtime.directio.DataFormat;
+import com.asakusafw.runtime.directio.api.DirectIo;
+import com.asakusafw.runtime.directio.api.DirectIoApi;
+import com.asakusafw.runtime.directio.api.DirectIoDelegate;
+import com.asakusafw.runtime.io.ModelInput;
+
+/**
+ * A legacy implementation of Direct I/O API entry class.
+ * @since 0.9.0
+ */
+public final class LegacyDirectIo {
+
+    /**
+     * The API of this implementation.
+     */
+    public static final DirectIoApi API = new DirectIoApi() {
+        @Override
+        public <T> ModelInput<T> open(
+                Class<? extends DataFormat<T>> formatClass,
+                String basePath, String resourcePattern) throws IOException {
+            return LegacyDirectIo.open(formatClass, basePath, resourcePattern);
+        }
+    };
+
+    static final ThreadLocal<DirectIoDelegate> DELEGATE = ThreadLocal.withInitial(() -> {
+        throw new IllegalStateException("Direct I/O API is not yet initialized");
+    });
+
+    private LegacyDirectIo() {
+        return;
+    }
+
+    /**
+     * Returns data model objects from Direct I/O data sources.
+     * @param <T> the data model object type
+     * @param formatClass the Direct I/O data format class
+     * @param basePath the base path (must not contain variables)
+     * @param resourcePattern the resource pattern (must not contain variables)
+     * @return the data model objects
+     * @throws IOException if failed to open data model objects on the data source
+     * @see DirectIo#open(Class, String, String)
+     */
+    public static <T> ModelInput<T> open(
+            Class<? extends DataFormat<T>> formatClass,
+            String basePath,
+            String resourcePattern) throws IOException {
+        return DELEGATE.get().open(formatClass, basePath, resourcePattern);
+    }
+
+    static void set(Configuration configuration) {
+        DELEGATE.set(new DirectIoDelegate(configuration));
+    }
+
+    static void clear() {
+        DELEGATE.remove();
+    }
+
+    /**
+     * Initializes {@link LegacyDirectIo}.
+     * @since 0.9.0
+     */
+    public static final class Initializer extends Configured implements RuntimeResource {
+
+        @Override
+        public void setup(ResourceConfiguration configuration) {
+            LegacyDirectIo.set(getConf());
+        }
+
+        @Override
+        public void cleanup(ResourceConfiguration configuration) {
+            LegacyDirectIo.clear();
+        }
+    }
+}

--- a/sandbox-project/asakusa-directio-runtime-ext/src/main/java/com/asakusafw/runtime/directio/api/legacy/package-info.java
+++ b/sandbox-project/asakusa-directio-runtime-ext/src/main/java/com/asakusafw/runtime/directio/api/legacy/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * The legacy Direct I/O implementations.
+ */
+package com.asakusafw.runtime.directio.api.legacy;

--- a/sandbox-project/asakusa-directio-runtime-ext/src/main/resources/META-INF/services/com.asakusafw.runtime.core.RuntimeResource
+++ b/sandbox-project/asakusa-directio-runtime-ext/src/main/resources/META-INF/services/com.asakusafw.runtime.core.RuntimeResource
@@ -1,1 +1,0 @@
-com.asakusafw.runtime.directio.api.DirectIo$Initializer

--- a/sandbox-project/asakusa-directio-runtime-ext/src/main/resources/META-INF/services/com.asakusafw.runtime.core.legacy.RuntimeResource
+++ b/sandbox-project/asakusa-directio-runtime-ext/src/main/resources/META-INF/services/com.asakusafw.runtime.core.legacy.RuntimeResource
@@ -1,0 +1,1 @@
+com.asakusafw.runtime.directio.api.legacy.LegacyDirectIo$Initializer


### PR DESCRIPTION
## Summary

This PR introduces API stub classes into Asakusa Framework API entries.

## Background, Problem or Goal of the patch

In the latest implementation, each Framework API class has concrete implementation for MapReduce environment. This makes using framework API in other platforms such as Spark more difficult.

## Design of the fix, or a new feature

This introduces `API Stub` feature, which enables to replace framework API implementation with another one for the target platform. Note that, we have worked it out by replacing classes in the user application (a.k.a. API redirector).

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 