### PR TITLE
Fix type infer in operator DSL compiler.

### DIFF
--- a/operator/core/src/main/java/com/asakusafw/operator/model/OperatorDescription.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/model/OperatorDescription.java
@@ -659,6 +659,11 @@ public class OperatorDescription {
             return extern;
         }
 
+        @Override
+        public String toString() {
+            return String.format("%s(%s)", getKind(), getName()); //$NON-NLS-1$
+        }
+
         /**
          * Represents parameter kind.
          */

--- a/operator/core/src/test/java/com/asakusafw/operator/flowpart/FlowPartAnalyzerTest.java
+++ b/operator/core/src/test/java/com/asakusafw/operator/flowpart/FlowPartAnalyzerTest.java
@@ -144,6 +144,41 @@ public class FlowPartAnalyzerTest extends OperatorCompilerTestRoot {
     }
 
     /**
+     * w/ class argument.
+     */
+    @Test
+    public void with_ctor_class() {
+        compile(new Action("com.example.ctor.WithClass") {
+            @Override
+            protected void perform(OperatorClass target) {
+                TypeVariable va = getTypeVariable(target.getDeclaration(), "A");
+                TypeVariable vb = getTypeVariable(target.getDeclaration(), "B");
+
+                assertThat(target, is(notNullValue()));
+                assertThat(target.getElements().size(), is(1));
+                OperatorElement element = target.getElements().get(0);
+                OperatorDescription description = element.getDescription();
+                assertThat(description, is(notNullValue()));
+                assertThat(description.getInputs().size(), is(1));
+                assertThat(description.getOutputs().size(), is(1));
+                assertThat(description.getArguments().size(), is(1));
+
+                Node input = description.getInputs().get(0);
+                assertThat(input.getName(), is("in"));
+                assertThat(input.getType(), is(sameType(va)));
+
+                Node output = description.getOutputs().get(0);
+                assertThat(output.getName(), is("out"));
+                assertThat(output.getType(), is(sameType(vb)));
+
+                Node argument = description.getArguments().get(0);
+                assertThat(argument.getName(), is("aClass"));
+                assertThat(argument.getType(), is(sameType(Class.class, vb)));
+            }
+        });
+    }
+
+    /**
      * w/ extern in.
      */
     @Test

--- a/operator/core/src/test/resources/com/asakusafw/operator/flowpart/FlowPartAnalyzerTest.files/com/example/ctor/WithClass.java.txt
+++ b/operator/core/src/test/resources/com/asakusafw/operator/flowpart/FlowPartAnalyzerTest.files/com/example/ctor/WithClass.java.txt
@@ -1,0 +1,16 @@
+package com.example.ctor;
+
+import com.example.*;
+import com.asakusafw.vocabulary.flow.*;
+
+@FlowPart
+public class $s<
+        A extends CharSequence,
+        B extends CharSequence> extends FlowDescription {
+
+    public $s(In<A> in, Out<B> out, Class<B> aClass) {
+    }
+
+    @Override
+    protected void describe() {}
+}

--- a/operator/core/src/test/resources/com/asakusafw/operator/flowpart/FlowPartFactoryEmitterTest.files/com/example/WithClass.java.txt
+++ b/operator/core/src/test/resources/com/asakusafw/operator/flowpart/FlowPartFactoryEmitterTest.files/com/example/WithClass.java.txt
@@ -1,0 +1,24 @@
+package com.example;
+
+import com.asakusafw.vocabulary.flow.*;
+
+/**
+ * A class.
+ * @param <A> type parameter
+ * @param <B> type parameter
+ */
+@FlowPart
+public class $s<A, B> extends FlowDescription {
+    
+    /**
+     * Ctor.
+     * @param in input
+     * @param out output
+     * @param arg argument
+     */
+    public $s(A in, B out, Class<B> arg) {
+    }
+    
+    @Override
+    protected void describe() {}
+}


### PR DESCRIPTION
## Summary

This PR fixes type infer in operator DSL compiler (`./operator`).

## Background, Problem or Goal of the patch

The latest implementation, the compiler cannot recognize following a flow-part class:

```java
@FlowPart
public class F<
        A extends ...,
        B extends ...> extends FlowDescription {

    public F(In<A> in, Out<B> out, Class<B> aClass) {
    }
    ...
}
```

The above type variable `B` (in `Out<B>`) must be inferred by using `Class<B> aClass`, but the latest implementation had ignored the `Class<T>`.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A,

## Wanted reviewer

@akirakw 