### PR TITLE
Add Java DOM for method reference expressions.

### DIFF
--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/ConstructorReferenceExpressionImpl.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/ConstructorReferenceExpressionImpl.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.utils.java.internal.model.syntax;
+
+import java.util.List;
+
+import com.asakusafw.utils.java.model.syntax.ConstructorReferenceExpression;
+import com.asakusafw.utils.java.model.syntax.ModelKind;
+import com.asakusafw.utils.java.model.syntax.Type;
+import com.asakusafw.utils.java.model.syntax.Visitor;
+
+/**
+ * An implementation of {@link ConstructorReferenceExpression}.
+ * @since 0.9.1
+ */
+public final class ConstructorReferenceExpressionImpl extends ModelRoot implements ConstructorReferenceExpression {
+
+    private Type qualifier;
+
+    private List<? extends Type> typeArguments;
+
+    @Override
+    public Type getQualifier() {
+        return this.qualifier;
+    }
+
+    /**
+     * Sets the owner type.
+     * @param qualifier the owner type
+     * @throws IllegalArgumentException if {@code qualifier} was {@code null}
+     */
+    public void setQualifier(Type qualifier) {
+        Util.notNull(qualifier, "qualifier"); //$NON-NLS-1$
+        this.qualifier = qualifier;
+    }
+
+    @Override
+    public List<? extends Type> getTypeArguments() {
+        return this.typeArguments;
+    }
+
+    /**
+     * Sets the type arguments.
+     * @param typeArguments the type arguments
+     * @throws IllegalArgumentException if {@code typeArguments} was {@code null}
+     */
+    public void setTypeArguments(List<? extends Type> typeArguments) {
+        Util.notNull(typeArguments, "typeArguments"); //$NON-NLS-1$
+        Util.notContainNull(typeArguments, "typeArguments"); //$NON-NLS-1$
+        this.typeArguments = Util.freeze(typeArguments);
+    }
+
+    /**
+     * Returns {@link ModelKind#CONSTRUCTOR_REFERENCE_EXPRESSION} which represents this element kind.
+     * @return {@link ModelKind#CONSTRUCTOR_REFERENCE_EXPRESSION}
+     */
+    @Override
+    public ModelKind getModelKind() {
+        return ModelKind.CONSTRUCTOR_REFERENCE_EXPRESSION;
+    }
+
+    @Override
+    public <R, C, E extends Throwable> R accept(Visitor<R, C, E> visitor, C context) throws E {
+        Util.notNull(visitor, "visitor"); //$NON-NLS-1$
+        return visitor.visitConstructorReferenceExpression(this, context);
+    }
+}

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/MethodReferenceExpressionImpl.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/MethodReferenceExpressionImpl.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.utils.java.internal.model.syntax;
+
+import java.util.List;
+
+import com.asakusafw.utils.java.model.syntax.MethodReferenceExpression;
+import com.asakusafw.utils.java.model.syntax.ModelKind;
+import com.asakusafw.utils.java.model.syntax.SimpleName;
+import com.asakusafw.utils.java.model.syntax.Type;
+import com.asakusafw.utils.java.model.syntax.TypeOrExpression;
+import com.asakusafw.utils.java.model.syntax.Visitor;
+
+/**
+ * An implementation of {@link MethodReferenceExpression}.
+ * @since 0.9.1
+ */
+public final class MethodReferenceExpressionImpl extends ModelRoot implements MethodReferenceExpression {
+
+    private TypeOrExpression qualifier;
+
+    private List<? extends Type> typeArguments;
+
+    private SimpleName name;
+
+    @Override
+    public TypeOrExpression getQualifier() {
+        return this.qualifier;
+    }
+
+    /**
+     * Sets the qualifier expression or type.
+     * @param qualifier the qualifier expression or type
+     * @throws IllegalArgumentException if {@code qualifier} was {@code null}
+     */
+    public void setQualifier(TypeOrExpression qualifier) {
+        Util.notNull(qualifier, "qualifier"); //$NON-NLS-1$
+        this.qualifier = qualifier;
+    }
+
+    @Override
+    public List<? extends Type> getTypeArguments() {
+        return this.typeArguments;
+    }
+
+    /**
+     * Sets the type arguments.
+     * @param typeArguments the type arguments
+     * @throws IllegalArgumentException if {@code typeArguments} was {@code null}
+     */
+    public void setTypeArguments(List<? extends Type> typeArguments) {
+        Util.notNull(typeArguments, "typeArguments"); //$NON-NLS-1$
+        Util.notContainNull(typeArguments, "typeArguments"); //$NON-NLS-1$
+        this.typeArguments = Util.freeze(typeArguments);
+    }
+
+    @Override
+    public SimpleName getName() {
+        return this.name;
+    }
+
+    /**
+     * Sets the target method name.
+     * @param name the target method name
+     * @throws IllegalArgumentException if {@code name} was {@code null}
+     */
+    public void setName(SimpleName name) {
+        Util.notNull(name, "name"); //$NON-NLS-1$
+        this.name = name;
+    }
+
+    /**
+     * Returns {@link ModelKind#METHOD_REFERENCE_EXPRESSION} which represents this element kind.
+     * @return {@link ModelKind#METHOD_REFERENCE_EXPRESSION}
+     */
+    @Override
+    public ModelKind getModelKind() {
+        return ModelKind.METHOD_REFERENCE_EXPRESSION;
+    }
+
+    @Override
+    public <R, C, E extends Throwable> R accept(Visitor<R, C, E> visitor, C context) throws E {
+        Util.notNull(visitor, "visitor"); //$NON-NLS-1$
+        return visitor.visitMethodReferenceExpression(this, context);
+    }
+}

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/ModelFactoryImpl.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/syntax/ModelFactoryImpl.java
@@ -1156,6 +1156,37 @@ public class ModelFactoryImpl implements ModelFactory {
     }
 
     @Override
+    public ConstructorReferenceExpressionImpl newConstructorReferenceExpression(
+            Type qualifier,
+            List<? extends Type> typeArguments) {
+        Util.notNull(qualifier, "qualifier"); //$NON-NLS-1$
+        Util.notNull(typeArguments, "typeArguments"); //$NON-NLS-1$
+        Util.notContainNull(typeArguments, "typeArguments"); //$NON-NLS-1$
+        ConstructorReferenceExpressionImpl result = new ConstructorReferenceExpressionImpl();
+        result.setQualifier(qualifier);
+        result.setTypeArguments(typeArguments);
+        return result;
+    }
+
+    @Override
+    public MethodReferenceExpressionImpl newMethodReferenceExpression(
+            TypeOrExpression qualifier,
+            List<? extends Type> typeArguments,
+            SimpleName name) {
+        Util.notNull(qualifier, "qualifier"); //$NON-NLS-1$
+        Util.notNull(typeArguments, "typeArguments"); //$NON-NLS-1$
+        Util.notContainNull(typeArguments, "typeArguments"); //$NON-NLS-1$
+        Util.notNull(name, "name"); //$NON-NLS-1$
+        MethodReferenceExpressionImpl result = new MethodReferenceExpressionImpl();
+        result.setQualifier(qualifier instanceof Expression
+                ? parenthesize((Expression) qualifier, ExpressionPriority.PRIMARY)
+                : qualifier);
+        result.setTypeArguments(typeArguments);
+        result.setName(name);
+        return result;
+    }
+
+    @Override
     public Modifier newModifier(ModifierKind modifierKind) {
         Util.notNull(modifierKind, "modifierKind"); //$NON-NLS-1$
         ModifierImpl result = new ModifierImpl();

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelDigester.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelDigester.java
@@ -40,6 +40,7 @@ import com.asakusafw.utils.java.model.syntax.ClassLiteral;
 import com.asakusafw.utils.java.model.syntax.CompilationUnit;
 import com.asakusafw.utils.java.model.syntax.ConditionalExpression;
 import com.asakusafw.utils.java.model.syntax.ConstructorDeclaration;
+import com.asakusafw.utils.java.model.syntax.ConstructorReferenceExpression;
 import com.asakusafw.utils.java.model.syntax.ContinueStatement;
 import com.asakusafw.utils.java.model.syntax.DoStatement;
 import com.asakusafw.utils.java.model.syntax.DocBlock;
@@ -72,6 +73,7 @@ import com.asakusafw.utils.java.model.syntax.LocalVariableDeclaration;
 import com.asakusafw.utils.java.model.syntax.MarkerAnnotation;
 import com.asakusafw.utils.java.model.syntax.MethodDeclaration;
 import com.asakusafw.utils.java.model.syntax.MethodInvocationExpression;
+import com.asakusafw.utils.java.model.syntax.MethodReferenceExpression;
 import com.asakusafw.utils.java.model.syntax.Model;
 import com.asakusafw.utils.java.model.syntax.Modifier;
 import com.asakusafw.utils.java.model.syntax.NamedType;
@@ -719,6 +721,27 @@ public final class ModelDigester extends StrictVisitor<Void, DigestContext, NoTh
         digest(elem.getTypeArguments(), context);
         digest(elem.getName(), context);
         digest(elem.getArguments(), context);
+        return null;
+    }
+
+    @Override
+    public Void visitConstructorReferenceExpression(
+            ConstructorReferenceExpression elem,
+            DigestContext context) {
+        digest(elem.getModelKind(), context);
+        digest(elem.getQualifier(), context);
+        digest(elem.getTypeArguments(), context);
+        return null;
+    }
+
+    @Override
+    public Void visitMethodReferenceExpression(
+            MethodReferenceExpression elem,
+            DigestContext context) {
+        digest(elem.getModelKind(), context);
+        digest(elem.getQualifier(), context);
+        digest(elem.getTypeArguments(), context);
+        digest(elem.getName(), context);
         return null;
     }
 

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelEmitter.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelEmitter.java
@@ -47,6 +47,7 @@ import com.asakusafw.utils.java.model.syntax.ClassLiteral;
 import com.asakusafw.utils.java.model.syntax.CompilationUnit;
 import com.asakusafw.utils.java.model.syntax.ConditionalExpression;
 import com.asakusafw.utils.java.model.syntax.ConstructorDeclaration;
+import com.asakusafw.utils.java.model.syntax.ConstructorReferenceExpression;
 import com.asakusafw.utils.java.model.syntax.ContinueStatement;
 import com.asakusafw.utils.java.model.syntax.DoStatement;
 import com.asakusafw.utils.java.model.syntax.DocBlock;
@@ -84,6 +85,7 @@ import com.asakusafw.utils.java.model.syntax.LocalVariableDeclaration;
 import com.asakusafw.utils.java.model.syntax.MarkerAnnotation;
 import com.asakusafw.utils.java.model.syntax.MethodDeclaration;
 import com.asakusafw.utils.java.model.syntax.MethodInvocationExpression;
+import com.asakusafw.utils.java.model.syntax.MethodReferenceExpression;
 import com.asakusafw.utils.java.model.syntax.Model;
 import com.asakusafw.utils.java.model.syntax.ModelKind;
 import com.asakusafw.utils.java.model.syntax.Modifier;
@@ -892,6 +894,28 @@ class EmitEngine extends StrictVisitor<Void, EmitContext, NoThrow> {
         processTypeParameters(elem.getTypeArguments(), context);
         process(elem.getName(), context);
         processParameters(elem.getArguments(), context);
+        return null;
+    }
+
+    @Override
+    public Void visitConstructorReferenceExpression(ConstructorReferenceExpression elem, EmitContext context) {
+        begin(elem, context);
+        processInlineComment(elem, context);
+        process(elem.getQualifier(), context);
+        context.symbol("::"); //$NON-NLS-1$
+        processTypeParameters(elem.getTypeArguments(), context);
+        context.keyword("new"); //$NON-NLS-1$
+        return null;
+    }
+
+    @Override
+    public Void visitMethodReferenceExpression(MethodReferenceExpression elem, EmitContext context) {
+        begin(elem, context);
+        processInlineComment(elem, context);
+        process(elem.getQualifier(), context);
+        context.symbol("::"); //$NON-NLS-1$
+        processTypeParameters(elem.getTypeArguments(), context);
+        process(elem.getName(), context);
         return null;
     }
 

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelMatcher.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/internal/model/util/ModelMatcher.java
@@ -40,6 +40,7 @@ import com.asakusafw.utils.java.model.syntax.ClassLiteral;
 import com.asakusafw.utils.java.model.syntax.CompilationUnit;
 import com.asakusafw.utils.java.model.syntax.ConditionalExpression;
 import com.asakusafw.utils.java.model.syntax.ConstructorDeclaration;
+import com.asakusafw.utils.java.model.syntax.ConstructorReferenceExpression;
 import com.asakusafw.utils.java.model.syntax.ContinueStatement;
 import com.asakusafw.utils.java.model.syntax.DoStatement;
 import com.asakusafw.utils.java.model.syntax.DocBlock;
@@ -72,6 +73,7 @@ import com.asakusafw.utils.java.model.syntax.LocalVariableDeclaration;
 import com.asakusafw.utils.java.model.syntax.MarkerAnnotation;
 import com.asakusafw.utils.java.model.syntax.MethodDeclaration;
 import com.asakusafw.utils.java.model.syntax.MethodInvocationExpression;
+import com.asakusafw.utils.java.model.syntax.MethodReferenceExpression;
 import com.asakusafw.utils.java.model.syntax.Model;
 import com.asakusafw.utils.java.model.syntax.Modifier;
 import com.asakusafw.utils.java.model.syntax.NamedType;
@@ -1165,6 +1167,43 @@ public final class ModelMatcher extends StrictVisitor<Boolean, Model, NoThrow> {
             return Boolean.FALSE;
         }
         if (Boolean.FALSE.equals(match(elem.getArguments(), that.getArguments()))) {
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+
+    @Override
+    public Boolean visitConstructorReferenceExpression(
+            ConstructorReferenceExpression elem,
+            Model context) {
+        if (elem.getModelKind() != context.getModelKind()) {
+            return Boolean.FALSE;
+        }
+        ConstructorReferenceExpression that = (ConstructorReferenceExpression) context;
+        if (Boolean.FALSE.equals(match(elem.getQualifier(), that.getQualifier()))) {
+            return Boolean.FALSE;
+        }
+        if (Boolean.FALSE.equals(match(elem.getTypeArguments(), that.getTypeArguments()))) {
+            return Boolean.FALSE;
+        }
+        return Boolean.TRUE;
+    }
+
+    @Override
+    public Boolean visitMethodReferenceExpression(
+            MethodReferenceExpression elem,
+            Model context) {
+        if (elem.getModelKind() != context.getModelKind()) {
+            return Boolean.FALSE;
+        }
+        MethodReferenceExpression that = (MethodReferenceExpression) context;
+        if (Boolean.FALSE.equals(match(elem.getQualifier(), that.getQualifier()))) {
+            return Boolean.FALSE;
+        }
+        if (Boolean.FALSE.equals(match(elem.getTypeArguments(), that.getTypeArguments()))) {
+            return Boolean.FALSE;
+        }
+        if (Boolean.FALSE.equals(match(elem.getName(), that.getName()))) {
             return Boolean.FALSE;
         }
         return Boolean.TRUE;

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ConstructorReferenceExpression.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ConstructorReferenceExpression.java
@@ -16,15 +16,21 @@
 package com.asakusafw.utils.java.model.syntax;
 
 /**
- * An abstract super interface of types.
+ * An interface which represents method reference expressions only for constructors.
  * <ul>
  *   <li> Specified In: <ul>
- *     <li> {@code [JLS3:4] Types, Values, and Variables} </li>
+ *     <li> {@code [JLS8:15.13] Method Reference Expressions} </li>
  *   </ul> </li>
  * </ul>
+ * @since 0.9.1
  */
-public interface Type
-        extends TypeOrExpression, TypedElement {
+public interface ConstructorReferenceExpression
+        extends MethodOrConstructorReferenceExpression {
 
-    // properties
+    /**
+     * Returns the owner type.
+     * @return the owner type
+     */
+    @Override
+    Type getQualifier();
 }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/Expression.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/Expression.java
@@ -25,7 +25,7 @@ package com.asakusafw.utils.java.model.syntax;
  * </ul>
  */
 public interface Expression
-        extends TypedElement, LambdaBody {
+        extends TypeOrExpression, TypedElement, LambdaBody {
 
     // properties
 }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/MethodOrConstructorReferenceExpression.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/MethodOrConstructorReferenceExpression.java
@@ -15,16 +15,29 @@
  */
 package com.asakusafw.utils.java.model.syntax;
 
+import java.util.List;
+
 /**
- * An abstract super interface of types.
+ * An interface which represents method reference expressions.
  * <ul>
  *   <li> Specified In: <ul>
- *     <li> {@code [JLS3:4] Types, Values, and Variables} </li>
+ *     <li> {@code [JLS8:15.13] Method Reference Expressions} </li>
  *   </ul> </li>
  * </ul>
+ * @since 0.9.1
  */
-public interface Type
-        extends TypeOrExpression, TypedElement {
+public interface MethodOrConstructorReferenceExpression
+        extends Expression {
 
-    // properties
+    /**
+     * Returns the qualifier expression or type.
+     * @return the qualifier expression or type
+     */
+    TypeOrExpression getQualifier();
+
+    /**
+     * Returns the type arguments.
+     * @return the type arguments
+     */
+    List<? extends Type> getTypeArguments();
 }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/MethodReferenceExpression.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/MethodReferenceExpression.java
@@ -16,15 +16,20 @@
 package com.asakusafw.utils.java.model.syntax;
 
 /**
- * An abstract super interface of types.
+ * An interface which represents method reference expressions.
  * <ul>
  *   <li> Specified In: <ul>
- *     <li> {@code [JLS3:4] Types, Values, and Variables} </li>
+ *     <li> {@code [JLS8:15.13] Method Reference Expressions} </li>
  *   </ul> </li>
  * </ul>
+ * @since 0.9.1
  */
-public interface Type
-        extends TypeOrExpression, TypedElement {
+public interface MethodReferenceExpression
+        extends MethodOrConstructorReferenceExpression {
 
-    // properties
+    /**
+     * Returns the target method name.
+     * @return the target method name
+     */
+    SimpleName getName();
 }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelFactory.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelFactory.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 /**
  * A factory for providing {@link Model} objects.
  * @since 0.1.0
- * @version 0.9.0
+ * @version 0.9.1
  */
 public interface ModelFactory {
 
@@ -1190,6 +1190,61 @@ public interface ModelFactory {
             List<? extends Type> typeArguments,
             SimpleName name,
             List<? extends Expression> arguments
+    );
+
+    /**
+     * Returns a new {@link ConstructorReferenceExpression} object.
+     * @param qualifier the type owner type
+     * @return the created object
+     * @throws IllegalArgumentException if {@code qualifier} was {@code null}
+     * @since 0.9.1
+     */
+    default ConstructorReferenceExpression newConstructorReferenceExpression(Type qualifier) {
+        return newConstructorReferenceExpression(qualifier, Collections.emptyList());
+    }
+
+    /**
+     * Returns a new {@link ConstructorReferenceExpression} object.
+     * @param qualifier the type owner type
+     * @param typeArguments the type arguments
+     * @return the created object
+     * @throws IllegalArgumentException if {@code qualifier} was {@code null}
+     * @throws IllegalArgumentException if {@code typeArguments} was {@code null}
+     * @since 0.9.1
+     */
+    ConstructorReferenceExpression newConstructorReferenceExpression(
+            Type qualifier,
+            List<? extends Type> typeArguments
+    );
+
+    /**
+     * Returns a new {@link MethodReferenceExpression} object.
+     * @param qualifier the qualifier expression or type qualifier
+     * @param name the method name
+     * @return the created object
+     * @throws IllegalArgumentException if {@code qualifier} was {@code null}
+     * @throws IllegalArgumentException if {@code name} was {@code null}
+     * @since 0.9.1
+     */
+    default MethodReferenceExpression newMethodReferenceExpression(TypeOrExpression qualifier, SimpleName name) {
+        return newMethodReferenceExpression(qualifier, Collections.emptyList(), name);
+    }
+
+    /**
+     * Returns a new {@link MethodReferenceExpression} object.
+     * @param qualifier the qualifier expression or type qualifier
+     * @param typeArguments the type arguments
+     * @param name the method name
+     * @return the created object
+     * @throws IllegalArgumentException if {@code qualifier} was {@code null}
+     * @throws IllegalArgumentException if {@code typeArguments} was {@code null}
+     * @throws IllegalArgumentException if {@code name} was {@code null}
+     * @since 0.9.1
+     */
+    MethodReferenceExpression newMethodReferenceExpression(
+            TypeOrExpression qualifier,
+            List<? extends Type> typeArguments,
+            SimpleName name
     );
 
     /**

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelKind.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/ModelKind.java
@@ -22,7 +22,7 @@ import java.util.List;
 /**
  * Represents a kind of {@link Model}.
  * @since 0.1.0
- * @version 0.9.0
+ * @version 0.9.1
  */
 public enum ModelKind {
 
@@ -504,6 +504,25 @@ public enum ModelKind {
         PropertyKind.METHOD_INVOCATION_EXPRESSION_TYPE_ARGUMENTS,
         PropertyKind.METHOD_INVOCATION_EXPRESSION_NAME,
         PropertyKind.METHOD_INVOCATION_EXPRESSION_ARGUMENTS,
+    }),
+
+    /**
+     * Represents {@link MethodReferenceExpression}.
+     * @since 0.9.1
+     */
+    METHOD_REFERENCE_EXPRESSION(MethodReferenceExpression.class, new PropertyKind[] {
+        PropertyKind.METHOD_OR_CONSTRUCTOR_REFERENCE_EXPRESSION_QUALIFIER,
+        PropertyKind.METHOD_OR_CONSTRUCTOR_REFERENCE_EXPRESSION_TYPE_ARGUMENTS,
+        PropertyKind.METHOD_REFERENCE_EXPRESSION_NAME,
+    }),
+
+    /**
+     * Represents {@link ConstructorReferenceExpression}.
+     * @since 0.9.1
+     */
+    CONSTRUCTOR_REFERENCE_EXPRESSION(ConstructorReferenceExpression.class, new PropertyKind[] {
+        PropertyKind.METHOD_OR_CONSTRUCTOR_REFERENCE_EXPRESSION_QUALIFIER,
+        PropertyKind.METHOD_OR_CONSTRUCTOR_REFERENCE_EXPRESSION_TYPE_ARGUMENTS,
     }),
 
     /**

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/PropertyKind.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/PropertyKind.java
@@ -18,7 +18,7 @@ package com.asakusafw.utils.java.model.syntax;
 /**
  * Represents a kind of properties in {@link Model}.
  * @since 0.1.0
- * @version 0.9.0
+ * @version 0.9.1
  */
 public enum PropertyKind {
 
@@ -910,6 +910,33 @@ public enum PropertyKind {
     METHOD_INVOCATION_EXPRESSION_ARGUMENTS(
         MethodInvocationExpression.class,
         "arguments" //$NON-NLS-1$
+    ),
+
+    /**
+     * Represents {@link MethodOrConstructorReferenceExpression#getQualifier()}.
+     * @since 0.9.1
+     */
+    METHOD_OR_CONSTRUCTOR_REFERENCE_EXPRESSION_QUALIFIER(
+        MethodReferenceExpression.class,
+        "qualifier" //$NON-NLS-1$
+    ),
+
+    /**
+     * Represents {@link MethodOrConstructorReferenceExpression#getTypeArguments()}.
+     * @since 0.9.1
+     */
+    METHOD_OR_CONSTRUCTOR_REFERENCE_EXPRESSION_TYPE_ARGUMENTS(
+        MethodOrConstructorReferenceExpression.class,
+        "typeArguments" //$NON-NLS-1$
+    ),
+
+    /**
+     * Represents {@link MethodReferenceExpression#getName()}.
+     * @since 0.9.1
+     */
+    METHOD_REFERENCE_EXPRESSION_NAME(
+        MethodReferenceExpression.class,
+        "name" //$NON-NLS-1$
     ),
 
     /**

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/StrictVisitor.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/StrictVisitor.java
@@ -410,6 +410,20 @@ public abstract class StrictVisitor<R, C, E extends Throwable>
     }
 
     @Override
+    public R visitConstructorReferenceExpression(
+            ConstructorReferenceExpression elem,
+            C context) throws E {
+        throw new UnsupportedOperationException("ConstructorReferenceExpression"); //$NON-NLS-1$
+    }
+
+    @Override
+    public R visitMethodReferenceExpression(
+            MethodReferenceExpression elem,
+            C context) throws E {
+        throw new UnsupportedOperationException("MethodReferenceExpression"); //$NON-NLS-1$
+    }
+
+    @Override
     public R visitModifier(
             Modifier elem,
             C context) throws E {

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/TypeOrExpression.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/TypeOrExpression.java
@@ -16,15 +16,9 @@
 package com.asakusafw.utils.java.model.syntax;
 
 /**
- * An abstract super interface of types.
- * <ul>
- *   <li> Specified In: <ul>
- *     <li> {@code [JLS3:4] Types, Values, and Variables} </li>
- *   </ul> </li>
- * </ul>
+ * Represents either {@link Type} or {@link Expression}.
+ * @since 0.9.1
  */
-public interface Type
-        extends TypeOrExpression, TypedElement {
-
-    // properties
+public interface TypeOrExpression extends Model {
+    // no special members
 }

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/Visitor.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/syntax/Visitor.java
@@ -743,6 +743,32 @@ public abstract class Visitor<R, C, E extends Throwable> {
     }
 
     /**
+     * Processes {@link ConstructorReferenceExpression} using this visitor.
+     * @param elem the target element
+     * @param context the current context (nullable)
+     * @return the processing result
+     * @throws E if error was occurred while processing the target element
+     */
+    public R visitConstructorReferenceExpression(
+            ConstructorReferenceExpression elem,
+            C context) throws E {
+        return null;
+    }
+
+    /**
+     * Processes {@link MethodReferenceExpression} using this visitor.
+     * @param elem the target element
+     * @param context the current context (nullable)
+     * @return the processing result
+     * @throws E if error was occurred while processing the target element
+     */
+    public R visitMethodReferenceExpression(
+            MethodReferenceExpression elem,
+            C context) throws E {
+        return null;
+    }
+
+    /**
      * Processes {@link Modifier} using this visitor.
      * @param elem the target element
      * @param context the current context (nullable)

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/util/ExpressionBuilder.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/util/ExpressionBuilder.java
@@ -491,6 +491,66 @@ public class ExpressionBuilder {
         return chain(f.newMethodInvocationExpression(context, typeArguments, name, arguments));
     }
 
+    /**
+     * Returns the method reference using the building expression as its qualifier.
+     * @param name the target method name
+     * @return the chained expression builder
+     * @throws IllegalArgumentException if the parameters are {@code null}
+     */
+    public ExpressionBuilder methodReference(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("name must not be null"); //$NON-NLS-1$
+        }
+        return methodReference(Collections.emptyList(), f.newSimpleName(name));
+    }
+
+    /**
+     * Returns the method reference using the building expression as its qualifier.
+     * @param name the target method name
+     * @return the chained expression builder
+     * @throws IllegalArgumentException if the parameters are {@code null}
+     */
+    public ExpressionBuilder methodReference(SimpleName name) {
+        if (name == null) {
+            throw new IllegalArgumentException("name must not be null"); //$NON-NLS-1$
+        }
+        return methodReference(Collections.emptyList(), name);
+    }
+
+    /**
+     * Returns the method invocation using the building expression as its qualifier.
+     * @param typeArguments the type arguments
+     * @param name the target method name
+     * @return the chained expression builder
+     * @throws IllegalArgumentException if the parameters are {@code null}
+     */
+    public ExpressionBuilder methodReference(List<? extends Type> typeArguments, String name) {
+        if (typeArguments == null) {
+            throw new IllegalArgumentException("typeArguments must not be null"); //$NON-NLS-1$
+        }
+        if (name == null) {
+            throw new IllegalArgumentException("name must not be null"); //$NON-NLS-1$
+        }
+        return methodReference(typeArguments, f.newSimpleName(name));
+    }
+
+    /**
+     * Returns the method invocation using the building expression as its qualifier.
+     * @param typeArguments the type arguments
+     * @param name the target method name
+     * @return the chained expression builder
+     * @throws IllegalArgumentException if the parameters are {@code null}
+     */
+    public ExpressionBuilder methodReference(List<? extends Type> typeArguments, SimpleName name) {
+        if (typeArguments == null) {
+            throw new IllegalArgumentException("typeArguments must not be null"); //$NON-NLS-1$
+        }
+        if (name == null) {
+            throw new IllegalArgumentException("name must not be null"); //$NON-NLS-1$
+        }
+        return chain(f.newMethodReferenceExpression(context, typeArguments, name));
+    }
+
     private ExpressionBuilder chain(Expression expression) {
         assert expression != null;
         context = expression;

--- a/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/util/TypeBuilder.java
+++ b/utils-project/java-dom/src/main/java/com/asakusafw/utils/java/model/util/TypeBuilder.java
@@ -503,6 +503,87 @@ public class TypeBuilder {
         return expr(f.newMethodInvocationExpression(toNamedType().getName(), typeArguments, name, arguments));
     }
 
+    /**
+     * Returns the constructor invocation using the building type as its qualifier.
+     * @return the chained expression builder
+     */
+    public ExpressionBuilder constructorReference() {
+        return constructorReference(Collections.emptyList());
+    }
+
+    /**
+     * Returns the constructor invocation using the building type as its qualifier.
+     * @param typeArguments the type arguments
+     * @return the chained expression builder
+     * @throws IllegalArgumentException if the parameters are {@code null}
+     */
+    public ExpressionBuilder constructorReference(List<? extends Type> typeArguments) {
+        if (typeArguments == null) {
+            throw new IllegalArgumentException("typeArguments must not be null"); //$NON-NLS-1$
+        }
+        return expr(f.newConstructorReferenceExpression(context, typeArguments));
+    }
+
+    /**
+     * Returns the method reference using the building type as its qualifier.
+     * @param name the target method name
+     * @return the chained expression builder
+     * @throws IllegalArgumentException if the parameters are {@code null}
+     */
+    public ExpressionBuilder methodReference(String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("name must not be null"); //$NON-NLS-1$
+        }
+        return methodReference(Collections.emptyList(), f.newSimpleName(name));
+    }
+
+    /**
+     * Returns the method reference using the building type as its qualifier.
+     * @param name the target method name
+     * @return the chained expression builder
+     * @throws IllegalArgumentException if the parameters are {@code null}
+     */
+    public ExpressionBuilder methodReference(SimpleName name) {
+        if (name == null) {
+            throw new IllegalArgumentException("name must not be null"); //$NON-NLS-1$
+        }
+        return methodReference(Collections.emptyList(), name);
+    }
+
+    /**
+     * Returns the method invocation using the building type as its qualifier.
+     * @param typeArguments the type arguments
+     * @param name the target method name
+     * @return the chained expression builder
+     * @throws IllegalArgumentException if the parameters are {@code null}
+     */
+    public ExpressionBuilder methodReference(List<? extends Type> typeArguments, String name) {
+        if (typeArguments == null) {
+            throw new IllegalArgumentException("typeArguments must not be null"); //$NON-NLS-1$
+        }
+        if (name == null) {
+            throw new IllegalArgumentException("name must not be null"); //$NON-NLS-1$
+        }
+        return methodReference(typeArguments, f.newSimpleName(name));
+    }
+
+    /**
+     * Returns the method invocation using the building type as its qualifier.
+     * @param typeArguments the type arguments
+     * @param name the target method name
+     * @return the chained expression builder
+     * @throws IllegalArgumentException if the parameters are {@code null}
+     */
+    public ExpressionBuilder methodReference(List<? extends Type> typeArguments, SimpleName name) {
+        if (typeArguments == null) {
+            throw new IllegalArgumentException("typeArguments must not be null"); //$NON-NLS-1$
+        }
+        if (name == null) {
+            throw new IllegalArgumentException("name must not be null"); //$NON-NLS-1$
+        }
+        return expr(f.newMethodReferenceExpression(context, typeArguments, name));
+    }
+
     private TypeBuilder chain(Type type) {
         assert type != null;
         this.context = type;

--- a/utils-project/java-dom/src/test/java/com/asakusafw/utils/java/internal/model/util/ModelEmitterTest.java
+++ b/utils-project/java-dom/src/test/java/com/asakusafw/utils/java/internal/model/util/ModelEmitterTest.java
@@ -610,6 +610,70 @@ public class ModelEmitterTest {
     }
 
     /**
+     * constructor reference.
+     */
+    @Test
+    public void ConstructorReference_type() {
+        assertToString(
+            fromExpr("Hello",
+                // ((UnaryOperator<String>) String::new).apply("Hello, world!")
+                f.newMethodInvocationExpression(
+                        f.newCastExpression(
+                                f.newParameterizedType(
+                                        Models.toType(f, java.util.function.UnaryOperator.class),
+                                        Models.toType(f, String.class)),
+                                f.newConstructorReferenceExpression(
+                                        Models.toType(f, String.class))),
+                        f.newSimpleName("apply"),
+                        f.newLiteral("\"Hello, world!\""))),
+            "Hello",
+            "Hello, world!");
+    }
+
+    /**
+     * method reference.
+     */
+    @Test
+    public void MethodReference_type() {
+        assertToString(
+            fromExpr("Hello",
+                // ((UnaryOperator<String>) String::toString).apply("Hello, world!")
+                f.newMethodInvocationExpression(
+                        f.newCastExpression(
+                                f.newParameterizedType(
+                                        Models.toType(f, java.util.function.UnaryOperator.class),
+                                        Models.toType(f, String.class)),
+                                f.newMethodReferenceExpression(
+                                        Models.toType(f, String.class),
+                                        f.newSimpleName("toString"))),
+                        f.newSimpleName("apply"),
+                        f.newLiteral("\"Hello, world!\""))),
+            "Hello",
+            "Hello, world!");
+    }
+
+    /**
+     * method reference.
+     */
+    @Test
+    public void MethodReference_expression() {
+        assertToString(
+            fromExpr("Hello",
+                // ((Supplier<String>) "Hello, world!"::toString).get()
+                f.newMethodInvocationExpression(
+                        f.newCastExpression(
+                                f.newParameterizedType(
+                                        Models.toType(f, java.util.function.Supplier.class),
+                                        Models.toType(f, String.class)),
+                                f.newMethodReferenceExpression(
+                                        f.newLiteral("\"Hello, world!\""),
+                                        f.newSimpleName("toString"))),
+                        f.newSimpleName("get"))),
+            "Hello",
+            "Hello, world!");
+    }
+
+    /**
      * new object.
      */
     @Test


### PR DESCRIPTION
## Summary

This PR adds method reference expression into Java DOM.

## Background, Problem or Goal of the patch

In #665, we added lambda expressions (`x -> f(x)`) into Java DOM library, but we forgot to add method reference expressions (`Some::method`).

## Design of the fix, or a new feature

This introduces the two key interfaces `MethodReferenceExpression` and `ConstructorReferenceExpression`. The former can refer methods, and the latter refer constructors (`Some::new`). Because `new` is a reserved word, `MethodReferenceExpression` cannot handle it as a method name in the current implementation.

## Related Issue, Pull Request or Code

* #665

## Wanted reviewer

N/A.
