### PR TITLE
Enable operator custom attributes.

### DIFF
--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/attribute/Attribute.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/attribute/Attribute.java
@@ -13,7 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.asakusafw.vocabulary.attribute;
+
+import com.asakusafw.vocabulary.flow.graph.FlowElementAttribute;
+
 /**
- * Provides annotations for data model and operations over data models.
+ * An abstract super interface of DSL element attributes.
+ * @since 0.9.0
  */
-package com.asakusafw.vocabulary.model;
+public interface Attribute extends FlowElementAttribute {
+
+    /**
+     * Returns the declaring class of this attribute.
+     * @return the declaring class of this attribute
+     */
+    @Override
+    Class<? extends Attribute> getDeclaringClass();
+}

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/attribute/BufferType.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/attribute/BufferType.java
@@ -13,7 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.asakusafw.vocabulary.attribute;
+
 /**
- * Provides annotations for data model and operations over data models.
+ * Represents a buffer type of inputs.
+ * @since 0.9.1
  */
-package com.asakusafw.vocabulary.model;
+public enum BufferType implements Attribute {
+
+    /**
+     * Allocates a buffer onto the Java heap, and keeps all elements on it.
+     */
+    HEAP,
+
+    /**
+     * Allocates a buffer onto the Java heap and temporary files.
+     */
+    STORED,
+
+    /**
+     * Does not allocate buffer space.
+     */
+    VOLATILE,
+}

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/attribute/package-info.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/attribute/package-info.java
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Provides annotations for data model and operations over data models.
+ * Attributes about flow elements.
  */
-package com.asakusafw.vocabulary.model;
+package com.asakusafw.vocabulary.attribute;

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/builder/FlowElementBuilder.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/builder/FlowElementBuilder.java
@@ -18,6 +18,7 @@ package com.asakusafw.vocabulary.flow.builder;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,7 @@ import java.util.Objects;
 import com.asakusafw.vocabulary.flow.FlowDescription;
 import com.asakusafw.vocabulary.flow.Source;
 import com.asakusafw.vocabulary.flow.graph.FlowElement;
+import com.asakusafw.vocabulary.flow.graph.FlowElementAttribute;
 import com.asakusafw.vocabulary.flow.graph.FlowElementDescription;
 import com.asakusafw.vocabulary.flow.graph.FlowElementInput;
 import com.asakusafw.vocabulary.flow.graph.FlowElementOutput;
@@ -34,8 +36,11 @@ import com.asakusafw.vocabulary.flow.graph.PortConnection;
 /**
  * Builds operator graphs.
  * @since 0.9.0
+ * @version 0.9.1
  */
 public abstract class FlowElementBuilder {
+
+    private static final FlowElementAttribute[] EMPTY_ATTRS = new FlowElementAttribute[0];
 
     private final List<PortInfo> inputs = new ArrayList<>();
 
@@ -106,8 +111,22 @@ public abstract class FlowElementBuilder {
      * @throws IllegalArgumentException if some parameters were {@code null}
      */
     public PortInfo defineInput(String name, Source<?> upstream) {
+        return defineInput(name, upstream, EMPTY_ATTRS);
+    }
+
+    /**
+     * Defines a new input for operator.
+     * @param name input name
+     * @param upstream upstream dataset
+     * @param attributes the port attributes
+     * @return defined port information
+     * @throws IllegalArgumentException if some parameters were {@code null}
+     * @since 0.9.1
+     */
+    public PortInfo defineInput(String name, Source<?> upstream, FlowElementAttribute... attributes) {
         Objects.requireNonNull(name, "name must not be null"); //$NON-NLS-1$
         Objects.requireNonNull(upstream, "upstream must not be null"); //$NON-NLS-1$
+        Objects.requireNonNull(attributes);
         FlowElementOutput output = upstream.toOutputPort();
         PortInfo info = new PortInfo(PortInfo.Direction.INPUT, name, getType(output));
         inputs.add(info);
@@ -115,7 +134,7 @@ public abstract class FlowElementBuilder {
         return info;
     }
 
-    private Type getType(FlowElementOutput output) {
+    private static Type getType(FlowElementOutput output) {
         return output.getDescription().getDataType();
     }
 
@@ -127,9 +146,7 @@ public abstract class FlowElementBuilder {
      * @throws IllegalArgumentException if some parameters were {@code null}
      */
     public PortInfo defineOutput(String name, Type type) {
-        Objects.requireNonNull(name, "name must not be null"); //$NON-NLS-1$
-        Objects.requireNonNull(type, "type must not be null"); //$NON-NLS-1$
-        return defineOutput0(name, type);
+        return defineOutput(name, type, EMPTY_ATTRS);
     }
 
     /**
@@ -140,15 +157,45 @@ public abstract class FlowElementBuilder {
      * @throws IllegalArgumentException if some parameters were {@code null}
      */
     public PortInfo defineOutput(String name, Source<?> typeRef) {
-        Objects.requireNonNull(name, "name must not be null"); //$NON-NLS-1$
-        Objects.requireNonNull(typeRef, "typeRef must not be null"); //$NON-NLS-1$
-        return defineOutput0(name, getType(typeRef.toOutputPort()));
+        return defineOutput(name, typeRef, EMPTY_ATTRS);
     }
 
-    private PortInfo defineOutput0(String name, Type type) {
+    /**
+     * Defines a new output for operator.
+     * @param name output name
+     * @param type output type
+     * @param attributes the port attributes
+     * @return defined port information
+     * @throws IllegalArgumentException if some parameters were {@code null}
+     * @since 0.9.1
+     */
+    public PortInfo defineOutput(String name, Type type, FlowElementAttribute... attributes) {
+        Objects.requireNonNull(name, "name must not be null"); //$NON-NLS-1$
+        Objects.requireNonNull(type, "type must not be null"); //$NON-NLS-1$
+        Objects.requireNonNull(attributes);
+        return defineOutput0(name, type, attributes);
+    }
+
+    /**
+     * Defines a new output for operator.
+     * @param name output name
+     * @param typeRef output type reference
+     * @param attributes the port attributes
+     * @return defined port information
+     * @throws IllegalArgumentException if some parameters were {@code null}
+     * @since 0.9.1
+     */
+    public PortInfo defineOutput(String name, Source<?> typeRef, FlowElementAttribute... attributes) {
+        Objects.requireNonNull(name, "name must not be null"); //$NON-NLS-1$
+        Objects.requireNonNull(typeRef, "typeRef must not be null"); //$NON-NLS-1$
+        Objects.requireNonNull(attributes);
+        return defineOutput0(name, getType(typeRef.toOutputPort()), attributes);
+    }
+
+    private PortInfo defineOutput0(String name, Type type, FlowElementAttribute[] attributes) {
         assert name != null;
         assert type != null;
-        PortInfo info = new PortInfo(PortInfo.Direction.OUTPUT, name, type);
+        PortInfo info = new PortInfo(PortInfo.Direction.OUTPUT, name, type, Arrays.asList(attributes));
         outputs.add(info);
         return info;
     }

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/builder/FlowElementBuilder.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/builder/FlowElementBuilder.java
@@ -128,9 +128,18 @@ public abstract class FlowElementBuilder {
         Objects.requireNonNull(upstream, "upstream must not be null"); //$NON-NLS-1$
         Objects.requireNonNull(attributes);
         FlowElementOutput output = upstream.toOutputPort();
-        PortInfo info = new PortInfo(PortInfo.Direction.INPUT, name, getType(output));
-        inputs.add(info);
+        Type type = getType(output);
+        PortInfo info = defineInput0(name, type, attributes);
         inputMapping.put(name, output);
+        return info;
+    }
+
+    private PortInfo defineInput0(String name, Type type, FlowElementAttribute... attributes) {
+        assert name != null;
+        assert type != null;
+        assert attributes != null;
+        PortInfo info = new PortInfo(PortInfo.Direction.INPUT, name, type, Arrays.asList(attributes));
+        inputs.add(info);
         return info;
     }
 
@@ -192,9 +201,10 @@ public abstract class FlowElementBuilder {
         return defineOutput0(name, getType(typeRef.toOutputPort()), attributes);
     }
 
-    private PortInfo defineOutput0(String name, Type type, FlowElementAttribute[] attributes) {
+    private PortInfo defineOutput0(String name, Type type, FlowElementAttribute... attributes) {
         assert name != null;
         assert type != null;
+        assert attributes != null;
         PortInfo info = new PortInfo(PortInfo.Direction.OUTPUT, name, type, Arrays.asList(attributes));
         outputs.add(info);
         return info;

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/builder/OperatorNodeBuilder.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/builder/OperatorNodeBuilder.java
@@ -24,7 +24,9 @@ import java.util.Objects;
 
 import com.asakusafw.vocabulary.flow.graph.FlowElementAttribute;
 import com.asakusafw.vocabulary.flow.graph.FlowElementDescription;
+import com.asakusafw.vocabulary.flow.graph.FlowElementPortDescription;
 import com.asakusafw.vocabulary.flow.graph.OperatorDescription;
+import com.asakusafw.vocabulary.flow.graph.PortDirection;
 
 /**
  * Builds operator internally.
@@ -96,11 +98,12 @@ public class OperatorNodeBuilder extends FlowElementBuilder {
                         method.getName(),
                         info.getName()));
             }
-            if (info.getKey() != null) {
-                builder.addInput(info.getName(), info.getType(), info.getKey().toShuffleKey());
-            } else {
-                builder.addInput(info.getName(), info.getType());
-            }
+            builder.addPort(new FlowElementPortDescription(
+                    info.getName(),
+                    info.getType(),
+                    PortDirection.INPUT,
+                    info.getKey() == null ? null : info.getKey().toShuffleKey(),
+                    info.getAttributes()));
         }
         for (PortInfo info : outputPorts) {
             if (info.getKey() != null) {
@@ -117,7 +120,12 @@ public class OperatorNodeBuilder extends FlowElementBuilder {
                         method.getName(),
                         info.getName()));
             }
-            builder.addOutput(info.getName(), info.getType());
+            builder.addPort(new FlowElementPortDescription(
+                    info.getName(),
+                    info.getType(),
+                    PortDirection.OUTPUT,
+                    null,
+                    info.getAttributes()));
         }
         for (DataInfo info : arguments) {
             Data data = info.getData();

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/builder/PortInfo.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/builder/PortInfo.java
@@ -16,10 +16,16 @@
 package com.asakusafw.vocabulary.flow.builder;
 
 import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.asakusafw.vocabulary.flow.graph.FlowElementAttribute;
 
 /**
  * Represents operator input/output port information.
  * @since 0.9.0
+ * @since 0.9.1
  */
 public class PortInfo extends EdgeInfo<PortInfo> {
 
@@ -29,6 +35,8 @@ public class PortInfo extends EdgeInfo<PortInfo> {
 
     private final Type type;
 
+    private final List<FlowElementAttribute> attributes;
+
     /**
      * Creates a new instance.
      * @param direction the port direction
@@ -36,9 +44,24 @@ public class PortInfo extends EdgeInfo<PortInfo> {
      * @param type the data type on the port
      */
     public PortInfo(Direction direction, String name, Type type) {
+        this(direction, name, type, Collections.emptyList());
+    }
+
+    /**
+     * Creates a new instance.
+     * @param direction the port direction
+     * @param name the port name
+     * @param type the data type on the port
+     * @param attributes the port attributes
+     * @since 0.9.1
+     */
+    public PortInfo(Direction direction, String name, Type type, List<? extends FlowElementAttribute> attributes) {
         this.direction = direction;
         this.name = name;
         this.type = type;
+        this.attributes = attributes.isEmpty()
+                ? Collections.emptyList()
+                : Collections.unmodifiableList(new ArrayList<>(attributes));
     }
 
     @Override
@@ -69,6 +92,15 @@ public class PortInfo extends EdgeInfo<PortInfo> {
      */
     public Type getType() {
         return type;
+    }
+
+    /**
+     * Returns the attributes.
+     * @return the attributes
+     * @since 0.9.1
+     */
+    public List<FlowElementAttribute> getAttributes() {
+        return attributes;
     }
 
     /**

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/FlowElement.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/FlowElement.java
@@ -20,14 +20,16 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Represents a node in flow graph.
  * Application developers should not use this class directly.
  * @since 0.1.0
- * @version 0.4.0
+ * @version 0.9.1
  */
 public final class FlowElement implements FlowElementAttributeProvider {
 
@@ -154,13 +156,14 @@ public final class FlowElement implements FlowElementAttributeProvider {
         return own.equals(attribute);
     }
 
-    /**
-     * Returns the attribute of the specified kind.
-     * @param <T> the attribute kind
-     * @param attributeClass the attribute type
-     * @return the target attribute, or {@code null} if this element does not have such an attribute
-     * @throws IllegalArgumentException if the parameter is {@code null}
-     */
+    @Override
+    public Set<? extends Class<? extends FlowElementAttribute>> getAttributeTypes() {
+        Set<Class<? extends FlowElementAttribute>> results = new HashSet<>();
+        results.addAll(attributeOverride.keySet());
+        results.addAll(getDescription().getAttributeTypes());
+        return results;
+    }
+
     @Override
     public <T extends FlowElementAttribute> T getAttribute(Class<T> attributeClass) {
         if (attributeClass == null) {

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/FlowElementAttributeProvider.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/FlowElementAttributeProvider.java
@@ -15,12 +15,21 @@
  */
 package com.asakusafw.vocabulary.flow.graph;
 
+import java.util.Set;
+
 /**
  * Provides {@link FlowElementAttribute}s.
  * @since 0.4.0
+ * @version 0.9.1
  */
-@FunctionalInterface
 public interface FlowElementAttributeProvider {
+
+    /**
+     * Returns the all available attribute types of this.
+     * @return the available attribute types
+     * @since 0.9.1
+     */
+    Set<? extends Class<? extends FlowElementAttribute>> getAttributeTypes();
 
     /**
      * Returns the attribute of this.

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/FlowElementPort.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/FlowElementPort.java
@@ -24,9 +24,9 @@ import java.util.Set;
  * An abstract super class of I/O ports of {@link FlowElement}.
  * Application developers should not use this class directly.
  * @since 0.1.0
- * @version 0.5.1
+ * @version 0.9.1
  */
-public abstract class FlowElementPort {
+public abstract class FlowElementPort implements FlowElementAttributeProvider {
 
     private final FlowElement owner;
 
@@ -66,6 +66,16 @@ public abstract class FlowElementPort {
      */
     public FlowElementPortDescription getDescription() {
         return description;
+    }
+
+    @Override
+    public Set<? extends Class<? extends FlowElementAttribute>> getAttributeTypes() {
+        return getDescription().getAttributeTypes();
+    }
+
+    @Override
+    public <T extends FlowElementAttribute> T getAttribute(Class<T> attributeClass) {
+        return getDescription().getAttribute(attributeClass);
     }
 
     /**

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/FlowElementPortDescription.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/FlowElementPortDescription.java
@@ -17,11 +17,19 @@ package com.asakusafw.vocabulary.flow.graph;
 
 import java.lang.reflect.Type;
 import java.text.MessageFormat;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * A description of I/O port of flow elements.
+ * @since 0.1.0
+ * @version 0.9.1
  */
-public class FlowElementPortDescription {
+public class FlowElementPortDescription implements FlowElementAttributeProvider {
 
     private final String name;
 
@@ -30,6 +38,8 @@ public class FlowElementPortDescription {
     private final PortDirection direction;
 
     private final ShuffleKey shuffleKey;
+
+    private final Map<Class<? extends FlowElementAttribute>, FlowElementAttribute> attributes;
 
     /**
      * Creates a new instance.
@@ -52,6 +62,7 @@ public class FlowElementPortDescription {
         this.dataType = dataType;
         this.direction = direction;
         this.shuffleKey = null;
+        this.attributes = Collections.emptyMap();
     }
 
     /**
@@ -75,6 +86,35 @@ public class FlowElementPortDescription {
         this.dataType = dataType;
         this.direction = PortDirection.INPUT;
         this.shuffleKey = shuffleKey;
+        this.attributes = Collections.emptyMap();
+    }
+
+    /**
+     * Creates a new instance.
+     * @param name the port name
+     * @param dataType the data type of the port
+     * @param direction the port direction
+     * @param shuffleKey the shuffle key (nullable)
+     * @param attributes the attributes
+     * @throws IllegalArgumentException if some parameters are {@code null}
+     * @since 0.9.1
+     */
+    public FlowElementPortDescription(
+            String name, Type dataType, PortDirection direction,
+            ShuffleKey shuffleKey, List<? extends FlowElementAttribute> attributes) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(dataType);
+        Objects.requireNonNull(direction);
+        Objects.requireNonNull(attributes);
+        this.name = name;
+        this.dataType = dataType;
+        this.direction = direction;
+        this.shuffleKey = shuffleKey;
+        Map<Class<? extends FlowElementAttribute>, FlowElementAttribute> map = new LinkedHashMap<>();
+        for (FlowElementAttribute attr : attributes) {
+            map.put(attr.getDeclaringClass(), attr);
+        }
+        this.attributes = Collections.unmodifiableMap(map);
     }
 
     /**
@@ -107,6 +147,19 @@ public class FlowElementPortDescription {
      */
     public ShuffleKey getShuffleKey() {
         return shuffleKey;
+    }
+
+    @Override
+    public Set<? extends Class<? extends FlowElementAttribute>> getAttributeTypes() {
+        return attributes.keySet();
+    }
+
+    @Override
+    public <T extends FlowElementAttribute> T getAttribute(Class<T> attributeClass) {
+        if (attributeClass == null) {
+            throw new IllegalArgumentException("attributeClass must not be null"); //$NON-NLS-1$
+        }
+        return attributeClass.cast(attributes.get(attributeClass));
     }
 
     @Override

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/FlowPartDescription.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/FlowPartDescription.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.asakusafw.vocabulary.flow.FlowDescription;
 import com.asakusafw.vocabulary.flow.Source;
@@ -29,7 +30,7 @@ import com.asakusafw.vocabulary.flow.Source;
 /**
  * A description of flow-part.
  * @since 0.1.0
- * @version 0.5.0
+ * @version 0.9.1
  */
 public class FlowPartDescription implements FlowElementDescription {
 
@@ -190,6 +191,11 @@ public class FlowPartDescription implements FlowElementDescription {
     @Override
     public List<FlowResourceDescription> getResources() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public Set<? extends Class<? extends FlowElementAttribute>> getAttributeTypes() {
+        return ATTRIBUTES.keySet();
     }
 
     @Override

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/InputDescription.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/InputDescription.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.asakusafw.vocabulary.external.ImporterDescription;
 
@@ -143,6 +144,11 @@ public class InputDescription implements FlowElementDescription {
     @Override
     public List<FlowResourceDescription> getResources() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public Set<? extends Class<? extends FlowElementAttribute>> getAttributeTypes() {
+        return ATTRIBUTES.keySet();
     }
 
     @Override

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/OperatorDescription.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/OperatorDescription.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import com.asakusafw.vocabulary.flow.Source;
@@ -32,7 +33,7 @@ import com.asakusafw.vocabulary.flow.Source;
 /**
  * A description of user/code operator.
  * @since 0.1.0
- * @version 0.5.1
+ * @version 0.9.1
  */
 public class OperatorDescription implements FlowElementDescription {
 
@@ -181,6 +182,11 @@ public class OperatorDescription implements FlowElementDescription {
      */
     public List<Parameter> getParameters() {
         return parameters;
+    }
+
+    @Override
+    public Set<? extends Class<? extends FlowElementAttribute>> getAttributeTypes() {
+        return attributes.keySet();
     }
 
     @Override
@@ -407,15 +413,15 @@ public class OperatorDescription implements FlowElementDescription {
 
         private final List<Class<?>> parameterTypes;
 
-        private final List<FlowElementPortDescription> inputPorts;
+        private final List<FlowElementPortDescription> inputPorts = new ArrayList<>();
 
-        private final List<FlowElementPortDescription> outputPorts;
+        private final List<FlowElementPortDescription> outputPorts = new ArrayList<>();
 
-        private final List<FlowResourceDescription> resources;
+        private final List<FlowResourceDescription> resources = new ArrayList<>();
 
-        private final List<Parameter> parameters;
+        private final List<Parameter> parameters = new ArrayList<>();
 
-        private final List<FlowElementAttribute> attributes;
+        private final List<FlowElementAttribute> attributes = new ArrayList<>();
 
         /**
          * Creates a new instance.
@@ -428,11 +434,6 @@ public class OperatorDescription implements FlowElementDescription {
             }
             this.annotationType = annotationType;
             this.parameterTypes = new ArrayList<>();
-            this.inputPorts = new ArrayList<>();
-            this.outputPorts = new ArrayList<>();
-            this.resources = new ArrayList<>();
-            this.parameters = new ArrayList<>();
-            this.attributes = new ArrayList<>();
         }
 
         /**
@@ -482,6 +483,27 @@ public class OperatorDescription implements FlowElementDescription {
                 throw new IllegalArgumentException("parameterType must not be null"); //$NON-NLS-1$
             }
             this.parameterTypes.add(parameterType);
+            return this;
+        }
+
+        /**
+         * Adds a new port of the target operator.
+         * @param description the port description
+         * @return this
+         * @since 0.9.1
+         */
+        public Builder addPort(FlowElementPortDescription description) {
+            Objects.requireNonNull(description);
+            switch (description.getDirection()) {
+            case INPUT:
+                inputPorts.add(description);
+                break;
+            case OUTPUT:
+                outputPorts.add(description);
+                break;
+            default:
+                throw new AssertionError(description);
+            }
             return this;
         }
 

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/OutputDescription.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/graph/OutputDescription.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.asakusafw.vocabulary.external.ExporterDescription;
 
@@ -143,6 +144,11 @@ public class OutputDescription implements FlowElementDescription {
     @Override
     public List<FlowResourceDescription> getResources() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public Set<? extends Class<? extends FlowElementAttribute>> getAttributeTypes() {
+        return ATTRIBUTES.keySet();
     }
 
     @Override

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/processor/InputBuffer.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/processor/InputBuffer.java
@@ -16,6 +16,8 @@
 package com.asakusafw.vocabulary.flow.processor;
 
 import com.asakusafw.vocabulary.flow.graph.FlowElementAttribute;
+import com.asakusafw.vocabulary.model.Once;
+import com.asakusafw.vocabulary.model.Spill;
 
 /**
  * Represents buffering strategies of list-style operator inputs.
@@ -73,6 +75,8 @@ public void invalid(&#64;Key(...) List&lt;Hoge&gt; list, Result&lt;Hoge&gt; resu
     }
 }
 </code></pre>
+     * @see Once
+     * @see Spill
      */
     ESCAPE,
 }

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/util/PseudElementDescription.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/flow/util/PseudElementDescription.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import com.asakusafw.vocabulary.flow.graph.FlowBoundary;
 import com.asakusafw.vocabulary.flow.graph.FlowElementAttribute;
@@ -153,6 +154,11 @@ public class PseudElementDescription implements FlowElementDescription {
     @Override
     public List<FlowResourceDescription> getResources() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public Set<? extends Class<? extends FlowElementAttribute>> getAttributeTypes() {
+        return attributes.keySet();
     }
 
     @Override

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/model/Once.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/model/Once.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vocabulary.model;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.asakusafw.vocabulary.operator.CoGroup;
+import com.asakusafw.vocabulary.operator.GroupSort;
+
+/**
+ * An annotation represents which the annotated element will be used only once.
+ *
+ * This can appear with the following elements:
+ * <ul>
+ * <li>
+ *   Input parameter of {@link CoGroup} and {@link GroupSort} operator methods.
+ *
+ *   A parameter with this annotation represents that elements in the parameter must be accessed only once.
+ *   The parameter must be defined as {@code Iterable} type, and clients can invoke
+ *   {@link Iterable#iterator() its iterator()} only once in the operator method.
+ *   If clients invoke the method more than once, it MAY raise an exception.
+ *
+ *   Typically, the annotated parameter is used with {@code for} statement like as following:
+<pre><code>
+&#64;CoGroup
+public void iterate(&#64;Key(...) &#64;Once Iterable&lt;Hoge&gt; input, Result&lt;Hoge&gt; result) {
+    for (Hoge hoge : input) {
+        ...
+    }
+}
+</code></pre>
+ *
+ *   With this annotation, obtaining elements in the sequence will change the old object from the sequence.
+ *   For example, the operations are not guaranteed in the following case:
+<pre><code>
+&#64;CoGroup
+public void invalid(&#64;Key(...) &#64;Once Iterable&lt;Hoge&gt; input, Result&lt;Hoge&gt; result) {
+    Iterator&lt;Hoge&gt; iter = input.iterator();
+    Hoge a = iter.next();
+    Hoge b = iter.next(); // this operation may break out contents of 'a'
+    ...
+}
+</code></pre>
+ *   In such the case, application developers should create a copy of the object:
+<pre><code>
+final Hoge a = new Hoge();
+final Hoge b = new Hoge();
+
+&#64;CoGroup
+public void invalid(&#64;Key(...) &#64;Once Iterable&lt;Hoge&gt; input, Result&lt;Hoge&gt; result) {
+    a.copyFrom(iter.next()); // create a copy
+    b.copyFrom(iter.next());
+    ...
+}
+</code></pre>
+ * </li>
+ * </ul>
+ *
+ * @since 0.9.1
+ */
+@Target({ ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Once {
+    // no special members
+}

--- a/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/model/Spill.java
+++ b/dsl-project/asakusa-dsl-vocabulary/src/main/java/com/asakusafw/vocabulary/model/Spill.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.vocabulary.model;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.asakusafw.vocabulary.operator.CoGroup;
+import com.asakusafw.vocabulary.operator.GroupSort;
+
+/**
+ * An annotation represents which the annotated element can spill its contents into backing store.
+ *
+ * This can appear with the following elements:
+ * <ul>
+ * <li>
+ *   Input parameter of {@link CoGroup} and {@link GroupSort} operator methods.
+ *
+ *   A parameter with this annotation may have too many elements in its list.
+ *   In such the case, we spill the elements into a temporary file, and flush the elements from the Java heap.
+ *
+ *   With this annotation, obtaining elements from the sequence will change the previously obtained object.
+ *   For example, the operations are not guaranteed in the following case:
+<pre><code>
+&#64;CoGroup
+public void invalid(&#64;Key(...) &#64;Spill List&lt;Hoge&gt; input, Result&lt;Hoge&gt; result) {
+    Hoge a = input.get(0);
+    Hoge b = input.get(1); // this operation may break out contents of 'a'
+    ...
+}
+</code></pre>
+ *   In such the case, application developers should create a copy of the object:
+<pre><code>
+final Hoge a = new Hoge();
+final Hoge b = new Hoge();
+
+&#64;CoGroup
+public void invalid(&#64;Key(...) &#64;Spill List&lt;Hoge&gt; input, Result&lt;Hoge&gt; result) {
+    a.copyFrom(input.get(0)); // take a copy
+    b.copyFrom(input.get(1));
+    ...
+}
+</code></pre>
+ * </li>
+ * </ul>
+ *
+ * @see Once
+ * @since 0.9.1
+ */
+@Target({ ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Spill {
+    // no special members
+}

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/FlowElementProcessor.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/flow/FlowElementProcessor.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.asakusafw.compiler.common.NameGenerator;
 import com.asakusafw.compiler.common.Precondition;
@@ -73,7 +74,7 @@ public interface FlowElementProcessor extends FlowCompilingEnvironment.Initializ
     /**
      * The abstract implementation of context objects for {@link FlowElementProcessor}.
      * @since 0.1.0
-     * @version 0.5.1
+     * @version 0.9.1
      */
     abstract class AbstractProcessorContext implements FlowElementAttributeProvider {
 
@@ -156,10 +157,12 @@ public interface FlowElementProcessor extends FlowCompilingEnvironment.Initializ
         }
 
         @Override
+        public Set<? extends Class<? extends FlowElementAttribute>> getAttributeTypes() {
+            return element.getAttributeTypes();
+        }
+
+        @Override
         public <T extends FlowElementAttribute> T getAttribute(Class<T> attributeClass) {
-            if (attributeClass == null) {
-                throw new IllegalArgumentException("attributeClass must not be null"); //$NON-NLS-1$
-            }
             return element.getAttribute(attributeClass);
         }
 

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/operator/ExecutableAnalyzer.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/operator/ExecutableAnalyzer.java
@@ -951,6 +951,15 @@ public class ExecutableAnalyzer {
         }
 
         /**
+         * Returns whether the target type is a subtype of {@link Iterable} or not.
+         * @return {@code true} if the target type is a list type, otherwise {@code false}
+         * @see #getTypeArgument()
+         */
+        public boolean isIterable() {
+            return isList() || typeDeclEqual(type, environment.getDeclaredType(Iterable.class));
+        }
+
+        /**
          * Returns whether the target type is a list type or not.
          * @return {@code true} if the target type is a list type, otherwise {@code false}
          * @see #getTypeArgument()

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/operator/processor/CoGroupOperatorProcessor.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/operator/processor/CoGroupOperatorProcessor.java
@@ -54,7 +54,7 @@ public class CoGroupOperatorProcessor extends AbstractOperatorProcessor {
             if (type.isResult()) {
                 break;
             }
-            if (type.isList() == false) {
+            if (type.isIterable() == false) {
                 a.error(i, Messages.getString("CoGroupOperatorProcessor.errorNotListInput")); //$NON-NLS-1$
             } else if (type.getTypeArgument().isModel() == false) {
                 a.error(i, Messages.getString("CoGroupOperatorProcessor.errorNotModelInput")); //$NON-NLS-1$

--- a/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/operator/processor/GroupSortOperatorProcessor.java
+++ b/mapreduce/compiler/core/src/main/java/com/asakusafw/compiler/operator/processor/GroupSortOperatorProcessor.java
@@ -49,7 +49,7 @@ public class GroupSortOperatorProcessor extends AbstractOperatorProcessor {
         if (a.getReturnType().isVoid() == false) {
             a.error(Messages.getString("GroupSortOperatorProcessor.errorNotVoidResult")); //$NON-NLS-1$
         }
-        if (a.getParameterType(0).isList() == false) {
+        if (a.getParameterType(0).isIterable() == false) {
             a.error(0, Messages.getString("GroupSortOperatorProcessor.errorNotListInput")); //$NON-NLS-1$
         } else if (a.getParameterType(0).getTypeArgument().isModel() == false) {
             a.error(0, Messages.getString("GroupSortOperatorProcessor.errorNotModelInput")); //$NON-NLS-1$

--- a/mapreduce/compiler/core/src/test/java/com/asakusafw/compiler/operator/processor/CoGroupOperatorProcessorTest.java
+++ b/mapreduce/compiler/core/src/test/java/com/asakusafw/compiler/operator/processor/CoGroupOperatorProcessorTest.java
@@ -82,6 +82,31 @@ public class CoGroupOperatorProcessorTest extends OperatorCompilerTestRoot {
     }
 
     /**
+     * iterable input.
+     */
+    @Test
+    public void input_iterable() {
+        add("com.example.InputIterable");
+        ClassLoader loader = start(new CoGroupOperatorProcessor());
+        Object factory = create(loader, "com.example.InputIterableFactory");
+
+        MockIn<MockHoge> a = MockIn.of(MockHoge.class, "a");
+        MockIn<MockFoo> b = MockIn.of(MockFoo.class, "b");
+
+        MockOut<MockHoge> r1 = MockOut.of(MockHoge.class, "r1");
+        MockOut<MockFoo> r2 = MockOut.of(MockFoo.class, "r2");
+
+        Object coGroup = invoke(factory, "example", a, b);
+        r1.add(output(MockHoge.class, coGroup, "r1"));
+        r2.add(output(MockFoo.class, coGroup, "r2"));
+
+        Graph<String> graph = toGraph(a, b);
+        assertThat(graph.getConnected("a"), isJust("InputIterable.example"));
+        assertThat(graph.getConnected("b"), isJust("InputIterable.example"));
+        assertThat(graph.getConnected("InputIterable.example"), isJust("r1", "r2"));
+    }
+
+    /**
      * generic method.
      */
     @Test

--- a/mapreduce/compiler/core/src/test/java/com/asakusafw/compiler/operator/processor/GroupSortOperatorProcessorTest.java
+++ b/mapreduce/compiler/core/src/test/java/com/asakusafw/compiler/operator/processor/GroupSortOperatorProcessorTest.java
@@ -73,6 +73,27 @@ public class GroupSortOperatorProcessorTest extends OperatorCompilerTestRoot {
     }
 
     /**
+     * w/ iterable input.
+     */
+    @Test
+    public void iterable_input() {
+        add("com.example.InputIterable");
+        ClassLoader loader = start(new GroupSortOperatorProcessor());
+        Object factory = create(loader, "com.example.InputIterableFactory");
+
+        MockIn<MockHoge> in = MockIn.of(MockHoge.class, "in");
+        MockOut<MockHoge> a = MockOut.of(MockHoge.class, "a");
+        MockOut<MockHoge> b = MockOut.of(MockHoge.class, "b");
+        Object gs = invoke(factory, "example", in);
+        a.add(output(MockHoge.class, gs, "first"));
+        b.add(output(MockHoge.class, gs, "last"));
+
+        Graph<String> graph = toGraph(in);
+        assertThat(graph.getConnected("in"), isJust("InputIterable.example"));
+        assertThat(graph.getConnected("InputIterable.example"), isJust("a", "b"));
+    }
+
+    /**
      * generic method.
      */
     @Test

--- a/mapreduce/compiler/core/src/test/resources/com/asakusafw/compiler/operator/processor/CoGroupOperatorProcessorTest.files/com/example/InputIterable.java.txt
+++ b/mapreduce/compiler/core/src/test/resources/com/asakusafw/compiler/operator/processor/CoGroupOperatorProcessorTest.files/com/example/InputIterable.java.txt
@@ -1,0 +1,21 @@
+package com.example;
+
+import com.asakusafw.compiler.operator.*;
+import com.asakusafw.compiler.operator.model.*;
+import com.asakusafw.compiler.operator.processor.*;
+import com.asakusafw.runtime.core.*;
+import com.asakusafw.vocabulary.model.*;
+import com.asakusafw.vocabulary.operator.*;
+
+public abstract class InputIterable {
+
+    @CoGroup
+    public void example(
+            @Key(group = "value") Iterable<MockHoge> a,
+            @Key(group = "value") Iterable<MockFoo> b,
+            Result<MockHoge> r1,
+            Result<MockFoo> r2) {
+        r1.add(a.iterator().next());
+        r2.add(b.iterator().next());
+    }
+}

--- a/mapreduce/compiler/core/src/test/resources/com/asakusafw/compiler/operator/processor/GroupSortOperatorProcessorTest.files/com/example/InputIterable.java.txt
+++ b/mapreduce/compiler/core/src/test/resources/com/asakusafw/compiler/operator/processor/GroupSortOperatorProcessorTest.files/com/example/InputIterable.java.txt
@@ -1,0 +1,26 @@
+package com.example;
+
+import com.asakusafw.compiler.operator.*;
+import com.asakusafw.compiler.operator.model.*;
+import com.asakusafw.compiler.operator.processor.*;
+import com.asakusafw.runtime.core.*;
+import com.asakusafw.vocabulary.model.*;
+import com.asakusafw.vocabulary.operator.*;
+
+public abstract class InputIterable {
+
+    @GroupSort
+    public void example(
+            @Key(group = {}, order = {"value"}) Iterable<MockHoge> in,
+            Result<MockHoge> first,
+            Result<MockHoge> last) {
+        MockHoge t = null;
+        for (MockHoge m : in) {
+            if (t == null) {
+                first.add(m);
+            }
+            t = m;
+        }
+        last.add(t);
+    }
+}

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/CoGroupKindOperatorUtil.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/CoGroupKindOperatorUtil.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.operator.builtin;
+
+import com.asakusafw.operator.builtin.DslBuilder.AnnotationRef;
+import com.asakusafw.operator.builtin.DslBuilder.ElementRef;
+import com.asakusafw.operator.builtin.DslBuilder.TypeRef;
+import com.asakusafw.operator.description.ClassDescription;
+import com.asakusafw.operator.description.EnumConstantDescription;
+
+final class CoGroupKindOperatorUtil {
+
+    private static final String INPUT_BUFFER = "inputBuffer"; //$NON-NLS-1$
+
+    static final ClassDescription TYPE_ONCE = new ClassDescription("com.asakusafw.vocabulary.model.Once"); //$NON-NLS-1$
+
+    static final ClassDescription TYPE_SPILL = new ClassDescription("com.asakusafw.vocabulary.model.Spill"); //$NON-NLS-1$
+
+    private static final ClassDescription TYPE_INPUT_BUFFER =
+            new ClassDescription("com.asakusafw.vocabulary.flow.processor.InputBuffer"); //$NON-NLS-1$
+
+    private static final ClassDescription TYPE_BUFFER_TYPE =
+            new ClassDescription("com.asakusafw.vocabulary.attribute.BufferType"); //$NON-NLS-1$
+
+    private static final EnumConstantDescription INPUT_BUFFER_ESCAPE =
+            new EnumConstantDescription(TYPE_INPUT_BUFFER, "ESCAPE"); //$NON-NLS-1$
+
+    private static final EnumConstantDescription BUFFER_TYPE_HEAP =
+            new EnumConstantDescription(TYPE_BUFFER_TYPE, "HEAP"); //$NON-NLS-1$
+
+    private static final EnumConstantDescription BUFFER_TYPE_STORED =
+            new EnumConstantDescription(TYPE_BUFFER_TYPE, "STORED"); //$NON-NLS-1$
+
+    private static final EnumConstantDescription BUFFER_TYPE_VOLATILE =
+            new EnumConstantDescription(TYPE_BUFFER_TYPE, "VOLATILE"); //$NON-NLS-1$
+
+    private CoGroupKindOperatorUtil() {
+        return;
+    }
+
+    static EnumConstantDescription getInputBuffer(DslBuilder dsl) {
+        return dsl.annotation().constant(INPUT_BUFFER);
+    }
+
+    static EnumConstantDescription getBufferType(ElementRef parameter, EnumConstantDescription parent) {
+        TypeRef type = parameter.type();
+        AnnotationRef once = parameter.annotation(TYPE_ONCE);
+        if (once != null && type.isIterable() == false) {
+            once.error("@Once must be declared with Iterable<...>");
+            return BUFFER_TYPE_HEAP;
+        }
+        AnnotationRef spill = parameter.annotation(TYPE_SPILL);
+        if (spill != null || parent.equals(INPUT_BUFFER_ESCAPE)) {
+            return BUFFER_TYPE_STORED;
+        } else if (once != null) {
+            return BUFFER_TYPE_VOLATILE;
+        } else {
+            // default buffer type
+            return BUFFER_TYPE_HEAP;
+        }
+    }
+}

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/CoGroupOperatorDriver.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/CoGroupOperatorDriver.java
@@ -45,7 +45,7 @@ public class CoGroupOperatorDriver implements OperatorDriver {
         if (dsl.result().type().isVoid() == false) {
             dsl.method().error(Messages.getString("CoGroupOperatorDriver.errorReturnNotVoid")); //$NON-NLS-1$
         }
-        EnumConstantDescription inputBuffer = CoGroupKindOperatorUtil.getInputBuffer(dsl);
+        EnumConstantDescription inputBuffer = GroupKindOperatorUtil.getInputBuffer(dsl);
         for (ElementRef p : dsl.parameters()) {
             TypeRef type = p.type();
             if (type.isList() || type.isIterable()) {
@@ -53,7 +53,7 @@ public class CoGroupOperatorDriver implements OperatorDriver {
                 if (arg.isDataModel()) {
                     KeyRef key = p.resolveKey(arg);
                     dsl.addInput(p.document(), p.name(), arg.mirror(), key, p.reference(),
-                            CoGroupKindOperatorUtil.getBufferType(p, inputBuffer));
+                            GroupKindOperatorUtil.getBufferType(p, inputBuffer));
                 } else {
                     p.error(Messages.getString("CoGroupOperatorDriver.errorInputNotDataModelListType")); //$NON-NLS-1$
                 }

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/CoGroupOperatorDriver.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/CoGroupOperatorDriver.java
@@ -23,14 +23,13 @@ import com.asakusafw.operator.builtin.DslBuilder.ElementRef;
 import com.asakusafw.operator.builtin.DslBuilder.KeyRef;
 import com.asakusafw.operator.builtin.DslBuilder.TypeRef;
 import com.asakusafw.operator.description.ClassDescription;
+import com.asakusafw.operator.description.EnumConstantDescription;
 import com.asakusafw.operator.model.OperatorDescription;
 
 /**
  * {@link OperatorDriver} for {@code CoGroup} annotation.
  */
 public class CoGroupOperatorDriver implements OperatorDriver {
-
-    private static final String INPUT_BUFFER = "inputBuffer"; //$NON-NLS-1$
 
     @Override
     public ClassDescription getAnnotationTypeName() {
@@ -46,13 +45,15 @@ public class CoGroupOperatorDriver implements OperatorDriver {
         if (dsl.result().type().isVoid() == false) {
             dsl.method().error(Messages.getString("CoGroupOperatorDriver.errorReturnNotVoid")); //$NON-NLS-1$
         }
+        EnumConstantDescription inputBuffer = CoGroupKindOperatorUtil.getInputBuffer(dsl);
         for (ElementRef p : dsl.parameters()) {
             TypeRef type = p.type();
             if (type.isList() || type.isIterable()) {
                 TypeRef arg = type.arg(0);
                 if (arg.isDataModel()) {
                     KeyRef key = p.resolveKey(arg);
-                    dsl.addInput(p.document(), p.name(), arg.mirror(), key, p.reference());
+                    dsl.addInput(p.document(), p.name(), arg.mirror(), key, p.reference(),
+                            CoGroupKindOperatorUtil.getBufferType(p, inputBuffer));
                 } else {
                     p.error(Messages.getString("CoGroupOperatorDriver.errorInputNotDataModelListType")); //$NON-NLS-1$
                 }
@@ -69,7 +70,7 @@ public class CoGroupOperatorDriver implements OperatorDriver {
                 p.error(Messages.getString("CoGroupOperatorDriver.errorParameterUnsupportedType")); //$NON-NLS-1$
             }
         }
-        dsl.addAttribute(dsl.annotation().constant(INPUT_BUFFER));
+        dsl.addAttribute(inputBuffer);
         dsl.requireShuffle();
         return dsl.toDescription();
     }

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/CoGroupOperatorDriver.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/CoGroupOperatorDriver.java
@@ -48,7 +48,7 @@ public class CoGroupOperatorDriver implements OperatorDriver {
         }
         for (ElementRef p : dsl.parameters()) {
             TypeRef type = p.type();
-            if (type.isList()) {
+            if (type.isList() || type.isIterable()) {
                 TypeRef arg = type.arg(0);
                 if (arg.isDataModel()) {
                     KeyRef key = p.resolveKey(arg);

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/DslBuilder.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/DslBuilder.java
@@ -425,11 +425,21 @@ final class DslBuilder {
 
         String name();
 
-        Set<Modifier> modifiers();
+        default Set<Modifier> modifiers() {
+            return Collections.emptySet();
+        }
 
-        KeyRef resolveKey(TypeRef modelType);
+        default AnnotationRef annotation(ClassDescription type) {
+            return null;
+        }
 
-        KeyRef resolveKey(TypeRef modelType, AnnotationMirror annotation);
+        default KeyRef resolveKey(TypeRef modelType) {
+            throw new IllegalStateException();
+        }
+
+        default KeyRef resolveKey(TypeRef modelType, AnnotationMirror annotation) {
+            throw new IllegalStateException();
+        }
 
         void error(String string);
     }
@@ -471,21 +481,6 @@ final class DslBuilder {
         @Override
         public String name() {
             return "MISSING"; //$NON-NLS-1$
-        }
-
-        @Override
-        public Set<Modifier> modifiers() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public KeyRef resolveKey(TypeRef modelType) {
-            throw new IllegalStateException();
-        }
-
-        @Override
-        public KeyRef resolveKey(TypeRef modelType, AnnotationMirror annotation) {
-            throw new IllegalStateException();
         }
 
         @Override
@@ -550,6 +545,19 @@ final class DslBuilder {
         @Override
         public Set<Modifier> modifiers() {
             return element.getModifiers();
+        }
+
+        @Override
+        public AnnotationRef annotation(ClassDescription type) {
+            TypeElement annotationType = environment.findTypeElement(type);
+            if (annotationType == null) {
+                return null;
+            }
+            AnnotationMirror annotation = AnnotationHelper.findAnnotation(environment, annotationType, element);
+            if (annotation == null) {
+                return null;
+            }
+            return new AnnotationRef(element, annotation);
         }
 
         @Override
@@ -627,21 +635,6 @@ final class DslBuilder {
         @Override
         public String name() {
             throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Set<Modifier> modifiers() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public KeyRef resolveKey(TypeRef modelType) {
-            throw new IllegalStateException();
-        }
-
-        @Override
-        public KeyRef resolveKey(TypeRef modelType, AnnotationMirror annotation) {
-            throw new IllegalStateException();
         }
 
         @Override

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/DslBuilder.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/DslBuilder.java
@@ -67,6 +67,8 @@ final class DslBuilder {
             new ClassDescription("com.asakusafw.vocabulary.flow.graph.FlowBoundary"), //$NON-NLS-1$
             "SHUFFLE"); //$NON-NLS-1$
 
+    static final ClassDescription TYPE_ITERABLE = Descriptions.classOf(Iterable.class);
+
     static final ClassDescription TYPE_LIST = Descriptions.classOf(List.class);
 
     static final ClassDescription TYPE_ENUM = Descriptions.classOf(Enum.class);
@@ -665,12 +667,16 @@ final class DslBuilder {
             return types().isSubtype(mirror, environment.findDeclaredType(TYPE_ENUM));
         }
 
+        public boolean isIterable() {
+            return isErasureEqualTo(environment.findDeclaredType(TYPE_ITERABLE));
+        }
+
         public boolean isList() {
-            return types().isSubtype(mirror, environment.findDeclaredType(TYPE_LIST));
+            return isErasureEqualTo(environment.findDeclaredType(TYPE_LIST));
         }
 
         public boolean isResult() {
-            return types().isSubtype(mirror, environment.findDeclaredType(Constants.TYPE_RESULT));
+            return isErasureEqualTo(environment.findDeclaredType(Constants.TYPE_RESULT));
         }
 
         public TypeRef arg(int index) {
@@ -690,6 +696,11 @@ final class DslBuilder {
 
         public boolean isEqualTo(TypeRef other) {
             return types().isSameType(mirror, other.mirror);
+        }
+
+        private boolean isErasureEqualTo(TypeMirror other) {
+            return types().isSameType(environment.getErasure(mirror), environment.getErasure(other));
+
         }
 
         public TypeMirror mirror() {

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/GroupSortOperatorDriver.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/GroupSortOperatorDriver.java
@@ -48,7 +48,7 @@ public class GroupSortOperatorDriver implements OperatorDriver {
         }
         for (ElementRef p : dsl.parameters()) {
             TypeRef type = p.type();
-            if (type.isList()) {
+            if (type.isList() || type.isIterable()) {
                 if (dsl.getInputs().isEmpty()) {
                     TypeRef arg = type.arg(0);
                     if (arg.isDataModel()) {

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/GroupSortOperatorDriver.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/GroupSortOperatorDriver.java
@@ -45,7 +45,7 @@ public class GroupSortOperatorDriver implements OperatorDriver {
         if (dsl.result().type().isVoid() == false) {
             dsl.method().error(Messages.getString("GroupSortOperatorDriver.errorReturnNotVoid")); //$NON-NLS-1$
         }
-        EnumConstantDescription inputBuffer = CoGroupKindOperatorUtil.getInputBuffer(dsl);
+        EnumConstantDescription inputBuffer = GroupKindOperatorUtil.getInputBuffer(dsl);
         for (ElementRef p : dsl.parameters()) {
             TypeRef type = p.type();
             if (type.isList() || type.isIterable()) {
@@ -54,7 +54,7 @@ public class GroupSortOperatorDriver implements OperatorDriver {
                     if (arg.isDataModel()) {
                         KeyRef key = p.resolveKey(arg);
                         dsl.addInput(p.document(), p.name(), arg.mirror(), key, p.reference(),
-                                CoGroupKindOperatorUtil.getBufferType(p, inputBuffer));
+                                GroupKindOperatorUtil.getBufferType(p, inputBuffer));
                     } else {
                         p.error(Messages.getString("GroupSortOperatorDriver.errorInputNotDataModelListType")); //$NON-NLS-1$
                     }

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/GroupSortOperatorDriver.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/GroupSortOperatorDriver.java
@@ -23,14 +23,13 @@ import com.asakusafw.operator.builtin.DslBuilder.ElementRef;
 import com.asakusafw.operator.builtin.DslBuilder.KeyRef;
 import com.asakusafw.operator.builtin.DslBuilder.TypeRef;
 import com.asakusafw.operator.description.ClassDescription;
+import com.asakusafw.operator.description.EnumConstantDescription;
 import com.asakusafw.operator.model.OperatorDescription;
 
 /**
  * {@link OperatorDriver} for {@code GroupSort} annotation.
  */
 public class GroupSortOperatorDriver implements OperatorDriver {
-
-    private static final String INPUT_BUFFER = "inputBuffer"; //$NON-NLS-1$
 
     @Override
     public ClassDescription getAnnotationTypeName() {
@@ -46,6 +45,7 @@ public class GroupSortOperatorDriver implements OperatorDriver {
         if (dsl.result().type().isVoid() == false) {
             dsl.method().error(Messages.getString("GroupSortOperatorDriver.errorReturnNotVoid")); //$NON-NLS-1$
         }
+        EnumConstantDescription inputBuffer = CoGroupKindOperatorUtil.getInputBuffer(dsl);
         for (ElementRef p : dsl.parameters()) {
             TypeRef type = p.type();
             if (type.isList() || type.isIterable()) {
@@ -53,7 +53,8 @@ public class GroupSortOperatorDriver implements OperatorDriver {
                     TypeRef arg = type.arg(0);
                     if (arg.isDataModel()) {
                         KeyRef key = p.resolveKey(arg);
-                        dsl.addInput(p.document(), p.name(), arg.mirror(), key, p.reference());
+                        dsl.addInput(p.document(), p.name(), arg.mirror(), key, p.reference(),
+                                CoGroupKindOperatorUtil.getBufferType(p, inputBuffer));
                     } else {
                         p.error(Messages.getString("GroupSortOperatorDriver.errorInputNotDataModelListType")); //$NON-NLS-1$
                     }
@@ -73,7 +74,7 @@ public class GroupSortOperatorDriver implements OperatorDriver {
                 p.error(Messages.getString("GroupSortOperatorDriver.errorParameterUnsupportedType")); //$NON-NLS-1$
             }
         }
-        dsl.addAttribute(dsl.annotation().constant(INPUT_BUFFER));
+        dsl.addAttribute(inputBuffer);
         dsl.requireShuffle();
         return dsl.toDescription();
     }

--- a/operator/builtin/src/test/java/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.java
+++ b/operator/builtin/src/test/java/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.java
@@ -256,7 +256,7 @@ public class CoGroupOperatorDriverTest extends OperatorDriverTestRoot {
                 Node in2 = description.getInputs().get(2);
                 assertThat(in2.getName(), is("in2"));
                 assertThat(in2.getType(), is(sameType("com.example.Model")));
-                assertThat(in2.getAttributes(), hasItem(Descriptions.valueOf(BufferType.SPILL)));
+                assertThat(in2.getAttributes(), hasItem(Descriptions.valueOf(BufferType.VOLATILE)));
             }
         });
     }

--- a/operator/builtin/src/test/java/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.java
+++ b/operator/builtin/src/test/java/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.java
@@ -219,7 +219,7 @@ public class CoGroupOperatorDriverTest extends OperatorDriverTestRoot {
                 Node in1 = description.getInputs().get(1);
                 assertThat(in1.getName(), is("in1"));
                 assertThat(in1.getType(), is(sameType("com.example.Model")));
-                assertThat(in1.getAttributes(), hasItem(Descriptions.valueOf(BufferType.STORED)));
+                assertThat(in1.getAttributes(), hasItem(Descriptions.valueOf(BufferType.SPILL)));
 
                 Node in2 = description.getInputs().get(2);
                 assertThat(in2.getName(), is("in2"));
@@ -246,17 +246,17 @@ public class CoGroupOperatorDriverTest extends OperatorDriverTestRoot {
                 Node in0 = description.getInputs().get(0);
                 assertThat(in0.getName(), is("in0"));
                 assertThat(in0.getType(), is(sameType("com.example.Model")));
-                assertThat(in0.getAttributes(), hasItem(Descriptions.valueOf(BufferType.STORED)));
+                assertThat(in0.getAttributes(), hasItem(Descriptions.valueOf(BufferType.SPILL)));
 
                 Node in1 = description.getInputs().get(1);
                 assertThat(in1.getName(), is("in1"));
                 assertThat(in1.getType(), is(sameType("com.example.Model")));
-                assertThat(in1.getAttributes(), hasItem(Descriptions.valueOf(BufferType.STORED)));
+                assertThat(in1.getAttributes(), hasItem(Descriptions.valueOf(BufferType.SPILL)));
 
                 Node in2 = description.getInputs().get(2);
                 assertThat(in2.getName(), is("in2"));
                 assertThat(in2.getType(), is(sameType("com.example.Model")));
-                assertThat(in2.getAttributes(), hasItem(Descriptions.valueOf(BufferType.STORED)));
+                assertThat(in2.getAttributes(), hasItem(Descriptions.valueOf(BufferType.SPILL)));
             }
         });
     }

--- a/operator/builtin/src/test/java/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.java
+++ b/operator/builtin/src/test/java/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.java
@@ -172,6 +172,30 @@ public class CoGroupOperatorDriverTest extends OperatorDriverTestRoot {
     }
 
     /**
+     * simple case.
+     */
+    @Test
+    public void with_iterable() {
+        compile(new Action("com.example.WithIterable") {
+            @Override
+            protected void perform(OperatorElement target) {
+                OperatorDescription description = target.getDescription();
+                assertThat(description.getInputs().size(), is(1));
+                assertThat(description.getOutputs().size(), is(1));
+                assertThat(description.getArguments().size(), is(0));
+
+                Node input = description.getInputs().get(0);
+                assertThat(input.getName(), is("in"));
+                assertThat(input.getType(), is(sameType("com.example.Model")));
+
+                Node output = description.getOutputs().get(0);
+                assertThat(output.getName(), is("out"));
+                assertThat(output.getType(), is(sameType("com.example.Proceeded")));
+            }
+        });
+    }
+
+    /**
      * violates method is not abstract.
      */
     @Test

--- a/operator/builtin/src/test/java/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.java
+++ b/operator/builtin/src/test/java/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.java
@@ -29,6 +29,8 @@ import com.asakusafw.operator.description.Descriptions;
 import com.asakusafw.operator.model.OperatorDescription;
 import com.asakusafw.operator.model.OperatorDescription.Node;
 import com.asakusafw.operator.model.OperatorElement;
+import com.asakusafw.vocabulary.attribute.BufferType;
+import com.asakusafw.vocabulary.flow.processor.InputBuffer;
 import com.asakusafw.vocabulary.operator.CoGroup;
 
 /**
@@ -172,7 +174,7 @@ public class CoGroupOperatorDriverTest extends OperatorDriverTestRoot {
     }
 
     /**
-     * simple case.
+     * w/ iterable inputs.
      */
     @Test
     public void with_iterable() {
@@ -191,6 +193,70 @@ public class CoGroupOperatorDriverTest extends OperatorDriverTestRoot {
                 Node output = description.getOutputs().get(0);
                 assertThat(output.getName(), is("out"));
                 assertThat(output.getType(), is(sameType("com.example.Proceeded")));
+            }
+        });
+    }
+
+    /**
+     * w/ buffer types.
+     */
+    @Test
+    public void with_buffer_type() {
+        compile(new Action("com.example.WithBufferType") {
+            @Override
+            protected void perform(OperatorElement target) {
+                OperatorDescription description = target.getDescription();
+                assertThat(description.getInputs().size(), is(3));
+                assertThat(description.getOutputs().size(), is(1));
+                assertThat(description.getArguments().size(), is(0));
+                assertThat(description.getAttributes(), hasItem(Descriptions.valueOf(InputBuffer.EXPAND)));
+
+                Node in0 = description.getInputs().get(0);
+                assertThat(in0.getName(), is("in0"));
+                assertThat(in0.getType(), is(sameType("com.example.Model")));
+                assertThat(in0.getAttributes(), hasItem(Descriptions.valueOf(BufferType.HEAP)));
+
+                Node in1 = description.getInputs().get(1);
+                assertThat(in1.getName(), is("in1"));
+                assertThat(in1.getType(), is(sameType("com.example.Model")));
+                assertThat(in1.getAttributes(), hasItem(Descriptions.valueOf(BufferType.STORED)));
+
+                Node in2 = description.getInputs().get(2);
+                assertThat(in2.getName(), is("in2"));
+                assertThat(in2.getType(), is(sameType("com.example.Model")));
+                assertThat(in2.getAttributes(), hasItem(Descriptions.valueOf(BufferType.VOLATILE)));
+            }
+        });
+    }
+
+    /**
+     * w/ buffer types.
+     */
+    @Test
+    public void with_buffer_type_parent() {
+        compile(new Action("com.example.WithBufferTypeParent") {
+            @Override
+            protected void perform(OperatorElement target) {
+                OperatorDescription description = target.getDescription();
+                assertThat(description.getInputs().size(), is(3));
+                assertThat(description.getOutputs().size(), is(1));
+                assertThat(description.getArguments().size(), is(0));
+                assertThat(description.getAttributes(), hasItem(Descriptions.valueOf(InputBuffer.ESCAPE)));
+
+                Node in0 = description.getInputs().get(0);
+                assertThat(in0.getName(), is("in0"));
+                assertThat(in0.getType(), is(sameType("com.example.Model")));
+                assertThat(in0.getAttributes(), hasItem(Descriptions.valueOf(BufferType.STORED)));
+
+                Node in1 = description.getInputs().get(1);
+                assertThat(in1.getName(), is("in1"));
+                assertThat(in1.getType(), is(sameType("com.example.Model")));
+                assertThat(in1.getAttributes(), hasItem(Descriptions.valueOf(BufferType.STORED)));
+
+                Node in2 = description.getInputs().get(2);
+                assertThat(in2.getName(), is("in2"));
+                assertThat(in2.getType(), is(sameType("com.example.Model")));
+                assertThat(in2.getAttributes(), hasItem(Descriptions.valueOf(BufferType.STORED)));
             }
         });
     }
@@ -313,5 +379,13 @@ public class CoGroupOperatorDriverTest extends OperatorDriverTestRoot {
     @Test
     public void violate_output_before_argument() {
         violate("com.example.ViolateOutputBeforeArgument");
+    }
+
+    /**
+     * violates input w/ "once" must be declared as iterable.
+     */
+    @Test
+    public void violate_input_once_iterable() {
+        violate("com.example.ViolateInputOnceIterable");
     }
 }

--- a/operator/builtin/src/test/java/com/asakusafw/operator/builtin/GroupSortOperatorDriverTest.java
+++ b/operator/builtin/src/test/java/com/asakusafw/operator/builtin/GroupSortOperatorDriverTest.java
@@ -126,6 +126,30 @@ public class GroupSortOperatorDriverTest extends OperatorDriverTestRoot {
     }
 
     /**
+     * w/ iterable input.
+     */
+    @Test
+    public void with_iterable() {
+        compile(new Action("com.example.WithIterable") {
+            @Override
+            protected void perform(OperatorElement target) {
+                OperatorDescription description = target.getDescription();
+                assertThat(description.getInputs().size(), is(1));
+                assertThat(description.getOutputs().size(), is(1));
+                assertThat(description.getArguments().size(), is(0));
+
+                Node input = description.getInputs().get(0);
+                assertThat(input.getName(), is("in"));
+                assertThat(input.getType(), is(sameType("com.example.Model")));
+
+                Node output = description.getOutputs().get(0);
+                assertThat(output.getName(), is("out"));
+                assertThat(output.getType(), is(sameType("com.example.Proceeded")));
+            }
+        });
+    }
+
+    /**
      * w/ type parameters.
      */
     @Test

--- a/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.files/com/example/ViolateInputOnceIterable.java.txt
+++ b/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.files/com/example/ViolateInputOnceIterable.java.txt
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.List;
+import com.asakusafw.runtime.core.Result;
+import com.asakusafw.vocabulary.model.*;
+import com.asakusafw.vocabulary.operator.*;
+
+public abstract class $s {
+
+    @CoGroup
+    public void method(@Key(group = "content") @Once List<Model> in, Result<Proceeded> out) {
+    }
+}

--- a/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.files/com/example/WithBufferType.java.txt
+++ b/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.files/com/example/WithBufferType.java.txt
@@ -1,0 +1,17 @@
+package com.example;
+
+import java.util.List;
+import com.asakusafw.runtime.core.Result;
+import com.asakusafw.vocabulary.model.*;
+import com.asakusafw.vocabulary.operator.*;
+
+public abstract class $s {
+
+    @CoGroup
+    public void method(
+            @Key(group = "content") List<Model> in0,
+            @Key(group = "content") @Spill List<Model> in1,
+            @Key(group = "content") @Once Iterable<Model> in2,
+            Result<Proceeded> out) {
+    }
+}

--- a/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.files/com/example/WithBufferTypeParent.java.txt
+++ b/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.files/com/example/WithBufferTypeParent.java.txt
@@ -1,0 +1,18 @@
+package com.example;
+
+import java.util.List;
+import com.asakusafw.runtime.core.Result;
+import com.asakusafw.vocabulary.flow.processor.*;
+import com.asakusafw.vocabulary.model.*;
+import com.asakusafw.vocabulary.operator.*;
+
+public abstract class $s {
+
+    @CoGroup(inputBuffer=InputBuffer.ESCAPE)
+    public void method(
+            @Key(group = "content") List<Model> in0,
+            @Key(group = "content") @Spill List<Model> in1,
+            @Key(group = "content") @Once Iterable<Model> in2,
+            Result<Proceeded> out) {
+    }
+}

--- a/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.files/com/example/WithIterable.java.txt
+++ b/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.files/com/example/WithIterable.java.txt
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.List;
+import com.asakusafw.runtime.core.Result;
+import com.asakusafw.vocabulary.model.Key;
+import com.asakusafw.vocabulary.operator.*;
+
+public abstract class $s {
+
+    @CoGroup
+    public void method(@Key(group = "content") Iterable<Model> in, Result<Proceeded> out) {
+    }
+}

--- a/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/GroupSortOperatorDriverTest.files/com/example/WithIterable.java.txt
+++ b/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/GroupSortOperatorDriverTest.files/com/example/WithIterable.java.txt
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.List;
+import com.asakusafw.runtime.core.Result;
+import com.asakusafw.vocabulary.model.Key;
+import com.asakusafw.vocabulary.operator.*;
+
+public abstract class $s {
+
+    @GroupSort
+    public void method(@Key(group = "content") Iterable<Model> in, Result<Proceeded> out) {
+    }
+}

--- a/operator/core/src/main/java/com/asakusafw/operator/description/ObjectDescription.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/description/ObjectDescription.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.operator.description;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Represents an object.
+ * @since 0.9.1
+ */
+public class ObjectDescription implements ValueDescription {
+
+    private final ClassDescription objectType;
+
+    private final List<ValueDescription> arguments;
+
+    /**
+     * Creates a new instance.
+     * @param objectType the object type
+     * @param arguments the constructor arguments
+     */
+    public ObjectDescription(ClassDescription objectType, List<? extends ValueDescription> arguments) {
+        this.objectType = objectType;
+        this.arguments = Collections.unmodifiableList(new ArrayList<>(arguments));
+    }
+
+    /**
+     * Creates a new instance.
+     * @param objectType the object type
+     * @param arguments the constructor arguments
+     * @return the created instance
+     */
+    public static ObjectDescription of(ClassDescription objectType, List<? extends ValueDescription> arguments) {
+        return new ObjectDescription(objectType, arguments);
+    }
+
+    /**
+     * Creates a new instance.
+     * @param objectType the object type
+     * @param arguments the constructor arguments
+     * @return the created instance
+     */
+    public static ObjectDescription of(ClassDescription objectType, ValueDescription... arguments) {
+        return new ObjectDescription(objectType, Arrays.asList(arguments));
+    }
+
+    @Override
+    public ValueKind getValueKind() {
+        return ValueKind.OBJECT;
+    }
+
+    @Override
+    public ClassDescription getValueType() {
+        return objectType;
+    }
+
+    /**
+     * Returns the arguments.
+     * @return the arguments
+     */
+    public List<ValueDescription> getArguments() {
+        return arguments;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(objectType);
+        result = prime * result + Objects.hashCode(arguments);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        ObjectDescription other = (ObjectDescription) obj;
+        if (!Objects.equals(objectType, other.objectType)) {
+            return false;
+        }
+        if (!Objects.equals(arguments, other.arguments)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return MessageFormat.format("Object(type={0}, args={1})", //$NON-NLS-1$
+                objectType,
+                arguments);
+    }
+}

--- a/operator/core/src/main/java/com/asakusafw/operator/description/ValueDescription.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/description/ValueDescription.java
@@ -69,6 +69,12 @@ public interface ValueDescription extends Description {
         ARRAY,
 
         /**
+         * instantiated objects.
+         *
+         */
+        OBJECT,
+
+        /**
          * unknown values.
          * @see UnknownValueDescription
          */

--- a/operator/core/src/main/java/com/asakusafw/operator/model/AttributeContainer.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/model/AttributeContainer.java
@@ -13,7 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.asakusafw.operator.model;
+
+import java.util.List;
+
+import com.asakusafw.operator.description.ValueDescription;
+
 /**
- * Provides annotations for data model and operations over data models.
+ * Elements which provides attributes.
+ * @since 0.9.1
  */
-package com.asakusafw.vocabulary.model;
+public interface AttributeContainer {
+    /**
+     * Returns the attributes.
+     * @return the attributes
+     */
+    List<ValueDescription> getAttributes();
+}

--- a/operator/core/src/main/java/com/asakusafw/operator/model/OperatorDescription.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/model/OperatorDescription.java
@@ -29,7 +29,7 @@ import com.asakusafw.operator.description.ValueDescription;
 /**
  * Represents an operator's semantics for Asakusa DSL.
  */
-public class OperatorDescription {
+public class OperatorDescription implements AttributeContainer {
 
     private final Document document;
 
@@ -141,10 +141,7 @@ public class OperatorDescription {
         return results;
     }
 
-    /**
-     * Returns the operator attributes.
-     * @return the operator attributes
-     */
+    @Override
     public List<ValueDescription> getAttributes() {
         return attributes;
     }
@@ -552,7 +549,7 @@ public class OperatorDescription {
      * @since 0.9.0
      * @version 0.9.1
      */
-    public static final class Node {
+    public static final class Node implements AttributeContainer {
 
         private final Kind kind;
 
@@ -673,11 +670,7 @@ public class OperatorDescription {
             return this;
         }
 
-        /**
-         * Returns the attributes.
-         * @return the attributes
-         * @since 0.9.1
-         */
+        @Override
         public List<ValueDescription> getAttributes() {
             return Collections.unmodifiableList(attributes);
         }

--- a/operator/core/src/main/java/com/asakusafw/operator/model/OperatorDescription.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/model/OperatorDescription.java
@@ -24,7 +24,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeMirror;
 
-import com.asakusafw.operator.description.EnumConstantDescription;
+import com.asakusafw.operator.description.ValueDescription;
 
 /**
  * Represents an operator's semantics for Asakusa DSL.
@@ -37,7 +37,7 @@ public class OperatorDescription {
 
     private final List<Node> outputs;
 
-    private final List<EnumConstantDescription> attributes;
+    private final List<ValueDescription> attributes;
 
     private ExecutableElement support;
 
@@ -67,7 +67,7 @@ public class OperatorDescription {
             Document document,
             List<? extends Node> parameters,
             List<? extends Node> outputs,
-            List<? extends EnumConstantDescription> attributes) {
+            List<? extends ValueDescription> attributes) {
         Objects.requireNonNull(document, "document must not be null"); //$NON-NLS-1$
         Objects.requireNonNull(parameters, "parameters must not be null"); //$NON-NLS-1$
         Objects.requireNonNull(outputs, "outputs must not be null"); //$NON-NLS-1$
@@ -145,7 +145,7 @@ public class OperatorDescription {
      * Returns the operator attributes.
      * @return the operator attributes
      */
-    public List<EnumConstantDescription> getAttributes() {
+    public List<ValueDescription> getAttributes() {
         return attributes;
     }
 
@@ -549,6 +549,8 @@ public class OperatorDescription {
 
     /**
      * Represents input/output/argument.
+     * @since 0.9.0
+     * @version 0.9.1
      */
     public static final class Node {
 
@@ -565,6 +567,8 @@ public class OperatorDescription {
         private volatile KeyMirror key;
 
         private volatile ExternMirror extern;
+
+        private final List<ValueDescription> attributes = new ArrayList<>();
 
         /**
          * Creates a new instance.
@@ -657,6 +661,25 @@ public class OperatorDescription {
          */
         public ExternMirror getExtern() {
             return extern;
+        }
+
+        /**
+         * Adds an attribute.
+         * @param attribute the attribute
+         * @return this
+         */
+        public Node withAttribute(ValueDescription attribute) {
+            this.attributes.add(attribute);
+            return this;
+        }
+
+        /**
+         * Returns the attributes.
+         * @return the attributes
+         * @since 0.9.1
+         */
+        public List<ValueDescription> getAttributes() {
+            return Collections.unmodifiableList(attributes);
         }
 
         @Override

--- a/operator/core/src/main/java/com/asakusafw/operator/util/ElementHelper.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/util/ElementHelper.java
@@ -430,11 +430,17 @@ public final class ElementHelper {
                 method = "defineInput"; //$NON-NLS-1$
                 arguments.add(Models.toLiteral(f, node.getName()));
                 arguments.add(f.newSimpleName(node.getName()));
+                for (ValueDescription attribute : node.getAttributes()) {
+                    arguments.add(DescriptionHelper.resolveValue(imports, attribute));
+                }
                 break;
             case OUTPUT:
                 method = "defineOutput"; //$NON-NLS-1$
                 arguments.add(Models.toLiteral(f, node.getName()));
                 arguments.add(resolveOutputType(environment, imports, node, element));
+                for (ValueDescription attribute : node.getAttributes()) {
+                    arguments.add(DescriptionHelper.resolveValue(imports, attribute));
+                }
                 break;
             case DATA:
                 method = "defineData"; //$NON-NLS-1$
@@ -460,9 +466,9 @@ public final class ElementHelper {
             }
             statements.add(builder.toStatement());
         }
-        for (EnumConstantDescription attribute : element.getDescription().getAttributes()) {
+        for (ValueDescription attribute : element.getDescription().getAttributes()) {
             statements.add(new ExpressionBuilder(f, builderExpression)
-                    .method("defineAttribute", DescriptionHelper.resolveConstant(imports, attribute)) //$NON-NLS-1$
+                    .method("defineAttribute", DescriptionHelper.resolveValue(imports, attribute)) //$NON-NLS-1$
                     .toStatement());
         }
         if (element.getDescription().getSupport() != null) {

--- a/operator/core/src/test/java/com/asakusafw/operator/Callback.java
+++ b/operator/core/src/test/java/com/asakusafw/operator/Callback.java
@@ -284,6 +284,8 @@ public abstract class Callback {
             @Override
             public boolean matches(Object item) {
                 return ((OperatorElement) item).getDescription().getAttributes().stream()
+                        .filter(EnumConstantDescription.class::isInstance)
+                        .map(EnumConstantDescription.class::cast)
                         .map(EnumConstantDescription::getDeclaringClass)
                         .anyMatch(Predicate.isEqual(type));
             }

--- a/operator/core/src/test/java/com/asakusafw/operator/method/MockAttribute.java
+++ b/operator/core/src/test/java/com/asakusafw/operator/method/MockAttribute.java
@@ -13,26 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.vocabulary.attribute;
+package com.asakusafw.operator.method;
+
+import com.asakusafw.vocabulary.attribute.Attribute;
 
 /**
- * Represents a buffer type of inputs.
- * @since 0.9.1
+ * Mock {@link Attribute}.
  */
-public enum BufferType implements Attribute {
+public enum MockAttribute implements Attribute {
 
     /**
-     * Allocates a buffer onto the Java heap, and keeps all elements on it.
+     * OK.
      */
-    HEAP,
-
-    /**
-     * Allocates a buffer onto the Java heap and temporary files.
-     */
-    SPILL,
-
-    /**
-     * Does not allocate buffer space.
-     */
-    VOLATILE,
+    OK,
 }


### PR DESCRIPTION
## Summary

This PR enhances operator graph models to keep custom attributes in their inputs/outputs.

## Background, Problem or Goal of the patch

The latest implementation, operator inputs/outputs cannot have any custom attributes.

## Design of the fix, or a new feature

This includes the following enhancements:
* the new operator DSL compiler now can handle custom attributes on the operator inputs/outputs
* the new operator DSL compiler now can accept complex attributes other than enum constants
*  `@CoGroup` and `@GroupSort` operator methods now can have `Iterable` inputs
* the new operator DSL compiler now can accept annotations `@Once` and `@Spill` in  `@CoGroup` and `@GroupSort` operator inputs
  * `@Once` - elements in the operator input must be read only once, which input must be declared as `Iterable` instead of `List`
  * `@Spill` - the input list of the operator may be spill the elements into temporary files (like as `InputBuffer.ESCAPE` for the individual inputs)
  * introduced `BufferType` constants for operator input attributes to handle the above annotations
  * the legacy operator compiler just ignores the above annotations, but accepts `Iterable` inputs

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 