### PR TITLE
Introduce `OperatorTestEnvironment.newResult()`.

### DIFF
--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/OperatorTestEnvironment.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/OperatorTestEnvironment.java
@@ -32,7 +32,9 @@ import com.asakusafw.runtime.core.BatchContext;
 import com.asakusafw.runtime.core.Report;
 import com.asakusafw.runtime.directio.DataFormat;
 import com.asakusafw.runtime.flow.RuntimeResourceManager;
+import com.asakusafw.runtime.model.DataModel;
 import com.asakusafw.runtime.stage.StageConstants;
+import com.asakusafw.runtime.testing.MockResult;
 import com.asakusafw.runtime.util.VariableTable;
 import com.asakusafw.runtime.util.VariableTable.RedefineStrategy;
 import com.asakusafw.testdriver.core.DataModelDefinition;
@@ -288,6 +290,30 @@ public class OperatorTestEnvironment extends DriverElementBase implements TestRu
      */
     public Configuration getConfiguration() {
         return createConfig();
+    }
+
+    /**
+     * Returns a new {@link MockResult}.
+     * The returned object will create copies of the incoming objects.
+     * @param <T> the data type
+     * @param dataType the data type
+     * @return the created {@link MockResult}
+     * @since 0.9.1
+     */
+    public <T extends DataModel<T>> MockResult<T> newResult(Class<T> dataType) {
+        Objects.requireNonNull(dataType);
+        return new MockResult<T>() {
+            @Override
+            protected T bless(T result) {
+                try {
+                    T copy = dataType.newInstance();
+                    copy.copyFrom(result);
+                    return copy;
+                } catch (ReflectiveOperationException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR introduces `OperatorTestEnvironment.newResult()` that provides `MockResult` object for testing operator methods.

## Background, Problem or Goal of the patch

`MockResult` is a mock of `Result` for testing operator methods to capture test outputs of `@Extract`, `@CoGroup`, or etc.
The introduced `OperatorTestEnvironment.newResult()` returns `MockResult` which always creates copies of added objects (see [MockResult.bless()](http://docs.asakusafw.com/0.9.0/release/api/com/asakusafw/runtime/testing/MockResult.html#bless-T-)).

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw see http://asakusafw.s3.amazonaws.com/documents/latest/develop/ja/html/testing/user-guide.html#id5