### PR TITLE
Introduce operator DSL compiler options.

### DIFF
--- a/operator/builtin/src/test/java/com/asakusafw/operator/builtin/OperatorDriverTestRoot.java
+++ b/operator/builtin/src/test/java/com/asakusafw/operator/builtin/OperatorDriverTestRoot.java
@@ -39,6 +39,7 @@ import com.asakusafw.operator.CompileEnvironment.Support;
 import com.asakusafw.operator.MockDataModelMirrorRepository;
 import com.asakusafw.operator.OperatorCompilerTestRoot;
 import com.asakusafw.operator.OperatorDriver;
+import com.asakusafw.operator.WarningAction;
 import com.asakusafw.operator.description.ClassDescription;
 import com.asakusafw.operator.method.OperatorMethodAnalyzer;
 import com.asakusafw.operator.model.OperatorClass;
@@ -108,7 +109,7 @@ public class OperatorDriverTestRoot extends OperatorCompilerTestRoot {
             @Override
             protected CompileEnvironment createCompileEnvironment(ProcessingEnvironment processingEnv) {
                 return super.createCompileEnvironment(processingEnv)
-                        .withFailOnWarn(true)
+                        .withWarningAction(WarningAction.REPORT)
                         .withStrictOperatorParameterOrder(true);
             }
         };

--- a/operator/core/src/main/java/com/asakusafw/operator/AbstractOperatorAnnotationProcessor.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/AbstractOperatorAnnotationProcessor.java
@@ -16,6 +16,7 @@
 package com.asakusafw.operator;
 
 import java.text.MessageFormat;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
@@ -83,6 +84,14 @@ public abstract class AbstractOperatorAnnotationProcessor implements Processor {
 
     @Override
     public final Set<String> getSupportedOptions() {
+        return CompilerOption.getOptionNames(getSupportedFeatures());
+    }
+
+    /**
+     * Returns the supported features.
+     * @return the supported features
+     */
+    protected Collection<? extends CompileEnvironment.Support> getSupportedFeatures() {
         return Collections.emptySet();
     }
 

--- a/operator/core/src/main/java/com/asakusafw/operator/CompilerOption.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/CompilerOption.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.operator;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+
+import com.asakusafw.operator.util.Logger;
+
+/**
+ * Compiler options.
+ * @since 0.9.0
+ */
+public final class CompilerOption {
+
+    static final Logger LOG = Logger.get(CompilerOption.class);
+
+    private static final String KEY_PREFIX = "com.asakusafw.operator."; //$NON-NLS-1$
+
+    /**
+     * The processor option name of warning action type.
+     * @see WarningAction
+     */
+    public static final String KEY_WARNING_ACTION = KEY_PREFIX + "warning"; //$NON-NLS-1$
+
+    static void install(CompileEnvironment environment) {
+        Map<String, String> options = new TreeMap<>(environment.getProcessingEnvironment().getOptions());
+        installWarningAction(environment, options);
+        installFeatures(environment, options);
+    }
+
+    private static void installWarningAction(CompileEnvironment environment, Map<String, String> options) {
+        Optional.ofNullable(options.remove(KEY_WARNING_ACTION))
+            .flatMap(WarningAction::fromSymbol)
+            .ifPresent(environment::withWarningAction);
+    }
+
+    private static void installFeatures(CompileEnvironment environment, Map<String, String> options) {
+        for (CompileEnvironment.Support feature : CompileEnvironment.Support.values()) {
+            Optional.ofNullable(options.remove(keyOf(feature)))
+                    .map(String::trim)
+                    .map(v -> v.isEmpty() || Boolean.parseBoolean(v))
+                    .ifPresent(v -> feature.set(environment, v));
+        }
+    }
+
+    /**
+     * Returns the available option names.
+     * @param available the available features
+     * @return the available option names
+     */
+    public static Set<String> getOptionNames(Collection<? extends CompileEnvironment.Support> available) {
+        Set<String> results = new HashSet<>();
+        results.add(KEY_WARNING_ACTION);
+        available.stream()
+            .map(CompilerOption::keyOf)
+            .forEach(results::add);
+        return results;
+    }
+
+    private static String keyOf(CompileEnvironment.Support item) {
+        return KEY_PREFIX + item.name();
+    }
+}

--- a/operator/core/src/main/java/com/asakusafw/operator/CompilerOption.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/CompilerOption.java
@@ -40,6 +40,10 @@ public final class CompilerOption {
      */
     public static final String KEY_WARNING_ACTION = KEY_PREFIX + "warning"; //$NON-NLS-1$
 
+    private CompilerOption() {
+        return;
+    }
+
     static void install(CompileEnvironment environment) {
         Map<String, String> options = new TreeMap<>(environment.getProcessingEnvironment().getOptions());
         installWarningAction(environment, options);

--- a/operator/core/src/main/java/com/asakusafw/operator/WarningAction.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/WarningAction.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.operator;
+
+import java.util.Locale;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+/**
+ * Action type of warnings.
+ * @since 0.9.0
+ */
+public enum WarningAction {
+
+    /**
+     * Ignores warning.
+     */
+    IGNORE,
+
+    /**
+     * Reports on warn.
+     */
+    REPORT,
+
+    /**
+     * Fails on warn.
+     */
+    FAIL,
+    ;
+
+    /**
+     * Returns the default value of {@link WarningAction}.
+     * @return the default value
+     */
+    public static WarningAction getDefault() {
+        return REPORT;
+    }
+
+    /**
+     * Returns a constant of the given symbol.
+     * @param symbol the symbol
+     * @return the related constant of the symbol, or empty if the symbol is wrong
+     */
+    public static Optional<WarningAction> fromSymbol(String symbol) {
+        if (symbol == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(valueOf(symbol.trim().toUpperCase(Locale.ENGLISH)));
+        } catch (NoSuchElementException e) {
+            return Optional.empty();
+        }
+    }
+}

--- a/operator/core/src/main/java/com/asakusafw/operator/flowpart/FlowPartAnnotationProcessor.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/flowpart/FlowPartAnnotationProcessor.java
@@ -17,6 +17,7 @@ package com.asakusafw.operator.flowpart;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Set;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -37,12 +38,21 @@ public class FlowPartAnnotationProcessor extends AbstractOperatorAnnotationProce
 
     static final Logger LOG = Logger.get(FlowPartAnnotationProcessor.class);
 
+    static final Collection<CompileEnvironment.Support> FEATURES = Collections.unmodifiableSet(EnumSet.of(
+            CompileEnvironment.Support.STRICT_PARAMETER_ORDER,
+            CompileEnvironment.Support.FORCE_REGENERATE_RESOURCES,
+            CompileEnvironment.Support.FLOWPART_EXTERNAL_IO));
+
     @Override
     protected CompileEnvironment createCompileEnvironment(ProcessingEnvironment processingEnv) {
         return CompileEnvironment.newInstance(
                 processingEnv,
-                CompileEnvironment.Support.DATA_MODEL_REPOSITORY,
-                CompileEnvironment.Support.FAIL_ON_WARN);
+                CompileEnvironment.Support.DATA_MODEL_REPOSITORY);
+    }
+
+    @Override
+    protected Collection<CompileEnvironment.Support> getSupportedFeatures() {
+        return FEATURES;
     }
 
     @Override

--- a/operator/core/src/main/java/com/asakusafw/operator/method/OperatorAnnotationProcessor.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/method/OperatorAnnotationProcessor.java
@@ -17,6 +17,7 @@ package com.asakusafw.operator.method;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -45,16 +46,26 @@ public class OperatorAnnotationProcessor extends AbstractOperatorAnnotationProce
 
     static final Logger LOG = Logger.get(OperatorAnnotationProcessor.class);
 
+    static final Collection<CompileEnvironment.Support> FEATURES = Collections.unmodifiableSet(EnumSet.of(
+            CompileEnvironment.Support.STRICT_PARAMETER_ORDER,
+            CompileEnvironment.Support.FORCE_REGENERATE_RESOURCES,
+            CompileEnvironment.Support.FORCE_GENERATE_IMPLEMENTATION,
+            CompileEnvironment.Support.FORCE_NORMALIZE_MEMBER_NAME));
+
     @Override
     protected CompileEnvironment createCompileEnvironment(ProcessingEnvironment processingEnv) {
         return CompileEnvironment.newInstance(
                 processingEnv,
                 CompileEnvironment.Support.DATA_MODEL_REPOSITORY,
                 CompileEnvironment.Support.OPERATOR_DRIVER,
-                CompileEnvironment.Support.FAIL_ON_WARN,
                 CompileEnvironment.Support.FORCE_GENERATE_IMPLEMENTATION,
                 CompileEnvironment.Support.FORCE_NORMALIZE_MEMBER_NAME,
                 CompileEnvironment.Support.STRICT_PARAMETER_ORDER);
+    }
+
+    @Override
+    protected Collection<CompileEnvironment.Support> getSupportedFeatures() {
+        return FEATURES;
     }
 
     @Override

--- a/operator/core/src/main/java/com/asakusafw/operator/method/OperatorMethodAnalyzer.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/method/OperatorMethodAnalyzer.java
@@ -304,7 +304,7 @@ public class OperatorMethodAnalyzer {
         return false;
     }
 
-    private String toNameId(Name simpleName) {
+    private static String toNameId(Name simpleName) {
         assert simpleName != null;
         StringBuilder buf = new StringBuilder();
         for (int i = 0, n = simpleName.length(); i < n; i++) {
@@ -317,8 +317,18 @@ public class OperatorMethodAnalyzer {
     }
 
     private void warn(Element element, String pattern, Object... arguments) {
-        if (environment.isFailOnWarn()) {
+        switch (environment.getWarningAction()) {
+        case IGNORE:
+            message(Diagnostic.Kind.NOTE, element, pattern, arguments);
+            break;
+        case REPORT:
             message(Diagnostic.Kind.WARNING, element, pattern, arguments);
+            break;
+        case FAIL:
+            message(Diagnostic.Kind.ERROR, element, pattern, arguments);
+            break;
+        default:
+            break;
         }
     }
 
@@ -332,7 +342,11 @@ public class OperatorMethodAnalyzer {
         assert pattern != null;
         assert arguments != null;
         String message = arguments.length == 0 ? pattern : MessageFormat.format(pattern, arguments);
-        environment.getProcessingEnvironment().getMessager().printMessage(kind, message, element);
+        if (kind == Diagnostic.Kind.NOTE) {
+            LOG.debug(message);
+        } else {
+            environment.getProcessingEnvironment().getMessager().printMessage(kind, message, element);
+        }
     }
 
     private static final class AnnotatedMethod {


### PR DESCRIPTION
## Summary

This PR introduce launch options to Asakusa operator DSL compiler (`./operator`).

## Background, Problem or Goal of the patch

The DSL compiler might have raised some noisy warnings if operator classes did not comply with strict DSL rules (e.g. the class is not declared as `abstract`). One of the introduced options can suppress their signals, or treat such classes as compile error.

Other options can turn on/off the compiler features temporarily (for only testing).

## Design of the fix, or a new feature

Application developers can specify options via asakusafw/asakusafw-sdk#115.

* `com.asakusafw.operator.warning`
  * configure action for discouraged operator DSL code
  * available options:
    * `ignore`
      * ignore warnings
    * `report`
      * report warnings
    * `fail`
      * fail on any warnings
  * default: `report`

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-sdk#115

## Wanted reviewer

@akirakw 