### PR TITLE
Remove mapreduce related dependencies from SDK artifacts.

### DIFF
--- a/sdk-project/asakusa-sdk-app-core/pom.xml
+++ b/sdk-project/asakusa-sdk-app-core/pom.xml
@@ -28,30 +28,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.asakusafw.mapreduce.compiler</groupId>
-      <artifactId>asakusa-mapreduce-compiler-cli</artifactId>
-      <version>${asakusafw-mapreduce.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.asakusafw.mapreduce.compiler</groupId>
-      <artifactId>asakusa-mapreduce-compiler-core</artifactId>
-      <version>${asakusafw-mapreduce.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>${hadoop.artifact.id}</artifactId>
-    </dependency>
-
-    <!-- Default Compiler Plug-ins -->
-    <dependency>
-      <groupId>com.asakusafw.mapreduce.compiler</groupId>
-      <artifactId>asakusa-mapreduce-compiler-extension-inspection</artifactId>
-      <version>${asakusafw-mapreduce.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.asakusafw.mapreduce.compiler</groupId>
-      <artifactId>asakusa-mapreduce-compiler-extension-yaess</artifactId>
-      <version>${asakusafw-mapreduce.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/sdk-project/asakusa-sdk-app-directio/pom.xml
+++ b/sdk-project/asakusa-sdk-app-directio/pom.xml
@@ -17,10 +17,5 @@
       <artifactId>asakusa-directio-vocabulary</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.asakusafw.mapreduce.compiler</groupId>
-      <artifactId>asakusa-mapreduce-compiler-extension-directio</artifactId>
-      <version>${asakusafw-mapreduce.version}</version>
-    </dependency>
   </dependencies>
 </project>

--- a/sdk-project/asakusa-sdk-app-hive/pom.xml
+++ b/sdk-project/asakusa-sdk-app-hive/pom.xml
@@ -13,9 +13,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.asakusafw.mapreduce.compiler</groupId>
-      <artifactId>asakusa-mapreduce-compiler-extension-hive</artifactId>
-      <version>${asakusafw-mapreduce.version}</version>
+      <groupId>com.asakusafw</groupId>
+      <artifactId>asakusa-hive-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/sdk-project/asakusa-sdk-app-windgate/pom.xml
+++ b/sdk-project/asakusa-sdk-app-windgate/pom.xml
@@ -17,10 +17,5 @@
       <artifactId>asakusa-windgate-vocabulary</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.asakusafw.mapreduce.compiler</groupId>
-      <artifactId>asakusa-mapreduce-compiler-extension-windgate</artifactId>
-      <version>${asakusafw-mapreduce.version}</version>
-    </dependency>
   </dependencies>
 </project>

--- a/sdk-project/asakusa-sdk-test-core/pom.xml
+++ b/sdk-project/asakusa-sdk-test-core/pom.xml
@@ -22,10 +22,5 @@
       <artifactId>asakusa-test-driver</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>com.asakusafw.mapreduce.compiler</groupId>
-      <artifactId>asakusa-mapreduce-compiler-test-adapter</artifactId>
-      <version>${asakusafw-mapreduce.version}</version>
-    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
## Summary

This PR removes Asakusa on MapReduce related dependencies from SDK artifacts.

## Background, Problem or Goal of the patch

In the latest implementation, the SDK artifacts contain Asakusa on MapReduce related dependencies (e.g. Asakusa DSL compiler for MapReduce), even if Asakusa on MapReduce features is not required.

## Design of the fix, or a new feature

This just removes `com.asakusafw.mapreduce.compiler` group dependencies from the artifacts. To enable individual features, please use `asakusafw.sdk.*` convention which introduced in asakusafw/asakusafw-sdk#109.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-sdk#109

## Wanted reviewer

@akirakw 