### PR TITLE
Fix validating buffer contents.

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/flow/FileMapListBuffer.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/flow/FileMapListBuffer.java
@@ -238,7 +238,6 @@ public class FileMapListBuffer<E extends Writable> extends AbstractList<E> imple
                 }
                 elements[i].write(buffer);
             }
-            assert buffer.contents.hasRemaining();
             long end = putContents(offset, buffer.contents);
             offsets[index] = end;
         }
@@ -262,6 +261,7 @@ public class FileMapListBuffer<E extends Writable> extends AbstractList<E> imple
             if (LOG.isTraceEnabled()) {
                 LOG.trace(String.format("writing fragment: %s@%,d+%,d", path, begin, contents.remaining())); //$NON-NLS-1$
             }
+            assert contents.hasRemaining();
             long offset = begin;
             while (contents.hasRemaining()) {
                 offset += channel.write(contents, offset);


### PR DESCRIPTION
## Summary

This PR fixes assertion in `FileMapListBuffer`.

## Background, Problem or Goal of the patch

The latest implementation sometimes raise `AssertionError` when the internal buffer was full, but it must be "the buffer page is not empty".

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #696 

## Wanted reviewer

@akirakw 