### PR TITLE
Fix operator DSL compiler for some operators.

### DIFF
--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/ConvertOperatorDriver.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/ConvertOperatorDriver.java
@@ -45,14 +45,7 @@ public class ConvertOperatorDriver implements OperatorDriver {
         if (dsl.method().modifiers().contains(Modifier.ABSTRACT)) {
             dsl.method().error(Messages.getString("ConvertOperatorDriver.errorAbstract")); //$NON-NLS-1$
         }
-        if (dsl.result().type().isDataModel()) {
-            ElementRef result = dsl.result();
-            dsl.addOutput(
-                    result.document(),
-                    dsl.annotation().string(CONVERTED_PORT),
-                    result.type().mirror(),
-                    result.reference());
-        } else {
+        if (dsl.result().type().isDataModel() == false) {
             dsl.method().error(Messages.getString("ConvertOperatorDriver.errorReturnNotDataModelType")); //$NON-NLS-1$
         }
         for (ElementRef p : dsl.parameters()) {
@@ -74,6 +67,12 @@ public class ConvertOperatorDriver implements OperatorDriver {
                 p.error(Messages.getString("ConvertOperatorDriver.errorParameterUnsupportedType")); //$NON-NLS-1$
             }
         }
+        ElementRef result = dsl.result();
+        dsl.addOutput(
+                result.document(),
+                dsl.annotation().string(CONVERTED_PORT),
+                result.type().mirror(),
+                result.reference());
         return dsl.toDescription();
     }
 }

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/DslBuilder.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/DslBuilder.java
@@ -56,7 +56,6 @@ import com.asakusafw.operator.model.OperatorDescription.Node;
 import com.asakusafw.operator.model.OperatorDescription.ParameterReference;
 import com.asakusafw.operator.model.OperatorDescription.Reference;
 import com.asakusafw.operator.model.OperatorDescription.Reference.Kind;
-import com.asakusafw.operator.model.OperatorDescription.SpecialReference;
 import com.asakusafw.operator.util.AnnotationHelper;
 
 /**
@@ -469,12 +468,20 @@ final class DslBuilder {
 
         final Element element;
 
+        private final Document document;
+
         private final Reference reference;
 
         GeneralElementRef(Element element, Reference reference) {
+            this(element, Document.reference(reference), reference);
+        }
+
+        GeneralElementRef(Element element, Document document, Reference reference) {
             assert element != null;
+            assert document != null;
             assert reference != null;
             this.element = element;
+            this.document = document;
             this.reference = reference;
         }
 
@@ -495,7 +502,7 @@ final class DslBuilder {
 
         @Override
         public Document document() {
-            return Document.reference(reference);
+            return document;
         }
 
         @Override
@@ -705,8 +712,9 @@ final class DslBuilder {
             List<ElementRef> results = new ArrayList<>();
             for (VariableElement var : ElementFilter.fieldsIn(type.getEnclosedElements())) {
                 if (var.getKind() == ElementKind.ENUM_CONSTANT) {
-                    SpecialReference reference = Reference.special(var.getSimpleName().toString());
-                    results.add(new GeneralElementRef(var, reference));
+                    Document document = Document.external(var);
+                    Reference reference = Reference.special(var.getSimpleName().toString());
+                    results.add(new GeneralElementRef(var, document, reference));
                 }
             }
             return results;

--- a/operator/builtin/src/test/java/com/asakusafw/operator/builtin/ConvertOperatorDriverTest.java
+++ b/operator/builtin/src/test/java/com/asakusafw/operator/builtin/ConvertOperatorDriverTest.java
@@ -68,17 +68,17 @@ public class ConvertOperatorDriverTest extends OperatorDriverTestRoot {
                 assertThat(input.getName(), is("model"));
                 assertThat(input.getType(), is(sameType("com.example.Model")));
 
-                Map<String, Node> outputs = toMap(description.getOutputs());
-
-                Node out = outputs.get(defaultName(Convert.class, "convertedPort"));
-                assertThat(out, is(notNullValue()));
-                assertThat(out.getType(), is(sameType("com.example.Proceeded")));
-                assertThat(out.getReference(), is(Reference.returns()));
-
-                Node orig = outputs.get(defaultName(Convert.class, "originalPort"));
+                Node orig = description.getOutputs().get(Convert.ID_OUTPUT_ORIGINAL);
                 assertThat(orig, is(notNullValue()));
+                assertThat(orig.getName(), is(defaultName(Convert.class, "originalPort")));
                 assertThat(orig.getType(), is(sameType("com.example.Model")));
                 assertThat(orig.getReference(), is((Reference) Reference.parameter(0)));
+
+                Node out = description.getOutputs().get(Convert.ID_OUTPUT_CONVERTED);
+                assertThat(out, is(notNullValue()));
+                assertThat(out.getName(), is(defaultName(Convert.class, "convertedPort")));
+                assertThat(out.getType(), is(sameType("com.example.Proceeded")));
+                assertThat(out.getReference(), is(Reference.returns()));
             }
         });
     }
@@ -102,15 +102,15 @@ public class ConvertOperatorDriverTest extends OperatorDriverTestRoot {
 
                 Map<String, Node> outputs = toMap(description.getOutputs());
 
-                Node out = outputs.get(defaultName(Convert.class, "convertedPort"));
-                assertThat(out, is(notNullValue()));
-                assertThat(out.getType(), is(sameType("com.example.Proceeded")));
-                assertThat(out.getReference(), is(Reference.returns()));
-
                 Node orig = outputs.get(defaultName(Convert.class, "originalPort"));
                 assertThat(orig, is(notNullValue()));
                 assertThat(orig.getType(), is(sameType("com.example.Model")));
                 assertThat(orig.getReference(), is((Reference) Reference.parameter(0)));
+
+                Node out = outputs.get(defaultName(Convert.class, "convertedPort"));
+                assertThat(out, is(notNullValue()));
+                assertThat(out.getType(), is(sameType("com.example.Proceeded")));
+                assertThat(out.getReference(), is(Reference.returns()));
 
                 Map<String, Node> arguments = toMap(description.getArguments());
                 assertThat(arguments.get("stringArg"), is(notNullValue()));

--- a/operator/core/src/main/java/com/asakusafw/operator/CompileEnvironment.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/CompileEnvironment.java
@@ -36,6 +36,7 @@ import javax.lang.model.type.TypeMirror;
 
 import com.asakusafw.operator.description.ClassDescription;
 import com.asakusafw.operator.model.DataModelMirror;
+import com.asakusafw.operator.model.JavaName;
 import com.asakusafw.operator.util.DescriptionHelper;
 import com.asakusafw.operator.util.Logger;
 import com.asakusafw.utils.java.jsr269.bridge.Jsr269;
@@ -64,6 +65,8 @@ public class CompileEnvironment {
     private volatile boolean flowpartExternalIo = false;
 
     private volatile boolean forceGenerateImplementation = false;
+
+    private volatile boolean forceNormalizeMemberName = true;
 
     private volatile boolean strictOperatorParameterOrder = false;
 
@@ -157,6 +160,7 @@ public class CompileEnvironment {
             .withFlowpartExternalIo(set.contains(Support.FLOWPART_EXTERNAL_IO))
             .withForceRegenerateResources(set.contains(Support.FORCE_REGENERATE_RESOURCES))
             .withForceGenerateImplementation(set.contains(Support.FORCE_GENERATE_IMPLEMENTATION))
+            .withForceNormalizeMemberName(set.contains(Support.FORCE_NORMALIZE_MEMBER_NAME))
             .withStrictOperatorParameterOrder(set.contains(Support.STRICT_PARAMETER_ORDER));
     }
 
@@ -295,6 +299,20 @@ public class CompileEnvironment {
     }
 
     /**
+     * Returns the normalized member name.
+     * @param token the original token
+     * @return the normalized name for members
+     */
+    public String getMemberName(String token) {
+        Objects.requireNonNull(token);
+        if (forceNormalizeMemberName) {
+            return JavaName.of(token).toMemberName();
+        } else {
+            return token;
+        }
+    }
+
+    /**
      * Sets the target resources is generated.
      * @param key the target resource key
      */
@@ -407,6 +425,24 @@ public class CompileEnvironment {
     }
 
     /**
+     * Returns whether or not the member names must be normalized.
+     * @return {@code true} is normalized, otherwise {@code false}
+     */
+    public boolean isForceNormalizeMemberName() {
+        return forceNormalizeMemberName;
+    }
+
+    /**
+     * Sets whether or not the member names must be normalized.
+     * @param newValue {@code true} is normalized, otherwise {@code false}
+     * @return the new value
+     */
+    public CompileEnvironment withForceNormalizeMemberName(boolean newValue) {
+        this.forceNormalizeMemberName = newValue;
+        return this;
+    }
+
+    /**
      * Represents kind of supported features in {@link CompileEnvironment}.
      */
     public enum Support {
@@ -440,6 +476,11 @@ public class CompileEnvironment {
          * Always generate implementation classes.
          */
         FORCE_GENERATE_IMPLEMENTATION,
+
+        /**
+         * Always uses the normalized member name for operator factory methods.
+         */
+        FORCE_NORMALIZE_MEMBER_NAME,
 
         /**
          * Supports external I/O ports in flow parts.

--- a/operator/core/src/main/java/com/asakusafw/operator/method/OperatorAnnotationProcessor.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/method/OperatorAnnotationProcessor.java
@@ -53,6 +53,7 @@ public class OperatorAnnotationProcessor extends AbstractOperatorAnnotationProce
                 CompileEnvironment.Support.OPERATOR_DRIVER,
                 CompileEnvironment.Support.FAIL_ON_WARN,
                 CompileEnvironment.Support.FORCE_GENERATE_IMPLEMENTATION,
+                CompileEnvironment.Support.FORCE_NORMALIZE_MEMBER_NAME,
                 CompileEnvironment.Support.STRICT_PARAMETER_ORDER);
     }
 

--- a/operator/core/src/main/java/com/asakusafw/operator/method/OperatorFactoryEmitter.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/method/OperatorFactoryEmitter.java
@@ -290,7 +290,7 @@ public class OperatorFactoryEmitter {
                         .toAttributes(),
                     ElementHelper.toTypeParameters(environment, element.getDeclaration().getTypeParameters(), imports),
                     nodeType,
-                    f.newSimpleName(element.getDeclaration().getSimpleName().toString()),
+                    f.newSimpleName(environment.getMemberName(element.getDeclaration().getSimpleName().toString())),
                     ElementHelper.toParameters(environment, element, imports),
                     0,
                     Collections.emptyList(),

--- a/operator/core/src/main/java/com/asakusafw/operator/method/OperatorImplementationEmitter.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/method/OperatorImplementationEmitter.java
@@ -159,7 +159,6 @@ public class OperatorImplementationEmitter {
                     new AttributeBuilder(f)
                         .annotation(DescriptionHelper.resolveAnnotation(imports, Constants.getGenetedAnnotation()))
                         .Public()
-                        .Final()
                         .toAttributes(),
                     className,
                     imports.resolve(converter.convert(superClass)),

--- a/operator/core/src/main/java/com/asakusafw/operator/model/OperatorDescription.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/model/OperatorDescription.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeMirror;
 
@@ -421,6 +422,16 @@ public class OperatorDescription {
         }
 
         /**
+         * Creates a new instance.
+         * @param element the target element
+         * @return the created instance
+         * @throws IllegalArgumentException if some parameters were {@code null}
+         */
+        public static ExternalDocument external(Element element) {
+            return new ExternalDocument(element);
+        }
+
+        /**
          * Returns the kind of this document.
          * @return the kind
          */
@@ -440,6 +451,11 @@ public class OperatorDescription {
              * Reference to other document.
              */
             REFERENCE,
+
+            /**
+             * The external element.
+             */
+            EXTERNAL,
         }
     }
 
@@ -499,6 +515,35 @@ public class OperatorDescription {
          */
         public Reference getReference() {
             return reference;
+        }
+    }
+
+    /**
+     * Represents a document provided by an external element.
+     */
+    public static class ExternalDocument extends Document {
+
+        private final Element element;
+
+        /**
+         * Creates a new instance.
+         * @param element the external element
+         */
+        public ExternalDocument(Element element) {
+            this.element = Objects.requireNonNull(element);
+        }
+
+        @Override
+        public Kind getKind() {
+            return Kind.EXTERNAL;
+        }
+
+        /**
+         * Returns the element.
+         * @return the element
+         */
+        public Element getElement() {
+            return element;
         }
     }
 

--- a/operator/core/src/test/resources/com/asakusafw/operator/method/OperatorFactoryEmitterTest.files/com/example/WithVariable.java.txt
+++ b/operator/core/src/test/resources/com/asakusafw/operator/method/OperatorFactoryEmitterTest.files/com/example/WithVariable.java.txt
@@ -1,0 +1,11 @@
+package com.example;
+
+public abstract class WithVariable {
+
+    /**OK*/
+    public static final String VAR = "OK";
+
+    @Mock
+    public void method() {
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes bug on operator DSL compiler (`./operator`).

## Background, Problem or Goal of the patch

The compiler works wrong if the application contains any of the following operators:
* `@Convert` -  had generated operators with wrong output port order.
* `@Branch` and `@MasterBranch` - had attempted to access to unsupported javadoc comment references  (and crashed).

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 