### PR TITLE
Fix artifact id of JFlex Maven Plugin

### DIFF
--- a/dmdl-project/asakusa-dmdl-core/pom.xml
+++ b/dmdl-project/asakusa-dmdl-core/pom.xml
@@ -15,7 +15,7 @@
     <plugins>
       <plugin>
         <groupId>de.jflex</groupId>
-        <artifactId>maven-jflex-plugin</artifactId>
+        <artifactId>jflex-maven-plugin</artifactId>
         <executions>
           <execution>
             <goals>

--- a/utils-project/java-dom/pom.xml
+++ b/utils-project/java-dom/pom.xml
@@ -15,7 +15,7 @@
     <plugins>
       <plugin>
         <groupId>de.jflex</groupId>
-        <artifactId>maven-jflex-plugin</artifactId>
+        <artifactId>jflex-maven-plugin</artifactId>
         <executions>
           <execution>
             <goals>

--- a/utils-project/javadoc-parser/pom.xml
+++ b/utils-project/javadoc-parser/pom.xml
@@ -17,7 +17,7 @@
     <plugins>
       <plugin>
         <groupId>de.jflex</groupId>
-        <artifactId>maven-jflex-plugin</artifactId>
+        <artifactId>jflex-maven-plugin</artifactId>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
## Summary
This PR fixes artifact id of JFlex Maven Plugin in pom.xml of some projects.

This plugin's id was previously `maven-jflex-plugin` but `jflex-maven-plugin` is current artifact id
 (see: http://jflex.sourceforge.net/jflex-maven-plugin ).

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.

## Wanted reviewer
N/A.
