### PR TITLE
Introduce attribute value map syntax into DMDL.

### DIFF
--- a/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/model/AstAttributeValueMap.java
+++ b/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/model/AstAttributeValueMap.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dmdl.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.asakusafw.dmdl.Region;
+
+/**
+ * Represents a map of string to attribute values.
+ * @since 0.9.1
+ */
+public class AstAttributeValueMap extends AbstractAstNode implements AstAttributeValue {
+
+    private final Region region;
+
+    /**
+     * Entries in this map.
+     */
+    public final List<Entry> entries;
+
+    /**
+     * Creates and returns a new instance.
+     * @param region the region of this node on the enclosing script, or {@code null} if unknown
+     * @param entries the entries in this map
+     * @throws IllegalArgumentException if some parameters were {@code null}
+     */
+    public AstAttributeValueMap(Region region, List<? extends Entry> entries) {
+        this.region = region;
+        this.entries = Collections.unmodifiableList(new ArrayList<>(entries));
+    }
+
+    @Override
+    public Region getRegion() {
+        return region;
+    }
+
+    /**
+     * Returns entries as map object.
+     * @return a related map
+     */
+    public Map<Object, AstAttributeValue> asMap() {
+        Map<Object, AstAttributeValue> results = new LinkedHashMap<>();
+        for (Entry entry : entries) {
+            results.put(entry.key.toValue(), entry.value);
+        }
+        return results;
+
+    }
+
+    @Override
+    public <C, R> R accept(C context, AstNode.Visitor<C, R> visitor) {
+        if (visitor == null) {
+            throw new IllegalArgumentException("visitor must not be null"); //$NON-NLS-1$
+        }
+        R result = visitor.visitAttributeValueMap(context, this);
+        return result;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + Objects.hashCode(entries);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        AstAttributeValueMap other = (AstAttributeValueMap) obj;
+        if (!Objects.equals(entries, other.entries)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return entries.stream()
+                .map(Entry::toString)
+                .collect(Collectors.joining("{", ",", "}")); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    }
+
+    /**
+     * An entry of {@link AstAttributeValueMap}.
+     * @since 0.9.1
+     */
+    public static class Entry {
+
+        /**
+         * The entry key.
+         */
+        public final AstLiteral key;
+
+        /**
+         * The entry value.
+         */
+        public final AstAttributeValue value;
+
+        /**
+         * Creates a new instance.
+         * @param key the entry key
+         * @param value the entry value
+         */
+        public Entry(AstLiteral key, AstAttributeValue value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Objects.hashCode(key);
+            result = prime * result + Objects.hashCode(value);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Entry other = (Entry) obj;
+            if (!Objects.equals(key, other.key)) {
+                return false;
+            }
+            if (!Objects.equals(value, other.value)) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s : %s", key, value); //$NON-NLS-1$
+        }
+    }
+}

--- a/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/model/AstLiteral.java
+++ b/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/model/AstLiteral.java
@@ -24,6 +24,7 @@ import com.asakusafw.dmdl.Region;
 /**
  * Represents literals.
  * @since 0.2.0
+ * @version 0.9.1
  */
 public class AstLiteral extends AbstractAstNode implements AstAttributeValue {
 
@@ -138,6 +139,26 @@ public class AstLiteral extends AbstractAstNode implements AstAttributeValue {
     public boolean toBooleanValue() {
         checkKind(LiteralKind.BOOLEAN);
         return token.equals("TRUE"); //$NON-NLS-1$
+    }
+
+    /**
+     * Returns the value of this literal.
+     * @return the value
+     * @since 0.9.1
+     */
+    public Object toValue() {
+        switch (getKind()) {
+        case BOOLEAN:
+            return toBooleanValue();
+        case DECIMAL:
+            return toDecimalValue();
+        case INTEGER:
+            return toIntegerValue();
+        case STRING:
+            return toStringValue();
+        default:
+            throw new AssertionError(getKind());
+        }
     }
 
     private void checkKind(LiteralKind expected) {

--- a/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/model/AstNode.java
+++ b/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/model/AstNode.java
@@ -45,6 +45,8 @@ public interface AstNode {
      * Visitor of {@link AstNode}.
      * @param <C> type of visitor context
      * @param <R> type of visitor result
+     * @since 0.2.0
+     * @version 0.9.1
      */
     public interface Visitor<C, R> {
 
@@ -71,6 +73,15 @@ public interface AstNode {
          * @return the result
          */
         R visitAttributeValueArray(C context, AstAttributeValueArray node);
+
+        /**
+         * Called back from {@link AstAttributeValueMap}.
+         * @param context the context of this visitor
+         * @param node the node invoked {@link AstNode#accept(Object, Visitor)}
+         * @return the result
+         * @since 0.9.1
+         */
+        R visitAttributeValueMap(C context, AstAttributeValueMap node);
 
         /**
          * Called back from {@link AstBasicType}.
@@ -255,6 +266,11 @@ public interface AstNode {
 
         @Override
         public R visitAttributeValueArray(C context, AstAttributeValueArray node) {
+            return null;
+        }
+
+        @Override
+        public R visitAttributeValueMap(C context, AstAttributeValueMap node) {
             return null;
         }
 

--- a/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/parser/DmdlEmitter.java
+++ b/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/parser/DmdlEmitter.java
@@ -19,10 +19,13 @@ import java.io.PrintWriter;
 import java.text.MessageFormat;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
 
 import com.asakusafw.dmdl.model.AstAttribute;
 import com.asakusafw.dmdl.model.AstAttributeElement;
+import com.asakusafw.dmdl.model.AstAttributeValue;
 import com.asakusafw.dmdl.model.AstAttributeValueArray;
+import com.asakusafw.dmdl.model.AstAttributeValueMap;
 import com.asakusafw.dmdl.model.AstBasicType;
 import com.asakusafw.dmdl.model.AstDescription;
 import com.asakusafw.dmdl.model.AstGrouping;
@@ -108,18 +111,48 @@ public final class DmdlEmitter {
 
         @Override
         public Void visitAttributeValueArray(Context context, AstAttributeValueArray node) {
-            context.println("'{'"); //$NON-NLS-1$
-            context.enter();
-            for (int i = 0, n = node.elements.size(); i < n; i++) {
-                node.elements.get(i).accept(context, this);
-                if (i != n - 1) {
-                    context.println(","); //$NON-NLS-1$
-                } else {
-                    context.println();
+            List<AstAttributeValue> elements = node.elements;
+            if (elements.isEmpty()) {
+                context.print("'{}'"); //$NON-NLS-1$
+            } else {
+                context.println("'{'"); //$NON-NLS-1$
+                context.enter();
+                for (int i = 0, n = elements.size(); i < n; i++) {
+                    elements.get(i).accept(context, this);
+                    if (i != n - 1) {
+                        context.println(","); //$NON-NLS-1$
+                    } else {
+                        context.println();
+                    }
                 }
+                context.exit();
+                context.print("'}'"); //$NON-NLS-1$
             }
-            context.exit();
-            context.print("'}'"); //$NON-NLS-1$
+            return null;
+        }
+
+        @Override
+        public Void visitAttributeValueMap(Context context, AstAttributeValueMap node) {
+            List<AstAttributeValueMap.Entry> entries = node.entries;
+            if (entries.isEmpty()) {
+                context.print("'{:}'"); //$NON-NLS-1$
+            } else {
+                context.println("'{'"); //$NON-NLS-1$
+                context.enter();
+                for (int i = 0, n = entries.size(); i < n; i++) {
+                    AstAttributeValueMap.Entry entry = entries.get(i);
+                    entry.key.accept(context, this);
+                    context.print(" : "); //$NON-NLS-1$
+                    entry.value.accept(context, this);
+                    if (i != n - 1) {
+                        context.println(","); //$NON-NLS-1$
+                    } else {
+                        context.println();
+                    }
+                }
+                context.exit();
+                context.print("'}'"); //$NON-NLS-1$
+            }
             return null;
         }
 

--- a/dmdl-project/asakusa-dmdl-core/src/main/javacc/DmdlParser.jj
+++ b/dmdl-project/asakusa-dmdl-core/src/main/javacc/DmdlParser.jj
@@ -27,8 +27,10 @@ package com.asakusafw.dmdl.parser;
 import java.net.URI;
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,7 +41,7 @@ import com.asakusafw.dmdl.model.*;
 /**
  * An implementation of the DMDL Script Parser.
  * @since 0.2.0
- * @version 0.5.3
+ * @version 0.9.1
  */
 class JjDmdlParser {
 
@@ -50,7 +52,7 @@ class JjDmdlParser {
     private LinkedList<ParseFrame> frameStack;
 
     /**
-     * Parse a DMDL Script and return a model object.
+     * Parses a DMDL Script and returns the corresponded model object.
      * @param source the source location
      * @return the analyzed AST
      * @throws ParseException if input text was not a valid DMDL script
@@ -66,7 +68,7 @@ class JjDmdlParser {
     }
 
     /**
-     * Parse a DMDL literal and return a model object.
+     * Parses a DMDL literal and returns the corresponded model object.
      * @param source the source location
      * @return the analyzed AST
      * @throws ParseException if input text was not a valid DMDL script
@@ -1062,6 +1064,7 @@ private AstAttributeElement AttributeElement() :
 /* Attribute Value
 <attribute-value>:
      <attribute-value-array>
+     <attribute-value-map>
      <qname>
      <literal>
 */
@@ -1072,7 +1075,10 @@ private AstAttributeValue AttributeValue() :
 }
 {
     (
+        LOOKAHEAD(3)
         value = AttributeValueArray()
+    |
+        value = AttributeValueMap()
     |
         value = QualifiedName()
     |
@@ -1119,6 +1125,53 @@ private AstAttributeValueArray AttributeValueArray() :
     {
         Region region = end("attribute-value-array");
         return new AstAttributeValueArray(region, elements);
+    }
+}
+
+/* Map of attribute values
+<attribute-value-map>:
+     '{' ':' '}'
+     '{' <attribute-pair-list> ','? '}'
+<attribute-pair-list>:
+     <attribute-pair-list> ',' <attribute-pair>
+     <attribute-pair>
+ <attribute-pair>:
+     <literal> ':' <attribute-value>
+*/
+private AstAttributeValueMap AttributeValueMap() :
+{
+    begin("attribute-value-map");
+    AstLiteral key;
+    AstAttributeValue value;
+    List<AstAttributeValueMap.Entry> entries = newList();
+}
+{
+    <OPEN_BLOCK>
+    (
+        key = Literal()
+        ":"
+        value = AttributeValue()
+        {
+            entries.add(new AstAttributeValueMap.Entry(key, value));
+        }
+        (
+            LOOKAHEAD(2)
+            ","
+            key = Literal()
+            ":"
+            value = AttributeValue()
+            {
+                entries.add(new AstAttributeValueMap.Entry(key, value));
+            }
+        )*
+        ( "," )?
+    |
+        ":"
+    )
+    <CLOSE_BLOCK>
+    {
+        Region region = end("attribute-value-map");
+        return new AstAttributeValueMap(region, entries);
     }
 }
 

--- a/dmdl-project/asakusa-dmdl-core/src/test/java/com/asakusafw/dmdl/parser/DmdlParserTest.java
+++ b/dmdl-project/asakusa-dmdl-core/src/test/java/com/asakusafw/dmdl/parser/DmdlParserTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.*;
 import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
@@ -34,6 +35,7 @@ import com.asakusafw.dmdl.model.AstAttribute;
 import com.asakusafw.dmdl.model.AstAttributeElement;
 import com.asakusafw.dmdl.model.AstAttributeValue;
 import com.asakusafw.dmdl.model.AstAttributeValueArray;
+import com.asakusafw.dmdl.model.AstAttributeValueMap;
 import com.asakusafw.dmdl.model.AstBasicType;
 import com.asakusafw.dmdl.model.AstExpression;
 import com.asakusafw.dmdl.model.AstJoin;
@@ -478,6 +480,32 @@ public class DmdlParserTest extends DmdlTesterRoot {
         assertThat(array.elements.get(1), is(value("\"Hello, world!\"", LiteralKind.STRING)));
         assertThat(array.elements.get(2), is(value("3.141592", LiteralKind.DECIMAL)));
         assertThat(array.elements.get(3), is(value("TRUE", LiteralKind.BOOLEAN)));
+    }
+
+    /**
+     * Parse a map.
+     */
+    @Test
+    public void map() {
+        AstAttribute attr = loadFirstAttribute();
+        AstAttributeValue value = getValue(attr, "e_map");
+        assertThat(value, instanceOf(AstAttributeValueMap.class));
+
+        AstAttributeValueMap map = (AstAttributeValueMap) value;
+        assertThat(map.entries.size(), is(6));
+        assertThat(get(map, "a"), is(value("100", LiteralKind.INTEGER)));
+        assertThat(get(map, "b"), is(value("\"Hello, world!\"", LiteralKind.STRING)));
+        assertThat(get(map, "c"), is(value("3.141592", LiteralKind.DECIMAL)));
+        assertThat(get(map, "d"), is(value("TRUE", LiteralKind.BOOLEAN)));
+        assertThat(get(map, BigInteger.valueOf(0)), is(instanceOf(AstAttributeValueArray.class)));
+        assertThat(get(map, BigInteger.valueOf(1)), is(instanceOf(AstAttributeValueMap.class)));
+    }
+
+    private AstAttributeValue get(AstAttributeValueMap map, Object value) {
+        return map.entries.stream()
+                .filter(e -> e.key.toValue().equals(value))
+                .findAny()
+                .get().value;
     }
 
     /**

--- a/dmdl-project/asakusa-dmdl-core/src/test/resources/com/asakusafw/dmdl/parser/map.txt
+++ b/dmdl-project/asakusa-dmdl-core/src/test/resources/com/asakusafw/dmdl/parser/map.txt
@@ -1,0 +1,11 @@
+@attribute(
+    e_map = {
+        "a" : 100,
+        "b" : "Hello, world!",
+        "c" : 3.141592,
+        "d" : TRUE,
+        0 : {},
+        1 : {:},
+    }
+)
+simple = {a : INT; };


### PR DESCRIPTION
## Summary

This PR introduces attribute value map syntax into DMDL.

## Background, Problem or Goal of the patch

In the latest implementation, DMDL attributes can include following values:
* literal
* name
* array of values

This PR introduces *map of values* as a new attribute value type that has pairs of key (as literal) and other attribute values.

## Design of the fix, or a new feature

This introduces a new grammer rule `<attribute-value-map>` which can appear in DMDL attributes.

```
<attribute-value>:
    ...
    <attribute-value-map>
    ...
<attribute-value-map>:
    '{' ':' '}'
    '{' <attribute-pair-list> ','? '}'
<attribute-pair-list>:
    <attribute-pair-list> ',' <attribute-pair>
    <attribute-pair>
<attribute-pair>:
    <literal> ':' <attribute-value>
```

Note that, empty maps must be `{ : }`, because `{ }` represents an empty array.

Here an example of attribute value map.

```
@some.attr(
    map = {
        "key" : "value",
        "nested" : { "key" : "value" },
    },
    empty_map = {:}, 
)
model = { ... };
```

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw
