### PR TITLE
Support `*Tester.configure()` in command tasks.

### DIFF
--- a/testing-project/asakusa-test-compiler/src/main/java/com/asakusafw/testdriver/compiler/CommandTaskMirror.java
+++ b/testing-project/asakusa-test-compiler/src/main/java/com/asakusafw/testdriver/compiler/CommandTaskMirror.java
@@ -16,10 +16,12 @@
 package com.asakusafw.testdriver.compiler;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents a command task.
  * @since 0.8.0
+ * @version 0.9.0
  */
 public interface CommandTaskMirror extends TaskMirror {
 
@@ -38,6 +40,17 @@ public interface CommandTaskMirror extends TaskMirror {
     /**
      * Returns the command arguments.
      * @return the command arguments
+     * @deprecated Use {@link #getArguments()} instead
      */
+    @Deprecated
     List<CommandToken> getArguments();
+
+    /**
+     * Returns the command arguments.
+     * @param extraConfigurations the extra configurations (treated as Hadoop configurations)
+     * @return the command arguments
+     */
+    default List<CommandToken> getArguments(Map<String, String> extraConfigurations) {
+        return getArguments();
+    }
 }

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/JobflowExecutor.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/JobflowExecutor.java
@@ -367,7 +367,7 @@ class JobflowExecutor {
             CommandTaskMirror t = (CommandTaskMirror) task;
             List<String> commandLine = new ArrayList<>();
             commandLine.add(new File(context.getFrameworkHomePath(), t.getCommand()).getAbsolutePath());
-            commandLine.addAll(resolveCommandTokens(t.getArguments()));
+            commandLine.addAll(resolveCommandTokens(t.getArguments(context.getExtraConfigurations())));
             return new Command(
                     commandLine,
                     t.getModuleName(),


### PR DESCRIPTION
## Summary

This PR enables settings `*Tester.configure()` for testkits other than MapReduce.

## Background, Problem or Goal of the patch

The latest implementation ignores extra configurations which are set by `*Tester.configure()` .

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 