### PR TITLE
Enable Direct I/O `DataFormat` for test inputs.

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/BinaryStreamFormat.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/BinaryStreamFormat.java
@@ -27,8 +27,28 @@ import com.asakusafw.runtime.io.ModelOutput;
  * This implementation class must have a public constructor without any parameters.
  * @param <T> the type of target data model
  * @since 0.2.5
+ * @version 0.9.1
  */
 public abstract class BinaryStreamFormat<T> implements FragmentableDataFormat<T> {
+
+    /**
+     * Creates a new {@link ModelInput} for the specified properties.
+     * @param dataType the target data type
+     * @param path the path about the target stream (for label)
+     * @param stream the target stream
+     * @return the created reader
+     * @throws IOException if failed to create reader
+     * @throws InterruptedException if interrupted
+     * @throws IllegalArgumentException if this does not support target property sequence,
+     *     or any parameter is {@code null}
+     * @since 0.9.1
+     */
+    public ModelInput<T> createInput(
+            Class<? extends T> dataType,
+            String path,
+            InputStream stream) throws IOException, InterruptedException {
+        return createInput(dataType, path, stream, 0L, -1L);
+    }
 
     /**
      * Creates a new {@link ModelInput} for the specified properties.

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/hadoop/HadoopDataSourceUtil.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/hadoop/HadoopDataSourceUtil.java
@@ -61,7 +61,9 @@ import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.jboss.netty.util.internal.ConcurrentHashMap;
 
 import com.asakusafw.runtime.directio.AbstractDirectDataSource;
+import com.asakusafw.runtime.directio.BinaryStreamFormat;
 import com.asakusafw.runtime.directio.Counter;
+import com.asakusafw.runtime.directio.DataFormat;
 import com.asakusafw.runtime.directio.DirectDataSource;
 import com.asakusafw.runtime.directio.DirectDataSourceProfile;
 import com.asakusafw.runtime.directio.DirectDataSourceProvider;
@@ -78,7 +80,7 @@ import com.asakusafw.runtime.stage.output.BridgeOutputFormat;
 /**
  * Utilities for Direct data access facilities on Hadoop.
  * @since 0.2.5
- * @version 0.9.0
+ * @version 0.9.1
  */
 public final class HadoopDataSourceUtil {
 
@@ -1095,6 +1097,36 @@ public final class HadoopDataSourceUtil {
         }
         Collections.sort(results);
         return results;
+    }
+
+    /**
+     * Converts {@link DataFormat} into an equivalent {@link HadoopFileFormat}.
+     * @param <T> the data type
+     * @param configuration the current configuration
+     * @param format the target data format
+     * @return the related format
+     * @throws IOException if the given {@link DataFormat} is not supported
+     * @since 0.9.1
+     */
+    public static <T> HadoopFileFormat<T> toHadoopFileFormat(
+            Configuration configuration, DataFormat<T> format) throws IOException {
+        assert format != null;
+        if (format instanceof HadoopFileFormat<?>) {
+            return (HadoopFileFormat<T>) format;
+        } else {
+            return new HadoopFileFormatAdapter<>(validateBinaryStreamFormat(format), configuration);
+        }
+    }
+
+    private static <T> BinaryStreamFormat<T> validateBinaryStreamFormat(DataFormat<T> format) throws IOException {
+        assert format != null;
+        if ((format instanceof BinaryStreamFormat<?>) == false) {
+            throw new IOException(MessageFormat.format(
+                    "{1} must be a subtype of {0}",
+                    BinaryStreamFormat.class.getName(),
+                    format.getClass().getName()));
+        }
+        return (BinaryStreamFormat<T>) format;
     }
 
     private HadoopDataSourceUtil() {

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/hadoop/HadoopFileFormat.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/hadoop/HadoopFileFormat.java
@@ -34,6 +34,7 @@ import com.asakusafw.runtime.io.ModelOutput;
  * This implementation class must have a public constructor without any parameters.
  * @param <T> the type of target data model
  * @since 0.2.6
+ * @version 0.9.1
  */
 public abstract class HadoopFileFormat<T> extends Configured implements FragmentableDataFormat<T> {
 
@@ -50,6 +51,27 @@ public abstract class HadoopFileFormat<T> extends Configured implements Fragment
      */
     public HadoopFileFormat(Configuration conf) {
         super(conf);
+    }
+
+    /**
+     * Creates a new {@link ModelInput} for the specified properties.
+     * @param dataType the target data type
+     * @param fileSystem the file system to open the target path
+     * @param path the path to the target file
+     * @param counter the current counter
+     * @return the created reader
+     * @throws IOException if failed to create reader
+     * @throws InterruptedException if interrupted
+     * @throws IllegalArgumentException if this does not support target property sequence,
+     *     or any parameter is {@code null}
+     * @since 0.9.1
+     */
+    public ModelInput<T> createInput(
+            Class<? extends T> dataType,
+            FileSystem fileSystem,
+            Path path,
+            Counter counter) throws IOException, InterruptedException {
+        return createInput(dataType, fileSystem, path, 0L, -1L, counter);
     }
 
     /**

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/csv/driver/CsvFormatEmitter.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/csv/driver/CsvFormatEmitter.java
@@ -433,24 +433,26 @@ public class CsvFormatEmitter extends JavaDataModelDriver {
             }
 
             SimpleName fragmentInput = f.newSimpleName("fragmentInput"); //$NON-NLS-1$
-            statements.add(f.newLocalVariableDeclaration(
-                    context.resolve(InputStream.class),
-                    fragmentInput,
-                    null));
             if (isFastMode()) {
-                statements.add(new ExpressionBuilder(f, fragmentInput)
-                    .assignFrom(new TypeBuilder(f, context.resolve(DelimiterRangeInputStream.class))
+                statements.add(new TypeBuilder(f, context.resolve(DelimiterRangeInputStream.class))
                         .newObject(
                                 blessInputStream(stream),
                                 Models.toLiteral(f, '\n'),
-                                fragmentSize,
+                                f.newConditionalExpression(
+                                        f.newInfixExpression(
+                                                fragmentSize,
+                                                InfixOperator.GREATER_EQUALS,
+                                                Models.toLiteral(f, 0L)),
+                                        fragmentSize,
+                                        new TypeBuilder(f, context.resolve(Long.class))
+                                            .field("MAX_VALUE") //$NON-NLS-1$
+                                            .toExpression()),
                                 isNotHead)
-                        .toExpression())
-                    .toStatement());
+                        .toLocalVariableDeclaration(context.resolve(InputStream.class), fragmentInput));
             } else {
                 statements.add(new ExpressionBuilder(f, fragmentInput)
-                    .assignFrom(blessInputStream(stream))
-                    .toStatement());
+                        .assignFrom(blessInputStream(stream))
+                        .toLocalVariableDeclaration(context.resolve(InputStream.class), fragmentInput));
             }
 
             SimpleName parser = f.newSimpleName("parser"); //$NON-NLS-1$

--- a/hive-project/asakusa-hive-core/src/main/java/com/asakusafw/directio/hive/orc/AbstractOrcFileFormat.java
+++ b/hive-project/asakusa-hive-core/src/main/java/com/asakusafw/directio/hive/orc/AbstractOrcFileFormat.java
@@ -181,10 +181,15 @@ public abstract class AbstractOrcFileFormat<T> extends HadoopFileFormat<T>
         if (conf.getOnIncompatibleType() != null) {
             driverConf.setOnIncompatibleType(conf.getOnIncompatibleType());
         }
+        long size = fragmentSize;
+        if (size < 0L) {
+            FileStatus stat = fileSystem.getFileStatus(path);
+            size = stat.getLen();
+        }
         return new OrcFileInput<>(
                 getDataModelDescriptor(), driverConf,
                 fileSystem, path,
-                offset, fragmentSize, counter);
+                offset, size, counter);
     }
 
     @Override

--- a/hive-project/asakusa-hive-core/src/main/java/com/asakusafw/directio/hive/orc/OrcFileInput.java
+++ b/hive-project/asakusa-hive-core/src/main/java/com/asakusafw/directio/hive/orc/OrcFileInput.java
@@ -74,7 +74,7 @@ public class OrcFileInput<T> implements ModelInput<T> {
      * @param fileSystem the file system to open the target path
      * @param path the path to the target file
      * @param offset starting stream offset
-     * @param fragmentSize suggested fragment bytes count, or {@code -1} as infinite
+     * @param fragmentSize suggested fragment bytes count
      * @param counter the current counter
      */
     public OrcFileInput(
@@ -92,7 +92,7 @@ public class OrcFileInput<T> implements ModelInput<T> {
      * @param fileSystem the file system to open the target path
      * @param path the path to the target file
      * @param offset starting stream offset
-     * @param fragmentSize suggested fragment bytes count, or {@code -1} as infinite
+     * @param fragmentSize suggested fragment bytes count
      * @param counter the current counter
      */
     public OrcFileInput(

--- a/hive-project/asakusa-hive-core/src/main/java/com/asakusafw/directio/hive/parquet/AbstractParquetFileFormat.java
+++ b/hive-project/asakusa-hive-core/src/main/java/com/asakusafw/directio/hive/parquet/AbstractParquetFileFormat.java
@@ -186,11 +186,16 @@ public abstract class AbstractParquetFileFormat<T> extends HadoopFileFormat<T>
         if (conf.getOnIncompatibleType() != null) {
             driverConf.setOnIncompatibleType(conf.getOnIncompatibleType());
         }
+        long size = fragmentSize;
+        if (size < 0L) {
+            FileStatus stat = fileSystem.getFileStatus(path);
+            size = stat.getLen();
+        }
         return new ParquetFileInput<>(
                 getDataModelDescriptor(),
                 driverConf,
                 getConf(), path,
-                offset, fragmentSize,
+                offset, size,
                 counter);
     }
 

--- a/hive-project/asakusa-hive-core/src/main/java/com/asakusafw/directio/hive/parquet/ParquetFileInput.java
+++ b/hive-project/asakusa-hive-core/src/main/java/com/asakusafw/directio/hive/parquet/ParquetFileInput.java
@@ -85,7 +85,7 @@ public class ParquetFileInput<T> implements ModelInput<T> {
      * @param hadoopConfiguration the hadoop configuration
      * @param path the path to the target file
      * @param offset starting stream offset
-     * @param fragmentSize suggested fragment bytes count, or {@code -1} as infinite
+     * @param fragmentSize suggested fragment bytes count
      * @param counter the current counter
      */
     public ParquetFileInput(

--- a/sandbox-project/asakusa-directio-dmdl-ext/src/main/java/com/asakusafw/dmdl/directio/tsv/driver/TsvFormatEmitter.java
+++ b/sandbox-project/asakusa-directio-dmdl-ext/src/main/java/com/asakusafw/dmdl/directio/tsv/driver/TsvFormatEmitter.java
@@ -320,24 +320,26 @@ public class TsvFormatEmitter extends JavaDataModelDriver {
             }
 
             SimpleName fragmentInput = f.newSimpleName("fragmentInput"); //$NON-NLS-1$
-            statements.add(f.newLocalVariableDeclaration(
-                    context.resolve(InputStream.class),
-                    fragmentInput,
-                    null));
             if (isFastMode()) {
-                statements.add(new ExpressionBuilder(f, fragmentInput)
-                    .assignFrom(new TypeBuilder(f, context.resolve(DelimiterRangeInputStream.class))
+                statements.add(new TypeBuilder(f, context.resolve(DelimiterRangeInputStream.class))
                         .newObject(
                                 blessInputStream(stream),
                                 Models.toLiteral(f, '\n'),
-                                fragmentSize,
+                                f.newConditionalExpression(
+                                        f.newInfixExpression(
+                                                fragmentSize,
+                                                InfixOperator.GREATER_EQUALS,
+                                                Models.toLiteral(f, 0L)),
+                                        fragmentSize,
+                                        new TypeBuilder(f, context.resolve(Long.class))
+                                            .field("MAX_VALUE") //$NON-NLS-1$
+                                            .toExpression()),
                                 isNotHead)
-                        .toExpression())
-                    .toStatement());
+                        .toLocalVariableDeclaration(context.resolve(InputStream.class), fragmentInput));
             } else {
                 statements.add(new ExpressionBuilder(f, fragmentInput)
-                    .assignFrom(blessInputStream(stream))
-                    .toStatement());
+                        .assignFrom(blessInputStream(stream))
+                        .toLocalVariableDeclaration(context.resolve(InputStream.class), fragmentInput));
             }
 
             if (conf.isEnableHeader()) {

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/DirectIoUtil.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/DirectIoUtil.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.testdriver;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configurable;
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.runtime.directio.BinaryStreamFormat;
+import com.asakusafw.runtime.directio.Counter;
+import com.asakusafw.runtime.directio.DataFormat;
+import com.asakusafw.runtime.directio.hadoop.HadoopDataSourceUtil;
+import com.asakusafw.runtime.directio.hadoop.HadoopFileFormat;
+import com.asakusafw.runtime.io.ModelInput;
+import com.asakusafw.testdriver.core.DataModelDefinition;
+import com.asakusafw.testdriver.core.DataModelReflection;
+import com.asakusafw.testdriver.core.DataModelSource;
+import com.asakusafw.testdriver.core.DataModelSourceFactory;
+import com.asakusafw.testdriver.core.IteratorDataModelSource;
+import com.asakusafw.testdriver.core.TestContext;
+
+final class DirectIoUtil {
+
+    static final Logger LOG = LoggerFactory.getLogger(DirectIoUtil.class);
+
+    private DirectIoUtil() {
+        return;
+    }
+
+    static <T> DataModelSourceFactory load(
+            Configuration configuration,
+            DataModelDefinition<T> definition,
+            Class<? extends DataFormat<?>> formatClass,
+            URL source) throws IOException, InterruptedException {
+        DataFormat<? super T> format = newDataFormat(configuration, formatClass);
+        if (format.getSupportedType().isAssignableFrom(definition.getModelClass()) == false) {
+            throw new IllegalArgumentException();
+        }
+        return load(configuration, definition, format, source);
+    }
+
+    static <T> DataModelSourceFactory load(
+            Configuration configuration,
+            DataModelDefinition<T> definition,
+            Class<? extends DataFormat<?>> formatClass,
+            File source) throws IOException, InterruptedException {
+        DataFormat<? super T> format = newDataFormat(configuration, formatClass);
+        if (format.getSupportedType().isAssignableFrom(definition.getModelClass()) == false) {
+            throw new IllegalArgumentException();
+        }
+        return load(configuration, definition, format, source);
+    }
+
+    private static <T> DataModelSourceFactory load(
+            Configuration configuration,
+            DataModelDefinition<T> definition,
+            DataFormat<? super T> format,
+            File source) throws IOException, InterruptedException {
+        if (format instanceof BinaryStreamFormat<?>) {
+            return load0(definition, (BinaryStreamFormat<? super T>) format, source);
+        }
+        HadoopFileFormat<? super T> hFormat = HadoopDataSourceUtil.toHadoopFileFormat(configuration, format);
+        return load0(definition, hFormat, source);
+    }
+
+    private static <T> DataModelSourceFactory load(
+            Configuration configuration,
+            DataModelDefinition<T> definition,
+            DataFormat<? super T> format,
+            URL source) throws IOException, InterruptedException {
+        if (source.getProtocol().equals("file")) { //$NON-NLS-1$
+            File file = null;
+            try {
+                file = new File(source.toURI());
+            } catch (URISyntaxException e) {
+                LOG.debug("failed to convert URL into local file path: {}", source, e); //$NON-NLS-1$
+            }
+            if (file != null) {
+                return load(configuration, definition, format, file);
+            }
+        }
+        if (format instanceof BinaryStreamFormat<?>) {
+            return load0(definition, (BinaryStreamFormat<? super T>) format, source);
+        }
+        HadoopFileFormat<? super T> hFormat = HadoopDataSourceUtil.toHadoopFileFormat(configuration, format);
+        return load0(definition, hFormat, source);
+    }
+
+    private static <T> DataFormat<T> newDataFormat(
+            Configuration configuration,
+            Class<? extends DataFormat<?>> formatClass) {
+        try {
+            @SuppressWarnings("unchecked")
+            DataFormat<T> format = (DataFormat<T>) formatClass.newInstance();
+            if (format instanceof Configurable) {
+                ((Configurable) format).setConf(configuration);
+            }
+            return format;
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static <T> DataModelSourceFactory load0(
+            DataModelDefinition<T> definition,
+            BinaryStreamFormat<? super T> format,
+            File source) throws IOException, InterruptedException {
+        String path = source.toURI().toString();
+        try (InputStream stream = new FileInputStream(source);
+                ModelInput<? super T> input = format.createInput(definition.getModelClass(), path, stream)) {
+            return collect(definition, input);
+        }
+    }
+
+    private static <T> DataModelSourceFactory load0(
+            DataModelDefinition<T> definition,
+            HadoopFileFormat<? super T> format,
+            File source) throws IOException, InterruptedException {
+        try (ModelInput<? super T> input = format.createInput(
+                definition.getModelClass(),
+                org.apache.hadoop.fs.FileSystem.getLocal(format.getConf()),
+                new org.apache.hadoop.fs.Path(source.toURI()),
+                new Counter())) {
+            return collect(definition, input);
+        }
+    }
+
+    private static <T> DataModelSourceFactory load0(
+            DataModelDefinition<T> definition,
+            BinaryStreamFormat<? super T> format,
+            URL source) throws IOException, InterruptedException {
+        String path = source.toString();
+        try (InputStream stream = source.openStream();
+                ModelInput<? super T> input = format.createInput(definition.getModelClass(), path, stream)) {
+            return collect(definition, input);
+        }
+    }
+
+    private static <T> DataModelSourceFactory load0(
+            DataModelDefinition<T> definition,
+            HadoopFileFormat<? super T> format,
+            URL source) throws IOException, InterruptedException {
+        List<String> segments = Arrays.stream(source.getPath().split("/")) //$NON-NLS-1$
+                .map(String::trim)
+                .filter(s -> s.isEmpty() == false)
+                .collect(Collectors.toList());
+        String name;
+        if (segments.isEmpty()) {
+            name = "testing.file"; //$NON-NLS-1$
+        } else {
+            name = segments.get(segments.size() - 1);
+        }
+        Path tmpdir = Files.createTempDirectory("asakusa-"); //$NON-NLS-1$
+        try (InputStream in = source.openStream()) {
+            Path target = tmpdir.resolve(name);
+            Files.copy(in, target);
+            return load0(definition, format, target.toFile());
+        } finally {
+            File dir = tmpdir.toFile();
+            if (FileUtils.deleteQuietly(dir) == false && dir.exists()) {
+                LOG.warn(MessageFormat.format(
+                        "failed to delete a temporary file: {0}",
+                        tmpdir));
+            }
+        }
+    }
+
+    private static <T> DataModelSourceFactory collect(
+            DataModelDefinition<T> definition,
+            ModelInput<? super T> input) throws IOException {
+        List<DataModelReflection> loaded = new ArrayList<>();
+        T object = newDataObject(definition);
+        while (input.readTo(object)) {
+            DataModelReflection ref = definition.toReflection(object);
+            loaded.add(ref);
+        }
+        return new DataModelSourceFactory() {
+            @Override
+            public <U> DataModelSource createSource(DataModelDefinition<U> def, TestContext context) {
+                return new IteratorDataModelSource(loaded.iterator());
+            }
+        };
+    }
+
+    private static <T> T newDataObject(DataModelDefinition<T> definition) {
+        try {
+            return definition.getModelClass().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/FlowDriverInput.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/FlowDriverInput.java
@@ -15,9 +15,13 @@
  */
 package com.asakusafw.testdriver;
 
+import java.io.File;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.asakusafw.runtime.directio.DataFormat;
+import com.asakusafw.testdriver.core.DataModelDefinition;
 import com.asakusafw.testdriver.core.DataModelSourceFactory;
 import com.asakusafw.testdriver.core.TestDataToolProvider;
 import com.asakusafw.utils.io.Provider;
@@ -29,6 +33,7 @@ import com.asakusafw.utils.io.Source;
  * @param <T> the input data model type
  * @param <S> the implementation class type
  * @since 0.6.0
+ * @version 0.9.1
  */
 public abstract class FlowDriverInput<T, S extends FlowDriverInput<T, S>> extends DriverInputBase<T> {
 
@@ -108,5 +113,33 @@ public abstract class FlowDriverInput<T, S extends FlowDriverInput<T, S>> extend
             throw new IllegalArgumentException("objects must not be null"); //$NON-NLS-1$
         }
         return prepare(toDataModelSourceFactory(provider));
+    }
+
+    /**
+     * Sets the test data set for this input.
+     * Note that, the original source path may be changed if tracking source file name.
+     * To keep the source file path information, please use {@link #prepare(Class, File)} instead.
+     * @param formatClass the data format class
+     * @param sourcePath the input file path on the class path
+     * @return this
+     * @throws IllegalArgumentException if the source is not valid for the given data format
+     * @since 0.9.1
+     */
+    public S prepare(Class<? extends DataFormat<? super T>> formatClass, String sourcePath) {
+        DataModelDefinition<T> definition = getDataModelDefinition();
+        return prepare(toDataModelSourceFactory(definition, formatClass, sourcePath));
+    }
+
+    /**
+     * Sets the test data set for this input.
+     * @param formatClass the data format class
+     * @param sourceFile the input file
+     * @return this
+     * @throws IllegalArgumentException if the source is not valid for the given data format
+     * @since 0.9.1
+     */
+    public S prepare(Class<? extends DataFormat<? super T>> formatClass, File sourceFile) {
+        DataModelDefinition<T> definition = getDataModelDefinition();
+        return prepare(toDataModelSourceFactory(definition, formatClass, sourceFile));
     }
 }

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/FlowDriverOutput.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/FlowDriverOutput.java
@@ -20,6 +20,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.UnaryOperator;
 
+import com.asakusafw.runtime.directio.DataFormat;
+import com.asakusafw.testdriver.core.DataModelDefinition;
 import com.asakusafw.testdriver.core.DataModelSinkFactory;
 import com.asakusafw.testdriver.core.DataModelSource;
 import com.asakusafw.testdriver.core.DataModelSourceFactory;
@@ -38,7 +40,7 @@ import com.asakusafw.utils.io.Source;
  * @param <T> the output data model type
  * @param <S> the implementation class type
  * @since 0.6.0
- * @version 0.7.0
+ * @version 0.9.1
  */
 public abstract class FlowDriverOutput<T, S extends FlowDriverOutput<T, S>> extends DriverOutputBase<T> {
 
@@ -170,6 +172,34 @@ public abstract class FlowDriverOutput<T, S extends FlowDriverOutput<T, S>> exte
             throw new IllegalArgumentException("provider must not be null"); //$NON-NLS-1$
         }
         return prepare(toDataModelSourceFactory(provider));
+    }
+
+    /**
+     * Sets the test data set for this input.
+     * Note that, the original source path may be changed if tracking source file name.
+     * To keep the source file path information, please use {@link #prepare(Class, File)} instead.
+     * @param formatClass the data format class
+     * @param sourcePath the input file path on the class path
+     * @return this
+     * @throws IllegalArgumentException if the source is not valid for the given data format
+     * @since 0.9.1
+     */
+    public S prepare(Class<? extends DataFormat<? super T>> formatClass, String sourcePath) {
+        DataModelDefinition<T> definition = getDataModelDefinition();
+        return prepare(toDataModelSourceFactory(definition, formatClass, sourcePath));
+    }
+
+    /**
+     * Sets the test data set for this input.
+     * @param formatClass the data format class
+     * @param sourceFile the input file
+     * @return this
+     * @throws IllegalArgumentException if the source is not valid for the given data format
+     * @since 0.9.1
+     */
+    public S prepare(Class<? extends DataFormat<? super T>> formatClass, File sourceFile) {
+        DataModelDefinition<T> definition = getDataModelDefinition();
+        return prepare(toDataModelSourceFactory(definition, formatClass, sourceFile));
     }
 
     /**

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/OperatorTestEnvironment.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/OperatorTestEnvironment.java
@@ -15,6 +15,7 @@
  */
 package com.asakusafw.testdriver;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.text.MessageFormat;
@@ -29,6 +30,7 @@ import org.junit.runners.model.Statement;
 
 import com.asakusafw.runtime.core.BatchContext;
 import com.asakusafw.runtime.core.Report;
+import com.asakusafw.runtime.directio.DataFormat;
 import com.asakusafw.runtime.flow.RuntimeResourceManager;
 import com.asakusafw.runtime.stage.StageConstants;
 import com.asakusafw.runtime.util.VariableTable;
@@ -325,6 +327,36 @@ public class OperatorTestEnvironment extends DriverElementBase implements TestRu
     public <T> DataLoader<T> loader(Class<T> dataType, Provider<? extends Source<? extends T>> provider) {
         Objects.requireNonNull(provider);
         return loader(dataType, toDataModelSourceFactory(provider));
+    }
+
+    /**
+     * Returns a new data loader.
+     * Note that, the original source path may be changed if tracking source file name.
+     * To keep the source file path information, please use {@link #loader(Class, Class, File)} instead.
+     * @param <T> the data type
+     * @param dataType the data type
+     * @param formatClass the data format class
+     * @param sourcePath the input file path on the class path
+     * @return the created loader
+     * @since 0.9.1
+     */
+    public <T> DataLoader<T> loader(
+            Class<T> dataType, Class<? extends DataFormat<? super T>> formatClass, String sourcePath) {
+        return loader(dataType, toDataModelSourceFactory(toDataModelDefinition(dataType), formatClass, sourcePath));
+    }
+
+    /**
+     * Returns a new data loader.
+     * @param <T> the data type
+     * @param dataType the data type
+     * @param formatClass the data format class
+     * @param file the input file path on the class path
+     * @return the created loader
+     * @since 0.9.1
+     */
+    public <T> DataLoader<T> loader(
+            Class<T> dataType, Class<? extends DataFormat<? super T>> formatClass, File file) {
+        return loader(dataType, toDataModelSourceFactory(toDataModelDefinition(dataType), formatClass, file));
     }
 
     /**

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/DirectIoUtilTest.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/DirectIoUtilTest.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.testdriver;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assume;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.asakusafw.runtime.windows.WindowsSupport;
+import com.asakusafw.testdriver.core.DataModelDefinition;
+import com.asakusafw.testdriver.core.DataModelReflection;
+import com.asakusafw.testdriver.core.DataModelSource;
+import com.asakusafw.testdriver.core.DataModelSourceFactory;
+import com.asakusafw.testdriver.core.TestContext;
+import com.asakusafw.testdriver.model.DefaultDataModelDefinition;
+import com.asakusafw.testdriver.testing.dsl.SimpleFileFormat;
+import com.asakusafw.testdriver.testing.dsl.SimpleStreamFormat;
+import com.asakusafw.testdriver.testing.model.Simple;
+
+/**
+ * Test for {@code DirectIoUtil}.
+ */
+public class DirectIoUtilTest {
+
+    /**
+     * Windows platform support.
+     */
+    @ClassRule
+    public static final WindowsSupport WINDOWS_SUPPORT = new WindowsSupport(true);
+
+    /**
+     * temporary folder.
+     */
+    @Rule
+    public final TemporaryFolder temporary = new TemporaryFolder();
+
+    static final DataModelDefinition<Simple> DEF = new DefaultDataModelDefinition<>(Simple.class);
+
+    /**
+     * stream - from file.
+     * @throws Exception if failed
+     */
+    @Test
+    public void stream_file() throws Exception {
+        File f = asFile("directio/simple.txt");
+        List<String> results = extract(DirectIoUtil.load(new Configuration(), DEF, SimpleStreamFormat.class, f));
+        assertThat(results, containsInAnyOrder("Hello, world!"));
+    }
+
+    /**
+     * file - from file.
+     * @throws Exception if failed
+     */
+    @Test
+    public void file_file() throws Exception {
+        File f = asFile("directio/simple.txt");
+        List<String> results = extract(DirectIoUtil.load(new Configuration(), DEF, SimpleFileFormat.class, f));
+        assertThat(results, containsInAnyOrder("Hello, world!"));
+    }
+
+    /**
+     * stream - from file URL.
+     * @throws Exception if failed
+     */
+    @Test
+    public void stream_fileUrl() throws Exception {
+        URL f = asFileUrl("directio/simple.txt");
+        List<String> results = extract(DirectIoUtil.load(new Configuration(), DEF, SimpleStreamFormat.class, f));
+        assertThat(results, containsInAnyOrder("Hello, world!"));
+    }
+
+    /**
+     * file - from file URL.
+     * @throws Exception if failed
+     */
+    @Test
+    public void file_fileUrl() throws Exception {
+        URL f = asFileUrl("directio/simple.txt");
+        List<String> results = extract(DirectIoUtil.load(new Configuration(), DEF, SimpleFileFormat.class, f));
+        assertThat(results, containsInAnyOrder("Hello, world!"));
+    }
+
+    /**
+     * stream - from Jar entry.
+     * @throws Exception if failed
+     */
+    @Test
+    public void stream_jarUrl() throws Exception {
+        URL f = asJarUrl("directio/simple.txt");
+        List<String> results = extract(DirectIoUtil.load(new Configuration(), DEF, SimpleStreamFormat.class, f));
+        assertThat(results, containsInAnyOrder("Hello, world!"));
+    }
+
+    /**
+     * file - from Jar entry.
+     * @throws Exception if failed
+     */
+    @Test
+    public void file_jarUrl() throws Exception {
+        URL f = asJarUrl("directio/simple.txt");
+        List<String> results = extract(DirectIoUtil.load(new Configuration(), DEF, SimpleFileFormat.class, f));
+        assertThat(results, containsInAnyOrder("Hello, world!"));
+    }
+
+    private File asFile(String name) {
+        URL url = getClass().getResource(name);
+        assertThat(url, is(notNullValue()));
+        try {
+            return new File(url.toURI());
+        } catch (URISyntaxException e) {
+            Assume.assumeNoException(e);
+            throw new AssertionError(e);
+        }
+    }
+
+    private URL asFileUrl(String name) {
+        File f = asFile(name);
+        try {
+            return f.toURI().toURL();
+        } catch (MalformedURLException e) {
+            Assume.assumeNoException(e);
+            throw new AssertionError(e);
+        }
+    }
+
+    private URL asJarUrl(String name) throws IOException {
+        URL url = getClass().getResource(name);
+        assertThat(url, is(notNullValue()));
+        File target = temporary.newFile();
+        try (ZipOutputStream output = new ZipOutputStream(new FileOutputStream(target));
+                InputStream input = url.openStream()) {
+            output.putNextEntry(new ZipEntry("root"));
+            IOUtils.copy(input, output);
+        }
+        try {
+            String normalized = target.toURI().toASCIIString();
+            URL nested = new URL("jar", null, normalized + "!/root");
+            nested.openStream().close();
+            return nested;
+        } catch (Exception e) {
+            Assume.assumeNoException(e);
+            throw new AssertionError(e);
+        }
+    }
+
+    private static List<String> extract(DataModelSourceFactory input) throws IOException {
+        List<String> results = new ArrayList<>();
+        try (DataModelSource source = input.createSource(DEF, new TestContext.Empty())) {
+            while (true) {
+                DataModelReflection ref = source.next();
+                if (ref == null) {
+                    break;
+                }
+                results.add(DEF.toObject(ref).getValueAsString());
+            }
+        }
+        return results;
+    }
+}

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/FlowDriverInputTest.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/FlowDriverInputTest.java
@@ -21,22 +21,24 @@ import static org.junit.Assert.*;
 
 import java.net.URI;
 
+import org.apache.hadoop.io.Text;
 import org.junit.Test;
 
 import com.asakusafw.testdriver.core.DataModelSourceFactory;
+import com.asakusafw.testdriver.testing.dsl.SimpleStreamFormat;
+import com.asakusafw.testdriver.testing.model.Simple;
 import com.asakusafw.utils.io.Provider;
 
 /**
  * Test for {@link FlowDriverInput}.
  */
 public class FlowDriverInputTest {
-
     /**
      * simple test for {@link FlowDriverInput#prepare(java.lang.String)}.
      */
     @Test
     public void prepare_uri() {
-        MockFlowDriverInput mock = new MockFlowDriverInput(getClass(), new MockTestDataToolProvider() {
+        MockFlowDriverInput<?> mock = MockFlowDriverInput.text(getClass(), new MockTestDataToolProvider() {
             @Override
             public DataModelSourceFactory getDataModelSourceFactory(URI uri) {
                 assertThat(uri.toString(), endsWith("data/dummy"));
@@ -51,7 +53,7 @@ public class FlowDriverInputTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void prepare_uri_missing() {
-        new MockFlowDriverInput(getClass(), new MockTestDataToolProvider()).prepare("data/__MISSING__");
+        new MockFlowDriverInput<>(getClass(), Text.class, provider()).prepare("data/__MISSING__");
     }
 
     /**
@@ -59,7 +61,7 @@ public class FlowDriverInputTest {
      */
     @Test
     public void prepare_factory() {
-        MockFlowDriverInput mock = new MockFlowDriverInput(getClass(), new MockTestDataToolProvider())
+        MockFlowDriverInput<?> mock = MockFlowDriverInput.text(getClass(), provider())
             .prepare(factory("Hello1", "Hello2"));
         verify(mock.getSource(), DEFINITION, list("Hello1", "Hello2"));
     }
@@ -69,7 +71,7 @@ public class FlowDriverInputTest {
      */
     @Test
     public void prepare_collection() {
-        MockFlowDriverInput mock = new MockFlowDriverInput(getClass(), new MockTestDataToolProvider())
+        MockFlowDriverInput<?> mock = MockFlowDriverInput.text(getClass(), provider())
             .prepare(list("Hello1", "Hello2"));
         verify(mock.getSource(), DEFINITION, list("Hello1", "Hello2"));
     }
@@ -79,8 +81,28 @@ public class FlowDriverInputTest {
      */
     @Test
     public void prepare_iterator() {
-        MockFlowDriverInput mock = new MockFlowDriverInput(getClass(), new MockTestDataToolProvider())
+        MockFlowDriverInput<?> mock = MockFlowDriverInput.text(getClass(), provider())
             .prepare(provider("Hello1", "Hello2"));
         verify(mock.getSource(), DEFINITION, list("Hello1", "Hello2"));
+    }
+
+    /**
+     * simple test for {@link FlowDriverInput#prepare(Class, String)}.
+     */
+    @Test
+    public void prepare_directio_path() {
+        MockFlowDriverInput<?> mock = new MockFlowDriverInput<>(getClass(), Simple.class, provider())
+                .prepare(SimpleStreamFormat.class, "directio/simple.txt");
+        verify(mock.getSource(), DEFINITION, list("Hello, world!"));
+    }
+
+    /**
+     * simple test for {@link FlowDriverInput#prepare(Class, java.io.File)}.
+     */
+    @Test
+    public void prepare_directio_file() {
+        MockFlowDriverInput<?> mock = new MockFlowDriverInput<>(getClass(), Simple.class, provider())
+                .prepare(SimpleStreamFormat.class, asFile("directio/simple.txt"));
+        verify(mock.getSource(), DEFINITION, list("Hello, world!"));
     }
 }

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/FlowDriverPortTestHelper.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/FlowDriverPortTestHelper.java
@@ -18,7 +18,10 @@ package com.asakusafw.testdriver;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -26,6 +29,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.hadoop.io.Text;
+import org.junit.Assume;
 
 import com.asakusafw.testdriver.core.DataModelDefinition;
 import com.asakusafw.testdriver.core.DataModelReflection;
@@ -43,6 +47,10 @@ final class FlowDriverPortTestHelper {
     static final MockTextDefinition DEFINITION = new MockTextDefinition();
 
     static final TestContext.Empty CONTEXT = new TestContext.Empty();
+
+    static MockTestDataToolProvider provider() {
+        return new MockTestDataToolProvider();
+    }
 
     static List<Text> list(String... texts) {
         List<Text> results = new ArrayList<>();
@@ -71,6 +79,18 @@ final class FlowDriverPortTestHelper {
 
     static DataModelSourceFactory factory(String... texts) {
         return new SourceDataModelSourceFactory(provider(texts));
+    }
+
+
+    static File asFile(String name) {
+        URL url = FlowDriverPortTestHelper.class.getResource(name);
+        assertThat(url, is(notNullValue()));
+        try {
+            return new File(url.toURI());
+        } catch (URISyntaxException e) {
+            Assume.assumeNoException(e);
+            throw new AssertionError(e);
+        }
     }
 
     static <T> void verify(DataModelSourceFactory target, DataModelDefinition<T> def, Collection<T> expected) {

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/MockFlowDriverInput.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/MockFlowDriverInput.java
@@ -19,20 +19,32 @@ import org.apache.hadoop.io.Text;
 
 /**
  * Mock implementation of {@link FlowDriverInput}.
+ * @param <T> the data type
  */
-public class MockFlowDriverInput extends FlowDriverInput<Text, MockFlowDriverInput> {
+public class MockFlowDriverInput<T> extends FlowDriverInput<T, MockFlowDriverInput<T>> {
+
+    /**
+     * Creates a new instance.
+     * @param callerClass the current context class
+     * @param dataType the data type
+     * @param testTools the test tools
+     */
+    public MockFlowDriverInput(Class<?> callerClass, Class<T> dataType, MockTestDataToolProvider testTools) {
+        super(callerClass, testTools, "mock", dataType);
+    }
 
     /**
      * Creates a new instance.
      * @param callerClass the current context class
      * @param testTools the test tools
+     * @return the created instance
      */
-    public MockFlowDriverInput(Class<?> callerClass, MockTestDataToolProvider testTools) {
-        super(callerClass, testTools, "mock", Text.class);
+    public static MockFlowDriverInput<Text> text(Class<?> callerClass, MockTestDataToolProvider testTools) {
+        return new MockFlowDriverInput<>(callerClass, Text.class, testTools);
     }
 
     @Override
-    protected MockFlowDriverInput getThis() {
+    protected MockFlowDriverInput<T> getThis() {
         return this;
     }
 }

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/MockFlowDriverOutput.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/MockFlowDriverOutput.java
@@ -19,20 +19,32 @@ import org.apache.hadoop.io.Text;
 
 /**
  * Mock implementation of {@link FlowDriverOutput}.
+ * @param <T> the data type
  */
-public class MockFlowDriverOutput extends FlowDriverOutput<Text, MockFlowDriverOutput> {
+public class MockFlowDriverOutput<T> extends FlowDriverOutput<T, MockFlowDriverOutput<T>> {
+
+    /**
+     * Creates a new instance.
+     * @param callerClass the current context class
+     * @param dataType the data type
+     * @param testTools the test tools
+     */
+    public MockFlowDriverOutput(Class<?> callerClass, Class<T> dataType, MockTestDataToolProvider testTools) {
+        super(callerClass, testTools, "mock", dataType);
+    }
 
     /**
      * Creates a new instance.
      * @param callerClass the current context class
      * @param testTools the test tools
+     * @return the created instance
      */
-    public MockFlowDriverOutput(Class<?> callerClass, MockTestDataToolProvider testTools) {
-        super(callerClass, testTools, "mock", Text.class);
+    public static MockFlowDriverOutput<Text> text(Class<?> callerClass, MockTestDataToolProvider testTools) {
+        return new MockFlowDriverOutput<>(callerClass, Text.class, testTools);
     }
 
     @Override
-    protected MockFlowDriverOutput getThis() {
+    protected MockFlowDriverOutput<T> getThis() {
         return this;
     }
 }

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/MockTestDataToolProvider.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/MockTestDataToolProvider.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.hadoop.io.Text;
 
+import com.asakusafw.runtime.model.DataModel;
 import com.asakusafw.testdriver.core.AbstractTestDataToolProvider;
 import com.asakusafw.testdriver.core.DataModelDefinition;
 import com.asakusafw.testdriver.core.DataModelSinkFactory;
@@ -28,6 +29,7 @@ import com.asakusafw.testdriver.core.DataModelSourceFactory;
 import com.asakusafw.testdriver.core.DifferenceSinkFactory;
 import com.asakusafw.testdriver.core.TestRule;
 import com.asakusafw.testdriver.core.VerifyRuleFactory;
+import com.asakusafw.testdriver.model.DefaultDataModelDefinition;
 
 /**
  * Mock implementation of {@link AbstractTestDataToolProvider}.
@@ -37,6 +39,9 @@ public class MockTestDataToolProvider extends AbstractTestDataToolProvider {
     @SuppressWarnings("unchecked")
     @Override
     public <T> DataModelDefinition<T> toDataModelDefinition(Class<T> dataModelClass) throws IOException {
+        if (DataModel.class.isAssignableFrom(dataModelClass)) {
+            return new DefaultDataModelDefinition<>(dataModelClass);
+        }
         if (dataModelClass != Text.class) {
             throw new IOException();
         }

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/OperatorTestEnvironmentTest.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/OperatorTestEnvironmentTest.java
@@ -18,7 +18,9 @@ package com.asakusafw.testdriver;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -31,6 +33,7 @@ import com.asakusafw.runtime.core.Report;
 import com.asakusafw.runtime.core.Report.Level;
 import com.asakusafw.runtime.core.ResourceConfiguration;
 import com.asakusafw.runtime.flow.RuntimeResourceManager;
+import com.asakusafw.testdriver.testing.dsl.SimpleStreamFormat;
 import com.asakusafw.testdriver.testing.model.Simple;
 
 /**
@@ -124,6 +127,47 @@ public class OperatorTestEnvironmentTest {
             List<Simple> list = env.loader(Simple.class, "data/simple-in.json")
                     .asList();
             assertThat(list, is(simples("This is a test")));
+        } finally {
+            env.after();
+        }
+    }
+
+    /**
+     * loader w/ directio path.
+     * @throws Throwable if failed
+     */
+    @Test
+    public void loader_directio_path() throws Throwable {
+        OperatorTestEnvironment env = new OperatorTestEnvironment(getFilePath("simple.xml")).reset(getClass());
+        env.before();
+        try {
+            List<Simple> list = env.loader(Simple.class, SimpleStreamFormat.class, "directio/simple.txt")
+                    .asList();
+            assertThat(list, is(simples("Hello, world!")));
+        } finally {
+            env.after();
+        }
+    }
+
+    /**
+     * loader w/ directio file.
+     * @throws Throwable if failed
+     */
+    @Test
+    public void loader_directio_file() throws Throwable {
+        File file;
+        try {
+            file = new File(getClass().getResource("directio/simple.txt").toURI());
+        } catch (URISyntaxException e) {
+            Assume.assumeNoException(e);
+            throw new AssertionError(e);
+        }
+        OperatorTestEnvironment env = new OperatorTestEnvironment(getFilePath("simple.xml")).reset(getClass());
+        env.before();
+        try {
+            List<Simple> list = env.loader(Simple.class, SimpleStreamFormat.class, file)
+                    .asList();
+            assertThat(list, is(simples("Hello, world!")));
         } finally {
             env.after();
         }

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/testing/dsl/SimpleFileFormat.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/testing/dsl/SimpleFileFormat.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.testdriver.testing.dsl;
+
+import com.asakusafw.runtime.directio.hadoop.HadoopFileFormatAdapter;
+import com.asakusafw.testdriver.testing.model.Simple;
+
+/**
+ * A simple file format of {@link Simple}.
+ */
+public class SimpleFileFormat extends HadoopFileFormatAdapter<Simple> {
+
+    /**
+     * Creates a new instance.
+     */
+    public SimpleFileFormat() {
+        super(new SimpleStreamFormat());
+    }
+}

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/testing/dsl/SimpleStreamFormat.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/testing/dsl/SimpleStreamFormat.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.testdriver.testing.dsl;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+
+import com.asakusafw.runtime.directio.BinaryStreamFormat;
+import com.asakusafw.runtime.io.ModelInput;
+import com.asakusafw.runtime.io.ModelOutput;
+import com.asakusafw.testdriver.testing.model.Simple;
+
+/**
+ * A simple stream format.
+ */
+public class SimpleStreamFormat extends BinaryStreamFormat<Simple> {
+
+    @Override
+    public Class<Simple> getSupportedType() {
+        return Simple.class;
+    }
+
+    @Override
+    public ModelInput<Simple> createInput(
+            Class<? extends Simple> dataType,
+            String path,
+            InputStream stream,
+            long offset, long fragmentSize) throws IOException, InterruptedException {
+        if (offset != 0) {
+            throw new IllegalArgumentException();
+        }
+        Scanner scanner = new Scanner(new InputStreamReader(stream, StandardCharsets.UTF_8));
+        return new ModelInput<Simple>() {
+            @Override
+            public boolean readTo(Simple model) throws IOException {
+                if (scanner.hasNextLine()) {
+                    model.setValueAsString(scanner.nextLine());
+                    return true;
+                }
+                return false;
+            }
+            @Override
+            public void close() throws IOException {
+                scanner.close();
+            }
+        };
+    }
+
+    @Override
+    public ModelOutput<Simple> createOutput(
+            Class<? extends Simple> dataType,
+            String path,
+            OutputStream stream) throws IOException, InterruptedException {
+        PrintWriter writer = new PrintWriter(new OutputStreamWriter(stream, StandardCharsets.UTF_8));
+        return new ModelOutput<Simple>() {
+            @Override
+            public void write(Simple model) throws IOException {
+                writer.print(model.getValueAsString());
+            }
+            @Override
+            public void close() throws IOException {
+                writer.close();
+            }
+        };
+    }
+
+}

--- a/testing-project/asakusa-test-driver/src/test/resources/com/asakusafw/testdriver/directio/simple.txt
+++ b/testing-project/asakusa-test-driver/src/test/resources/com/asakusafw/testdriver/directio/simple.txt
@@ -1,0 +1,1 @@
+Hello, world!


### PR DESCRIPTION
## Summary

This PR enables Direct I/O `DataFormat` for test inputs.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

This introduces the following new methods:

* `{FlowPart,JobFlow}Driver{Input,Output}<T>`
  * `prepare(Class<? extends DataFormat<? super T>> formatClass, File sourceFile)`
    * load the given file
  * `prepare(Class<? extends DataFormat<? super T>> formatClass, String sourcePath)`
    * load a file on the classpath (relative from the test class)
* `OperatorTestEnvironment`
  * `loader(Class<T> dataType, Class<? extends DataFormat<? super T>> formatClass, File file)`
    * load the given file
  * `loader(Class<T> dataType, Class<? extends DataFormat<? super T>> formatClass, String path)`
    * load a file on the classpath (relative from the test class)

Note that, the "file name" may be changed if the given source path is type of `String`, so that use `File` instead if file path affects the tests (e.g. the data format has `@directio.*.file_name` field).

## Related Issue, Pull Request or Code

* #700 (`OperatorTestEnvironment.loader()`)

## Wanted reviewer

@akirakw 