### PR TITLE
Enable Direct I/O `DataFormat` to keep test outputs.

### DIFF
--- a/testing-project/asakusa-test-driver/pom.xml
+++ b/testing-project/asakusa-test-driver/pom.xml
@@ -178,6 +178,11 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>asakusa-runtime</artifactId>
       <version>${project.version}</version>

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/DriverElementBase.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/DriverElementBase.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.conf.Configuration;
 import com.asakusafw.runtime.directio.DataFormat;
 import com.asakusafw.testdriver.core.DataModelDefinition;
 import com.asakusafw.testdriver.core.DataModelReflection;
+import com.asakusafw.testdriver.core.DataModelSinkFactory;
 import com.asakusafw.testdriver.core.DataModelSource;
 import com.asakusafw.testdriver.core.DataModelSourceFactory;
 import com.asakusafw.testdriver.core.DataModelSourceFilter;
@@ -259,6 +260,39 @@ public abstract class DriverElementBase {
                         transformer);
             }
         };
+    }
+
+    /**
+     * Converts an output path to {@link DataModelSinkFactory} to write to the path.
+     * @param <T> the data type
+     * @param definition the data model definition
+     * @param formatClass the data format class
+     * @param destinationFile the output path
+     * @return the target sink factory
+     * @since 0.9.1
+     */
+    protected final <T> DataModelSinkFactory toDataModelSinkFactory(
+            DataModelDefinition<T> definition,
+            Class<? extends DataFormat<? super T>> formatClass,
+            File destinationFile) {
+        if (definition == null) {
+            throw new IllegalArgumentException("definition must not be null"); //$NON-NLS-1$
+        }
+        if (formatClass == null) {
+            throw new IllegalArgumentException("formatClass must not be null"); //$NON-NLS-1$
+        }
+        if (destinationFile == null) {
+            throw new IllegalArgumentException("sourceFile must not be null"); //$NON-NLS-1$
+        }
+        try {
+            Configuration conf = ConfigurationFactory.getDefault().newInstance();
+            return DirectIoUtil.dump(conf, definition, formatClass, destinationFile);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(MessageFormat.format(
+                    MessageFormat.format(
+                            "error occurred while preparing Direct I/O output: {0}",
+                            destinationFile), e));
+        }
     }
 
     /**

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/FlowDriverOutput.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/FlowDriverOutput.java
@@ -566,6 +566,18 @@ public abstract class FlowDriverOutput<T, S extends FlowDriverOutput<T, S>> exte
     }
 
     /**
+     * Enables to store the result data set of this output.
+     * @param formatClass the data format class
+     * @param outputPath the output path
+     * @return this
+     * @since 0.9.1
+     */
+    public S dumpActual(Class<? extends DataFormat<? super T>> formatClass, File outputPath) {
+        DataModelDefinition<T> definition = getDataModelDefinition();
+        return dumpActual(toDataModelSinkFactory(definition, formatClass, outputPath));
+    }
+
+    /**
      * Enables to store the result differences of this output.
      * @param outputPath the output path
      * @return this

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/FlowDriverInputTest.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/FlowDriverInputTest.java
@@ -22,8 +22,10 @@ import static org.junit.Assert.*;
 import java.net.URI;
 
 import org.apache.hadoop.io.Text;
+import org.junit.ClassRule;
 import org.junit.Test;
 
+import com.asakusafw.runtime.windows.WindowsSupport;
 import com.asakusafw.testdriver.core.DataModelSourceFactory;
 import com.asakusafw.testdriver.testing.dsl.SimpleStreamFormat;
 import com.asakusafw.testdriver.testing.model.Simple;
@@ -33,6 +35,13 @@ import com.asakusafw.utils.io.Provider;
  * Test for {@link FlowDriverInput}.
  */
 public class FlowDriverInputTest {
+
+    /**
+     * Windows platform support.
+     */
+    @ClassRule
+    public static final WindowsSupport WINDOWS_SUPPORT = new WindowsSupport();
+
     /**
      * simple test for {@link FlowDriverInput#prepare(java.lang.String)}.
      */

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/testing/dsl/SimpleStreamFormat.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/testing/dsl/SimpleStreamFormat.java
@@ -74,7 +74,7 @@ public class SimpleStreamFormat extends BinaryStreamFormat<Simple> {
         return new ModelOutput<Simple>() {
             @Override
             public void write(Simple model) throws IOException {
-                writer.print(model.getValueAsString());
+                writer.println(model.getValueAsString());
             }
             @Override
             public void close() throws IOException {


### PR DESCRIPTION
## Summary

This PR enable Direct I/O `DataFormat` to keep test outputs (a.k.a. `dumpActual()`).

## Background, Problem or Goal of the patch

#701 and #704 have introduced Direct I/O `DataFormat` to generate test input data and expected output data. This additionally enables it for saving actual output data onto the local file system.
It may helps application developers to inspect the results by using external facilities.

## Design of the fix, or a new feature

This introduces the following new method:

* `{FlowPart,JobFlow}DriverOutput<T>.dumpActual(Class<? extends DataFormat<? super T>> formatClass, File expectedFile)`
    * saves the actual output data into the given file

Note that, this does not introduce `dumpActual(Class<? extends DataFormat<? super T>>, String)`, because this only supports local file system as its output target.

## Related Issue, Pull Request or Code

* #701 
* #704 

## Wanted reviewer

@akirakw 