### PR TITLE
Fix lack of Result interface in Operator Compiler

### DIFF
--- a/mapreduce/compiler/operator/pom.xml
+++ b/mapreduce/compiler/operator/pom.xml
@@ -45,6 +45,7 @@
                   <includes>
                     <include>com/asakusafw/runtime/model/**</include>
                     <include>com/asakusafw/runtime/value/**</include>
+                    <include>com/asakusafw/runtime/core/**</include>
                   </includes>
                 </filter>
               </filters>


### PR DESCRIPTION
## Summary
This PR fixes lack of `com.asakusafw.runtime.core.Result` interface in Operator Compiler jar archive.

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.

## Wanted reviewer
N/A.
