### PR TITLE
Add utility methods for StringOption.

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/value/StringOption.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/value/StringOption.java
@@ -125,9 +125,7 @@ public final class StringOption extends ValueOption<StringOption> {
      * Returns the value which this object represents.
      * @param alternate the alternative value for {@code null}
      * @return the value which this object represents, or the alternative one if this object represents {@code null}
-     * @deprecated Use {@link #or(String)} instead
      */
-    @Deprecated
     public Text or(Text alternate) {
         if (nullValue) {
             return alternate;
@@ -273,9 +271,7 @@ public final class StringOption extends ValueOption<StringOption> {
      * Returns whether both this object and the specified value represents an equivalent value or not.
      * @param other the target value (nullable)
      * @return {@code true} if this object has the specified value, otherwise {@code false}
-     * @deprecated Use {@link #equals(Object)} instead
      */
-    @Deprecated
     public boolean has(Text other) {
         if (isNull()) {
             return other == null;

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/value/StringOptionUtil.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/value/StringOptionUtil.java
@@ -17,7 +17,14 @@ package com.asakusafw.runtime.value;
 
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.hadoop.io.InputBuffer;
@@ -26,6 +33,7 @@ import org.apache.hadoop.io.Text;
 /**
  * Utilities for {@link StringOption}.
  * @since 0.8.0
+ * @version 0.9.1
  */
 public final class StringOptionUtil {
 
@@ -34,8 +42,54 @@ public final class StringOptionUtil {
      */
     public static final Charset ENCODING = StandardCharsets.UTF_8;
 
+    static final ThreadLocal<DecoderBuffer> DECODER_POOL = ThreadLocal.withInitial(DecoderBuffer::new);
+
+    private static final ThreadLocal<char[]> CHAR_ARRAY_BUFFERS = ThreadLocal.withInitial(() -> new char[512]);
+
+    private static final int CHAR_ARRAY_PADDING = 16;
+
     private StringOptionUtil() {
         return;
+    }
+
+    /**
+     * Returns the number of code-points in the given {@link StringOption}.
+     * If the object does represent neither {@code null} nor a valid character string, this operation may raise an
+     * error or return a wrong count.
+     * @param option the target object
+     * @return the number of code-points in this object, or {@code 0} if the object represents {@code null}
+     * @throws NullPointerException if the {@link StringOption} is/represents {@code null}
+     * @since 0.9.1
+     */
+    public static int countCodePoints(StringOption option) {
+        Text text = option.get();
+        byte[] bytes = text.getBytes();
+        int len = text.getLength();
+        int index = 0;
+        int count = 0;
+        while (index < len) {
+            byte b = bytes[index];
+            if ((b & 0b1000_0000) == 0) {
+                index += 1;
+            } else if ((b & 0b1110_0000) == 0b1100_0000) {
+                index += 2;
+            } else if ((b & 0b1111_0000) == 0b1110_0000) {
+                index += 3;
+            } else if ((b & 0b1111_1000) == 0b1111_0000) {
+                index += 4;
+            } else if ((b & 0b1111_1100) == 0b1111_1000) {
+                index += 5;
+            } else if ((b & 0b1111_1110) == 0b1111_1100) {
+                index += 6;
+            } else {
+                break;
+            }
+            count++;
+        }
+        if (index != len) {
+            throw new IllegalStateException(option.toString());
+        }
+        return count;
     }
 
     /**
@@ -125,5 +179,181 @@ public final class StringOptionUtil {
 
     private static void append(StringOption target, Text text) {
         target.get().append(text.getBytes(), 0, text.getLength());
+    }
+
+    /**
+     * Appends the text in the given {@link StringOption} into the {@link StringBuilder}.
+     * @param target the append target
+     * @param contents the text contents to be appended
+     * @throws NullPointerException if the {@link StringOption} is/represents {@code null}
+     * @since 0.9.1
+     */
+    public static void append(StringBuilder target, StringOption contents) {
+        CharBuffer buffer = DECODER_POOL.get().decode(contents.get());
+        target.append(buffer);
+    }
+
+    /**
+     * Parses the given {@link StringOption} which may represent a {@code int} value.
+     * @param contents the text contents
+     * @return the parsed value
+     * @throws NullPointerException if the {@link StringOption} is/represents {@code null}
+     * @throws IllegalArgumentException if the character sequence is wrong
+     * @since 0.9.1
+     */
+    public static int parseInt(StringOption contents) {
+        CharBuffer buffer = DECODER_POOL.get().decode(contents.get());
+        if (buffer.hasRemaining() == false) {
+            throw invalidNumber(contents);
+        }
+        boolean negative = false;
+        char first = buffer.get(0);
+        if (first < '0') {
+            if (first == '+') {
+                buffer.get();
+            } else if (first == '-') {
+                buffer.get();
+                negative = true;
+            }
+        }
+        int negativeResult = 0;
+        while (buffer.hasRemaining()) {
+            char c = buffer.get();
+            int column = Character.digit(c, 10);
+            if (column < 0) {
+                throw invalidNumber(contents);
+            }
+            negativeResult *= 10;
+            // check overflow
+            if (negativeResult < (Integer.MIN_VALUE | column)) {
+                throw invalidNumber(contents);
+            }
+            negativeResult -= column;
+        }
+        if (negative) {
+            return negativeResult;
+        } else {
+            if (negativeResult == Integer.MIN_VALUE) {
+                throw invalidNumber(contents);
+            }
+            return -negativeResult;
+        }
+    }
+
+    /**
+     * Parses the given {@link StringOption} which may represent a {@code long} value.
+     * @param contents the text contents
+     * @return the parsed value
+     * @throws NullPointerException if the {@link StringOption} is/represents {@code null}
+     * @throws IllegalArgumentException if the character sequence is wrong
+     * @since 0.9.1
+     */
+    public static long parseLong(StringOption contents) {
+        CharBuffer buffer = DECODER_POOL.get().decode(contents.get());
+        if (buffer.hasRemaining() == false) {
+            throw invalidNumber(contents);
+        }
+        boolean negative = false;
+        char first = buffer.get(0);
+        if (first < '0') {
+            if (first == '+') {
+                buffer.get();
+            } else if (first == '-') {
+                buffer.get();
+                negative = true;
+            }
+        }
+        long negativeResult = 0;
+        while (buffer.hasRemaining()) {
+            char c = buffer.get();
+            int column = Character.digit(c, 10);
+            if (column < 0) {
+                throw invalidNumber(contents);
+            }
+            negativeResult *= 10;
+            // check overflow
+            if (negativeResult < (Long.MIN_VALUE | column)) {
+                throw invalidNumber(contents);
+            }
+            negativeResult -= column;
+        }
+        if (negative) {
+            return negativeResult;
+        } else {
+            if (negativeResult == Long.MIN_VALUE) {
+                throw invalidNumber(contents);
+            }
+            return -negativeResult;
+        }
+    }
+
+    /**
+     * Parses the given {@link StringOption} which may represent a decimal value.
+     * @param contents the text contents
+     * @return the parsed decimal value
+     * @throws NullPointerException if the {@link StringOption} is/represents {@code null}
+     * @throws IllegalArgumentException if the character sequence is wrong
+     * @since 0.9.1
+     */
+    public static BigDecimal parseDecimal(StringOption contents) {
+        CharBuffer buffer = DECODER_POOL.get().decode(contents.get());
+        if (buffer.hasRemaining() == false) {
+            throw invalidNumber(contents);
+        }
+        int length = buffer.remaining();
+        if (buffer.hasArray()) {
+            char[] array = buffer.array();
+            int offsetInArray = buffer.position() + buffer.arrayOffset();
+            return new BigDecimal(array, offsetInArray, length);
+        } else {
+            char[] cbuf = borrowCharArrayBuf(length);
+            buffer.get(cbuf, 0, length);
+            return new BigDecimal(cbuf, 0, length);
+        }
+    }
+
+    private static NumberFormatException invalidNumber(StringOption contents) {
+        return new NumberFormatException(contents.toString());
+    }
+
+    private static char[] borrowCharArrayBuf(int length) {
+        char[] cs = CHAR_ARRAY_BUFFERS.get();
+        if (cs.length < length) {
+            cs = new char[Math.max(length, cs.length + CHAR_ARRAY_PADDING)];
+            CHAR_ARRAY_BUFFERS.set(cs);
+        }
+        return cs;
+    }
+
+    private static final class DecoderBuffer {
+
+        private final CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT);
+
+        private CharBuffer charBuffer;
+
+        DecoderBuffer() {
+            return;
+        }
+
+        CharBuffer decode(Text text) {
+            if (charBuffer == null || charBuffer.capacity() < text.getLength() * 2) {
+                int newCapacity = Math.max(1024, (int) (text.getLength() * 2.5));
+                charBuffer = CharBuffer.allocate(newCapacity);
+            }
+            charBuffer.clear();
+            ByteBuffer bytes = ByteBuffer.wrap(text.getBytes(), 0, text.getLength());
+            CoderResult result = decoder.decode(bytes, charBuffer, true);
+            if (result.isOverflow() || result.isError()) {
+                try {
+                    result.throwException();
+                } catch (CharacterCodingException e) {
+                    throw new IllegalArgumentException(e);
+                }
+            }
+            charBuffer.flip();
+            return charBuffer;
+        }
     }
 }

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/value/ValueOption.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/value/ValueOption.java
@@ -22,7 +22,7 @@ import com.asakusafw.runtime.io.util.WritableRawComparable;
  * Note that, the sub-classes may be thread unsafe.
  * @param <V> self type
  * @since 0.1.0
- * @version 0.2.5
+ * @version 0.9.1
  */
 public abstract class ValueOption<V extends ValueOption<V>> implements WritableRawComparable, Restorable {
 
@@ -40,6 +40,15 @@ public abstract class ValueOption<V extends ValueOption<V>> implements WritableR
     }
 
     /**
+     * Returns whether this object has any value or not.
+     * @return {@code true} if this object DOES NOT represent {@code null}, otherwise {@code false}
+     * @since 0.9.1
+     */
+    public final boolean isPresent() {
+        return nullValue == false;
+    }
+
+    /**
      * Makes this value represent {@code null}.
      * @deprecated Application developer should not use this method directly
      * @return this
@@ -48,6 +57,20 @@ public abstract class ValueOption<V extends ValueOption<V>> implements WritableR
     public final ValueOption<V> setNull() {
         this.nullValue = true;
         return this;
+    }
+
+    /**
+     * Returns the given value if this represents {@code null}.
+     * @param other the target value which will be returned if this object represents {@code null}
+     * @return the given value if this represents {@code null}, otherwise this
+     * @since 0.9.1
+     */
+    @SuppressWarnings("unchecked")
+    public final V orOption(V other) {
+        if (nullValue) {
+            return other;
+        }
+        return (V) this;
     }
 
     /**

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/value/StringOptionTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/value/StringOptionTest.java
@@ -18,6 +18,9 @@ package com.asakusafw.runtime.value;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
+
 import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
@@ -308,5 +311,123 @@ public class StringOptionTest extends ValueOptionTestRoot {
         StringOption option = new StringOption();
         StringOption restored = restore(option);
         assertThat(restored.isNull(), is(true));
+    }
+
+    /**
+     * is empty.
+     */
+    @Test
+    public void is_empty() {
+        npe(() -> new StringOption().isEmpty());
+        assertThat(new StringOption("").isEmpty(), is(true));
+        assertThat(new StringOption("Hello, world!").isEmpty(), is(false));
+        assertThat(new StringOption(" ").isEmpty(), is(false));
+    }
+
+    /**
+     * appendTo.
+     */
+    @Test
+    public void appendTo() {
+        npe(() -> new StringOption().appendTo(new StringBuilder()));
+        Consumer<String> tester = s -> {
+            String r = new StringOption(s).appendTo(new StringBuilder("<")).append(">").toString();
+            assertThat(r, is("<" + s + ">"));
+        };
+        tester.accept("");
+        tester.accept("a");
+        tester.accept("Hello, world!");
+        tester.accept(HELLO_JP);
+    }
+
+    /**
+     * contains.
+     */
+    @Test
+    public void contains() {
+        npe(() -> new StringOption().contains("a"));
+        npe(() -> new StringOption().contains(new StringOption("a")));
+        npe(() -> new StringOption("a").contains(new StringOption()));
+
+        BiPredicate<String, String> tester = (string, sub) -> {
+            StringOption opt = new StringOption(string);
+            boolean b0 = opt.contains(sub);
+            boolean b1 = opt.contains(new StringOption(sub));
+            assertThat(b0, is(b1));
+            return b0;
+        };
+        assertThat(tester.test("Hello", "Hello"), is(true));
+        assertThat(tester.test("Hello", ""), is(true));
+        assertThat(tester.test("Hello, world!", "a"), is(false));
+        assertThat(tester.test("Hello, world!", "Hello"), is(true));
+        assertThat(tester.test("Hello, world!", "world!"), is(true));
+        assertThat(tester.test("Hello, world!", "ello"), is(true));
+        assertThat(tester.test("Hello", "Hello, world!"), is(false));
+        assertThat(tester.test("Hello, world!", "Hello!"), is(false));
+        assertThat(tester.test("Hello, world!", "world?"), is(false));
+        assertThat(tester.test("Hello, world!", "Hello, world?"), is(false));
+    }
+
+    /**
+     * startsWith.
+     */
+    @Test
+    public void startsWith() {
+        npe(() -> new StringOption().startsWith("a"));
+        npe(() -> new StringOption().startsWith(new StringOption("a")));
+        npe(() -> new StringOption("a").startsWith(new StringOption()));
+
+        BiPredicate<String, String> tester = (string, prefix) -> {
+            StringOption opt = new StringOption(string);
+            boolean b0 = opt.startsWith(prefix);
+            boolean b1 = opt.startsWith(new StringOption(prefix));
+            assertThat(b0, is(b1));
+            return b0;
+        };
+        assertThat(tester.test("Hello", "Hello"), is(true));
+        assertThat(tester.test("Hello", ""), is(true));
+        assertThat(tester.test("Hello, world!", "a"), is(false));
+        assertThat(tester.test("Hello, world!", "Hello"), is(true));
+        assertThat(tester.test("Hello, world!", "world!"), is(false));
+        assertThat(tester.test("Hello", "Hello, world!"), is(false));
+        assertThat(tester.test("Hello, world!", "Hello!"), is(false));
+        assertThat(tester.test("Hello, world!", "world?"), is(false));
+        assertThat(tester.test("Hello, world!", "Hello, world?"), is(false));
+    }
+
+    /**
+     * endsWith.
+     */
+    @Test
+    public void endsWith() {
+        npe(() -> new StringOption().endsWith("a"));
+        npe(() -> new StringOption().endsWith(new StringOption("a")));
+        npe(() -> new StringOption("a").endsWith(new StringOption()));
+
+        BiPredicate<String, String> tester = (string, prefix) -> {
+            StringOption opt = new StringOption(string);
+            boolean b0 = opt.endsWith(prefix);
+            boolean b1 = opt.endsWith(new StringOption(prefix));
+            assertThat(b0, is(b1));
+            return b0;
+        };
+        assertThat(tester.test("Hello", "Hello"), is(true));
+        assertThat(tester.test("Hello", ""), is(true));
+        assertThat(tester.test("Hello, world!", "a"), is(false));
+        assertThat(tester.test("Hello, world!", "Hello"), is(false));
+        assertThat(tester.test("Hello, world!", "world!"), is(true));
+        assertThat(tester.test("Hello", "Hello, world!"), is(false));
+        assertThat(tester.test("Hello, world!", "Hello!"), is(false));
+        assertThat(tester.test("Hello, world!", "world?"), is(false));
+        assertThat(tester.test("Hello, world!", "Hello, world?"), is(false));
+    }
+
+    private static void npe(Runnable r) {
+        try {
+            r.run();
+            fail();
+        } catch (NullPointerException e) {
+            // ok.
+        }
     }
 }


### PR DESCRIPTION
## Summary

This PR introduces some utility methods about `StringOption`.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

This introduces the following new methods:
* `ValueOption<V <: ValueOption<V>>`
  * `isPresent() : boolean`
  * `orOption(V) : V`
* `StringOption`
  * `isEmpty() : boolean`
  * `contains({String, StringOption}) : boolean`
  * `startsWith({String, StringOption}) : boolean`
  * `endsWith({String, StringOption}) : boolean`
  * `appendTo(StringBuilder) : StringBuilder`
* `StringOptionUtil`
  * `countCodePoints() : int`
  * `parseInt(StringOption) : int`
  * `parseLong(StringOption) : long`
  * `parseDecimal(StringOption) : BigDecimal`

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 