### PR TITLE
Revise error messages about wrong test data.

### DIFF
--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/DirectIoUtil.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/DirectIoUtil.java
@@ -62,9 +62,6 @@ final class DirectIoUtil {
             Class<? extends DataFormat<?>> formatClass,
             URL source) throws IOException, InterruptedException {
         DataFormat<? super T> format = newDataFormat(configuration, formatClass);
-        if (format.getSupportedType().isAssignableFrom(definition.getModelClass()) == false) {
-            throw new IllegalArgumentException();
-        }
         return load(configuration, definition, format, source);
     }
 
@@ -74,9 +71,6 @@ final class DirectIoUtil {
             Class<? extends DataFormat<?>> formatClass,
             File source) throws IOException, InterruptedException {
         DataFormat<? super T> format = newDataFormat(configuration, formatClass);
-        if (format.getSupportedType().isAssignableFrom(definition.getModelClass()) == false) {
-            throw new IllegalArgumentException();
-        }
         return load(configuration, definition, format, source);
     }
 
@@ -85,6 +79,7 @@ final class DirectIoUtil {
             DataModelDefinition<T> definition,
             DataFormat<? super T> format,
             File source) throws IOException, InterruptedException {
+        checkDataType(definition, format);
         if (format instanceof BinaryStreamFormat<?>) {
             return load0(definition, (BinaryStreamFormat<? super T>) format, source);
         }
@@ -97,6 +92,7 @@ final class DirectIoUtil {
             DataModelDefinition<T> definition,
             DataFormat<? super T> format,
             URL source) throws IOException, InterruptedException {
+        checkDataType(definition, format);
         if (source.getProtocol().equals("file")) { //$NON-NLS-1$
             File file = null;
             try {
@@ -127,6 +123,16 @@ final class DirectIoUtil {
             return format;
         } catch (ReflectiveOperationException e) {
             throw new IllegalStateException(e);
+        }
+    }
+
+    private static void checkDataType(DataModelDefinition<?> definition, DataFormat<?> format) {
+        if (format.getSupportedType().isAssignableFrom(definition.getModelClass()) == false) {
+            throw new IllegalArgumentException(MessageFormat.format(
+                    "inconsistent data format: data-type={0}, format-type={1}, supported-type={2}",
+                    definition.getModelClass().getName(),
+                    format.getClass().getName(),
+                    format.getSupportedType().getName()));
         }
     }
 

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/BasicDataLoader.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/BasicDataLoader.java
@@ -28,7 +28,6 @@ import com.asakusafw.testdriver.core.DataModelReflection;
 import com.asakusafw.testdriver.core.DataModelSource;
 import com.asakusafw.testdriver.core.DataModelSourceFactory;
 import com.asakusafw.testdriver.core.PropertyName;
-import com.asakusafw.testdriver.core.PropertyType;
 import com.asakusafw.testdriver.core.TestContext;
 
 /**
@@ -63,10 +62,7 @@ public class BasicDataLoader<T> implements DataLoader<T> {
         List<PropertyName> names = new ArrayList<>();
         for (String term : terms) {
             PropertyName name = PropertyName.parse(term);
-            PropertyType type = definition.getType(name);
-            if (type == null) {
-                throw new IllegalArgumentException();
-            }
+            Util.checkProperty(definition, name);
             names.add(name);
         }
         return new BasicGroupLoader<>(context, definition, factory, names, refComparator);
@@ -75,7 +71,7 @@ public class BasicDataLoader<T> implements DataLoader<T> {
     @Override
     public DataLoader<T> order(String... terms) {
         if (refComparator != null) {
-            throw new IllegalStateException();
+            throw new IllegalStateException("order is already defined"); //$NON-NLS-1$
         }
         refComparator = Util.toComparator(definition, terms);
         return this;
@@ -84,7 +80,7 @@ public class BasicDataLoader<T> implements DataLoader<T> {
     @Override
     public DataLoader<T> order(Comparator<? super T> comparator) {
         if (refComparator != null) {
-            throw new IllegalStateException();
+            throw new IllegalStateException("order is already defined"); //$NON-NLS-1$
         }
         refComparator = Util.toComparator(definition, comparator);
         return this;

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/BasicGroupLoader.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/BasicGroupLoader.java
@@ -71,7 +71,7 @@ public class BasicGroupLoader<T> implements GroupLoader<T> {
     @Override
     public GroupLoader<T> order(String... terms) {
         if (refComparator != null) {
-            throw new IllegalStateException();
+            throw new IllegalStateException("order is already defined"); //$NON-NLS-1$
         }
         refComparator = Util.toComparator(definition, terms);
         return this;
@@ -80,7 +80,7 @@ public class BasicGroupLoader<T> implements GroupLoader<T> {
     @Override
     public GroupLoader<T> order(Comparator<? super T> comparator) {
         if (refComparator != null) {
-            throw new IllegalStateException();
+            throw new IllegalStateException("order is already defined"); //$NON-NLS-1$
         }
         refComparator = Util.toComparator(definition, comparator);
         return this;

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/Util.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/Util.java
@@ -55,6 +55,16 @@ final class Util {
         return;
     }
 
+    static void checkProperty(DataModelDefinition<?> definition, PropertyName name) {
+        PropertyType type = definition.getType(name);
+        if (type == null) {
+            throw new IllegalArgumentException(MessageFormat.format(
+                    "property \"{1}\" is not defined in {0}",
+                    definition.getClass().getName(),
+                    name));
+        }
+    }
+
     static <T> Comparator<DataModelReflection> toComparator(
             DataModelDefinition<T> definition,
             String... terms) {
@@ -79,13 +89,10 @@ final class Util {
     @SuppressWarnings("unchecked")
     private static <T> Comparator<DataModelReflection> toComparator(DataModelDefinition<T> definition, String term) {
         if (term.isEmpty()) {
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("order term must not be empty"); //$NON-NLS-1$
         }
         Ordering order = parseOrder(term);
-        PropertyType type = definition.getType(order.propertyName);
-        if (type == null) {
-            throw new IllegalArgumentException();
-        }
+        checkProperty(definition, order.propertyName);
         Comparator<DataModelReflection> comparator = (a, b) -> {
             Comparable<Object> aValue = (Comparable<Object>) a.getValue(order.propertyName);
             Comparable<Object> bValue = (Comparable<Object>) b.getValue(order.propertyName);
@@ -110,6 +117,9 @@ final class Util {
     static <T> Comparator<DataModelReflection> toComparator(
             DataModelDefinition<T> definition,
             Comparator<? super T> objectComparator) {
+        if (objectComparator == null) {
+            return null;
+        }
         return (a, b) -> {
             T aObj = definition.toObject(a);
             T bObj = definition.toObject(b);


### PR DESCRIPTION
## Summary

This PR revises error messages in `asakusa-test-driver`.

## Background, Problem or Goal of the patch

Recently introduced features (`OperatorTestEnvironment.loader`, `DataFormat` for test data) may throw an error with confusable messages. This will make them better.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #700
* #701
* #704

## Wanted reviewer

@akirakw 