### PR TITLE
Add another CSV text format support for Direct I/O.

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/csv/CsvFieldReader.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/csv/CsvFieldReader.java
@@ -1,0 +1,305 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.io.text.csv;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.text.MessageFormat;
+import java.util.NoSuchElementException;
+import java.util.function.UnaryOperator;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import com.asakusafw.runtime.io.text.FieldReader;
+import com.asakusafw.runtime.io.text.TextUtil;
+
+/**
+ * A {@link FieldReader} for RFC4180 style CSV files.
+ * @since 0.9.1
+ */
+public class CsvFieldReader implements FieldReader {
+
+    static final Log LOG = LogFactory.getLog(CsvFieldReader.class);
+
+    private static final int EOF = -1;
+
+    private final LineCursor lineCursor;
+
+    private final char fieldSeparator;
+
+    private final char quoteCharacter;
+
+    private final UnaryOperator<CharSequence> transformer;
+
+    private CharSequence currentLine;
+
+    private final StringBuilder fieldBuffer = new StringBuilder();
+
+    private int nextReadIndex = -1;
+
+    private long currentRecordIndex = -1;
+
+    private int currentFieldIndex = -1;
+
+    private State lastState = State.BEFORE_RECORD;
+
+    /**
+     * Creates a new instance.
+     * @param reader the source text reader
+     * @param fieldSeparator the field separator character
+     * @param quoteCharacter the quote character
+     * @param allowLineFeed {@code true} to allow LF in field, otherwise {@code false}
+     * @param transformer the line content transformer (nullable)
+     */
+    public CsvFieldReader(
+            Reader reader,
+            char fieldSeparator, char quoteCharacter,
+            boolean allowLineFeed,
+            UnaryOperator<CharSequence> transformer) {
+        this.lineCursor = new LineCursor(reader, quoteCharacter, fieldSeparator, allowLineFeed);
+        this.fieldSeparator = fieldSeparator;
+        this.quoteCharacter = quoteCharacter;
+        this.transformer = transformer == null ? UnaryOperator.identity() : transformer;
+    }
+
+    @Override
+    public boolean nextRecord() throws IOException {
+        lastState = State.BEFORE_RECORD;
+        currentLine = null;
+        currentFieldIndex = -1;
+        while (lineCursor.next()) {
+            CharSequence s = transformer.apply(lineCursor.getContent());
+            if (s == null) {
+                continue;
+            }
+            nextReadIndex = 0;
+            currentLine = s;
+            currentRecordIndex++;
+            return true;
+        }
+        currentRecordIndex = -1;
+        return false;
+    }
+
+    @Override
+    public boolean nextField() throws IOException {
+        if (lastState.moreFields == false) {
+            nextReadIndex = -1;
+            currentFieldIndex = -1;
+            lastState = State.AFTER_RECORD;
+            return false;
+        }
+        State state = State.BEGIN_FIELD;
+        CharSequence line = currentLine;
+        assert line != null;
+        fieldBuffer.setLength(0);
+        int index = nextReadIndex;
+        do {
+            int c = index == line.length() ? EOF : line.charAt(index++);
+            switch (state) {
+            case BEGIN_FIELD:
+                state = doBeginField(c);
+                break;
+            case BARE_BODY:
+                state = doBareBody(c);
+                break;
+            case QUOTE_BODY:
+                state = doQuoteBody(c);
+                break;
+            case QUOTE_BODY_SAW_QUOTE:
+                state = doQuoteBodySawQuote(c);
+                break;
+            default:
+                throw new AssertionError(lastState);
+            }
+        } while (state.moreCharacters);
+
+        nextReadIndex = index;
+        currentFieldIndex++;
+        lastState = state;
+        return true;
+    }
+
+    private State doBeginField(int c) {
+        if (c == quoteCharacter) {
+            // QUOTE
+            return State.QUOTE_BODY;
+        } else if (c == fieldSeparator) {
+            // FS
+            return State.END_OF_FIELD;
+        } else if (c == EOF) {
+            // EOF
+            return State.END_OF_RECORD;
+        } else {
+            // CR
+            // LF
+            // c
+            emit(c);
+            return State.BARE_BODY;
+        }
+    }
+
+    private State doBareBody(int c) {
+        if (c == quoteCharacter) {
+            // QUOTE
+            error(ErrorCode.UNEXPECTED_QUOTE);
+            emit(c);
+            return State.BARE_BODY;
+        } else if (c == fieldSeparator) {
+            // FS
+            return State.END_OF_FIELD;
+        } else if (c == EOF) {
+            // EOF
+            return State.END_OF_RECORD;
+        } else {
+            // c
+            emit(c);
+            return State.BARE_BODY;
+        }
+    }
+
+    private State doQuoteBody(int c) {
+        if (c == quoteCharacter) {
+            // QUOTE
+            return State.QUOTE_BODY_SAW_QUOTE;
+        } else if (c == EOF) {
+            // EOF
+            error(ErrorCode.UNEXPECTED_END_OF_FILE_IN_QUOTE);
+            return State.END_OF_RECORD;
+        } else {
+            // FS
+            // c
+            emit(c);
+            return State.QUOTE_BODY;
+        }
+    }
+
+    private State doQuoteBodySawQuote(int c) {
+        if (c == quoteCharacter) {
+            // QUOTE
+            emit(c);
+            return State.QUOTE_BODY;
+        } else if (c == fieldSeparator) {
+            // FS
+            return State.END_OF_FIELD;
+        } else if (c == EOF) {
+            // EOF
+            return State.END_OF_RECORD;
+        } else {
+            // c
+            error(ErrorCode.UNEXPECTED_END_OF_QUOTE);
+            emit(quoteCharacter);
+            emit(c);
+            return State.QUOTE_BODY;
+        }
+    }
+
+    private void emit(int c) {
+        fieldBuffer.append((char) c);
+    }
+
+    private void error(ErrorCode code) {
+        LOG.warn(MessageFormat.format(
+                "code={0}, contents={1}, column={2}",
+                code,
+                TextUtil.quote(currentLine),
+                nextReadIndex + 1));
+    }
+
+    @Override
+    public void rewindFields() throws IOException {
+        lastState = State.BEFORE_RECORD;
+        currentFieldIndex = -1;
+        nextReadIndex = 0;
+    }
+
+    @Override
+    public CharSequence getContent() {
+        switch (lastState) {
+        case END_OF_FIELD:
+        case END_OF_RECORD:
+            return fieldBuffer;
+        case BEFORE_RECORD:
+        case AFTER_RECORD:
+            throw new NoSuchElementException(String.format(
+                    "line-number=%,d, record-index=%,d, field-index=%,d, last-state=%s", //$NON-NLS-1$
+                    getRecordLineNumber(),
+                    getRecordIndex(),
+                    getFieldIndex(),
+                    lastState));
+        default:
+            throw new AssertionError(lastState);
+        }
+    }
+
+    @Override
+    public long getRecordLineNumber() {
+        return lineCursor.getLineNumber();
+    }
+
+    @Override
+    public long getRecordIndex() {
+        return currentRecordIndex;
+    }
+
+    @Override
+    public long getFieldIndex() {
+        return currentFieldIndex;
+    }
+
+    @Override
+    public void close() throws IOException {
+        currentLine = null;
+        currentFieldIndex = -1;
+        currentRecordIndex = -1;
+        lastState = State.AFTER_RECORD;
+        lineCursor.close();
+    }
+
+    private enum State {
+        // in decode
+        BEGIN_FIELD(true, false),
+        BARE_BODY(true, false),
+        QUOTE_BODY(true, false),
+        QUOTE_BODY_SAW_QUOTE(true, false),
+
+        // decode end
+        END_OF_FIELD(false, true),
+        END_OF_RECORD(false, false),
+
+        // lifecycle
+        BEFORE_RECORD(false, true),
+        AFTER_RECORD(false, false),
+        ;
+        final boolean moreCharacters;
+        final boolean moreFields;
+
+        State(boolean continueField, boolean continueRecord) {
+            this.moreCharacters = continueField;
+            this.moreFields = continueRecord;
+        }
+    }
+
+    private enum ErrorCode {
+
+        UNEXPECTED_QUOTE,
+
+        UNEXPECTED_END_OF_FILE_IN_QUOTE,
+
+        UNEXPECTED_END_OF_QUOTE,
+    }
+}

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/csv/CsvFieldWriter.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/csv/CsvFieldWriter.java
@@ -1,0 +1,291 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.io.text.csv;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+import com.asakusafw.runtime.io.text.FieldWriter;
+import com.asakusafw.runtime.io.text.LineSeparator;
+import com.asakusafw.runtime.io.text.TextUtil;
+import com.asakusafw.runtime.io.text.UnmappableOutput;
+import com.asakusafw.runtime.io.text.UnmappableOutputException;
+import com.asakusafw.runtime.io.text.driver.FieldOutput;
+import com.asakusafw.runtime.io.text.driver.StandardFieldOutputOption;
+
+/**
+ * A {@link FieldWriter} for RFC4180 style CSV files.
+ * @since 0.9.1
+ */
+public class CsvFieldWriter implements FieldWriter {
+
+    private final Writer writer;
+
+    private final char fieldSeparator;
+
+    private final char quoteCharacter;
+
+    private final String recordSeparatorSequence;
+
+    private final boolean denyLineFeedInQuote;
+
+    private final QuoteStyle defaultQuoteStyle;
+
+    private final QuoteStyle headerQuoteStyle;
+
+    private final UnaryOperator<CharSequence> transformer;
+
+    private final StringBuilder lineBuffer = new StringBuilder();
+
+    private int currentFieldIndex = -1;
+
+    private final List<UnmappableOutput> unmappables = new ArrayList<>();
+
+    private char[] writeBuffer;
+
+    private State lastState = State.BEFORE_RECORD;
+
+    /**
+     * Creates a new instance.
+     * @param writer the destination writer
+     * @param lineSeparator the line separator kind
+     * @param fieldSeparator the field separator character
+     * @param quoteCharacter the quote character
+     * @param allowLineFeed {@code true} to allow LF in field, otherwise {@code false}
+     * @param defaultQuoteStyle the default quote style
+     * @param headerQuoteStyle the quote style for headers
+     * @param transformer the output transformer (nullable)
+     */
+    public CsvFieldWriter(
+            Writer writer,
+            LineSeparator lineSeparator, char fieldSeparator, char quoteCharacter,
+            boolean allowLineFeed,
+            QuoteStyle defaultQuoteStyle, QuoteStyle headerQuoteStyle,
+            UnaryOperator<CharSequence> transformer) {
+        this.writer = writer;
+        this.fieldSeparator = fieldSeparator;
+        this.quoteCharacter = quoteCharacter;
+        this.recordSeparatorSequence = lineSeparator.getSequence();
+        this.denyLineFeedInQuote = allowLineFeed == false;
+        this.defaultQuoteStyle = defaultQuoteStyle;
+        this.headerQuoteStyle = headerQuoteStyle;
+        this.transformer = transformer == null ? UnaryOperator.identity() : transformer;
+    }
+
+    @Override
+    public void putField(FieldOutput output) throws IOException {
+        CharSequence contents = output.get();
+        switch (lastState) {
+        case BEFORE_RECORD:
+            break;
+        case END_OF_FIELD:
+            putEndOfFieldBody();
+            break;
+        default:
+            throw new AssertionError(lastState);
+        }
+        currentFieldIndex++;
+        if (contents == null) {
+            handleUnmap(UnmappableOutput.ErrorCode.UNDEFINED_NULL_SEQUENCE);
+        } else {
+            QuoteStyle style = computeQuoteStyle(output);
+            switch (style) {
+            case NEEDED:
+                putFieldComputeQuote(contents);
+                break;
+            case ALWAYS:
+                putFieldAlwaysQuote(contents);
+                break;
+            case NEVER:
+                putFieldNeverQuote(contents);
+                break;
+            default:
+                throw new AssertionError(style);
+            }
+        }
+        lastState = State.END_OF_FIELD;
+    }
+
+    private QuoteStyle computeQuoteStyle(FieldOutput output) {
+        Collection<? extends FieldOutput.Option> options = output.getOptions();
+        QuoteStyle result = defaultQuoteStyle;
+        if (options.isEmpty() == false) {
+            for (FieldOutput.Option option : options) {
+                if (option instanceof QuoteStyle) {
+                    result = (QuoteStyle) option;
+                    break;
+                } else if (option == StandardFieldOutputOption.HEADER) {
+                    result = headerQuoteStyle;
+                }
+            }
+        }
+        return result;
+    }
+
+    private void putFieldComputeQuote(CharSequence contents) {
+        if (isQuoteRequired(contents)) {
+            putWithQuote(contents);
+        } else {
+            emit(contents);
+        }
+    }
+
+    private void putFieldAlwaysQuote(CharSequence contents) {
+        putWithQuote(contents);
+    }
+
+    private void putFieldNeverQuote(CharSequence contents) {
+        boolean sawCr = false;
+        for (int i = 0, n = contents.length(); i < n; i++) {
+            char c = contents.charAt(i);
+            if (c == '\r') {
+                handleUnmap(UnmappableOutput.ErrorCode.EXTRA_RECORD_SEPARATOR);
+                sawCr = true;
+            } else if (c == '\n') {
+                if (sawCr == false) {
+                    handleUnmap(UnmappableOutput.ErrorCode.EXTRA_RECORD_SEPARATOR);
+                }
+                sawCr = false;
+            } else if (c == fieldSeparator) {
+                handleUnmap(UnmappableOutput.ErrorCode.EXTRA_FIELD_SEPARATOR);
+                sawCr = false;
+            } else if (c == quoteCharacter) {
+                handleUnmap(UnmappableOutput.ErrorCode.RESTRICTED_SEQUENCE,
+                        TextUtil.quote(String.valueOf(c)));
+                sawCr = false;
+            }
+            emit(c);
+        }
+    }
+
+    private void putWithQuote(CharSequence contents) {
+        emit(quoteCharacter);
+        for (int i = 0, n = contents.length(); i < n; i++) {
+            char c = contents.charAt(i);
+            if (c == '\n' && denyLineFeedInQuote) {
+                handleUnmap(UnmappableOutput.ErrorCode.RESTRICTED_SEQUENCE,
+                        TextUtil.quote(String.valueOf('\n')));
+            } else if (c == quoteCharacter) {
+                emit(c);
+            }
+            emit(c);
+        }
+        emit(quoteCharacter);
+    }
+
+    @Override
+    public void putEndOfRecord() throws IOException {
+        CharSequence output = transformer.apply(lineBuffer);
+        if (output != null) {
+            write(output);
+            resetBuffer();
+            switch (lastState) {
+            case BEFORE_RECORD:
+                handleUnmap(UnmappableOutput.ErrorCode.EXTRA_EMPTY_FIELD);
+                putEndOfRecordBody();
+                break;
+            case END_OF_FIELD:
+                putEndOfRecordBody();
+                break;
+            default:
+                throw new AssertionError(lastState);
+            }
+            write(lineBuffer);
+        }
+        resetBuffer();
+        currentFieldIndex = -1;
+        lastState = State.BEFORE_RECORD;
+
+        if (unmappables.isEmpty() == false) {
+            // Raise UnmappableOutputException even if the output was transformed
+            UnmappableOutputException e = new UnmappableOutputException(unmappables);
+            unmappables.clear();
+            throw e;
+        }
+    }
+
+    private void putEndOfFieldBody() {
+        emit(fieldSeparator);
+    }
+
+    private void putEndOfRecordBody() {
+        emit(recordSeparatorSequence);
+    }
+
+    private boolean isQuoteRequired(CharSequence cs) {
+        for (int i = 0, n = cs.length(); i < n; i++) {
+            char c = cs.charAt(i);
+            if (c == '\r' || c == '\n' || c == fieldSeparator || c == quoteCharacter) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void emit(int c) {
+        assert c >= 0;
+        lineBuffer.append((char) c);
+    }
+
+    private void emit(CharSequence string) {
+        lineBuffer.append(string);
+    }
+
+    private void write(CharSequence output) throws IOException {
+        // java.io.Writer#write() may call CharSequence.toString()
+        if (output instanceof StringBuilder) {
+            StringBuilder src = (StringBuilder) output;
+            char[] cbuf = writeBuffer;
+            if (cbuf == null) {
+                cbuf = new char[4096];
+                writeBuffer = cbuf;
+            }
+            for (int offset = 0, step = cbuf.length, n = output.length(); offset < n; offset += step) {
+                int length = Math.min(n - offset, step);
+                src.getChars(offset, offset + length, cbuf, 0);
+                writer.write(cbuf, 0, length);
+            }
+        } else {
+            writer.append(output);
+        }
+    }
+
+    private void resetBuffer() {
+        lineBuffer.setLength(0);
+    }
+
+    private void handleUnmap(UnmappableOutput.ErrorCode kind) {
+        handleUnmap(kind, null);
+    }
+
+    private void handleUnmap(UnmappableOutput.ErrorCode kind, String sequence) {
+        unmappables.add(new UnmappableOutput(kind, currentFieldIndex, sequence));
+    }
+
+    @Override
+    public void close() throws IOException {
+        writer.close();
+    }
+
+    private enum State {
+        BEFORE_RECORD,
+        END_OF_FIELD,
+    }
+}

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/csv/CsvTextFormat.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/csv/CsvTextFormat.java
@@ -1,0 +1,322 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.io.text.csv;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+
+import com.asakusafw.runtime.io.text.LineSeparator;
+import com.asakusafw.runtime.io.text.TextFormat;
+
+/**
+ * An implementation of {@link TextFormat} for  RFC4180 style CSV files.
+ * @since 0.9.1
+ */
+public class CsvTextFormat implements TextFormat {
+
+    /**
+     * The default charset.
+     */
+    public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
+
+    /**
+     * The default line separator.
+     */
+    public static final LineSeparator DEFAULT_LINE_SEPARATOR = LineSeparator.WINDOWS;
+
+    /**
+     * The default field separator.
+     */
+    public static final char DEFAULT_FIELD_SEPARATOR = ',';
+
+    /**
+     * The default quote character.
+     */
+    public static final char DEFAULT_QUOTE_CHARACTER = '"';
+
+    /**
+     * The default value of whether or not line-feed characters can appear in field.
+     */
+    public static final boolean DEFAULT_ALLOW_LINE_FEED_IN_FIELD = false;
+
+    /**
+     * The default quote style.
+     */
+    public static final QuoteStyle DEFAULT_QUOTE_STYLE = QuoteStyle.NEEDED;
+
+    private final Charset charset;
+
+    private final LineSeparator lineSeparator;
+
+    private final char fieldSeparator;
+
+    private final char quoteCharacter;
+
+    private final boolean allowLineFeedInField;
+
+    private final QuoteStyle defaultQuoteStyle;
+
+    private final QuoteStyle headerQuoteStyle;
+
+    private final Supplier<? extends UnaryOperator<CharSequence>> inputTransformer;
+
+    private final Supplier<? extends UnaryOperator<CharSequence>> outputTransformer;
+
+    CsvTextFormat(
+            Charset charset,
+            LineSeparator lineSeparator, char fieldSeparator, char quoteCharacter,
+            boolean allowLineFeedInQuote,
+            QuoteStyle defaultQuoteStyle, QuoteStyle headerQuoteStyle,
+            Supplier<? extends UnaryOperator<CharSequence>> inputTransformer,
+            Supplier<? extends UnaryOperator<CharSequence>> outputTransformer) {
+        this.charset = charset;
+        this.lineSeparator = lineSeparator;
+        this.fieldSeparator = fieldSeparator;
+        this.quoteCharacter = quoteCharacter;
+        this.allowLineFeedInField = allowLineFeedInQuote;
+        this.defaultQuoteStyle = defaultQuoteStyle;
+        this.headerQuoteStyle = headerQuoteStyle;
+        this.inputTransformer = inputTransformer != null ? inputTransformer : () -> null;
+        this.outputTransformer = outputTransformer != null ? outputTransformer : () -> null;
+    }
+
+    /**
+     * Returns a new builder.
+     * @return the created builder
+     */
+    public static final Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public CsvFieldReader open(InputStream input) throws IOException {
+        return open(new InputStreamReader(input, charset));
+    }
+
+    @Override
+    public CsvFieldWriter open(OutputStream output) throws IOException {
+        return open(new OutputStreamWriter(output, charset));
+    }
+
+    @Override
+    public CsvFieldReader open(Reader input) throws IOException {
+        return new CsvFieldReader(input,
+                fieldSeparator, quoteCharacter,
+                allowLineFeedInField,
+                inputTransformer.get());
+    }
+
+    @Override
+    public CsvFieldWriter open(Writer output) throws IOException {
+        return new CsvFieldWriter(
+                output,
+                lineSeparator, fieldSeparator, quoteCharacter,
+                allowLineFeedInField,
+                defaultQuoteStyle, headerQuoteStyle,
+                outputTransformer.get());
+    }
+
+    Charset getCharset() {
+        return charset;
+    }
+
+    LineSeparator getLineSeparator() {
+        return lineSeparator;
+    }
+
+    /**
+     * A builder of {@link CsvTextFormat}.
+     * @since 0.9.1
+     */
+    public static class Builder {
+
+        private Charset charset = DEFAULT_CHARSET;
+
+        private LineSeparator lineSeparator = DEFAULT_LINE_SEPARATOR;
+
+        private char fieldSeparator = DEFAULT_FIELD_SEPARATOR;
+
+        private char quoteCharacter = DEFAULT_QUOTE_CHARACTER;
+
+        private boolean allowLineFeedInField = DEFAULT_ALLOW_LINE_FEED_IN_FIELD;
+
+        private QuoteStyle defaultQuoteStyle = DEFAULT_QUOTE_STYLE;
+
+        private Optional<QuoteStyle> headerQuoteStyle = Optional.empty();
+
+        private Supplier<? extends UnaryOperator<CharSequence>> inputTransformer;
+
+        private Supplier<? extends UnaryOperator<CharSequence>> outputTransformer;
+
+        /**
+         * Sets the charset name.
+         * @param newValue the charset name
+         * @return this
+         */
+        public Builder withCharset(String newValue) {
+            Charset cs = newValue != null ? Charset.forName(newValue) : null;
+            return withCharset(cs);
+        }
+
+        /**
+         * Sets the charset.
+         * @param newValue the charset
+         * @return this
+         */
+        public Builder withCharset(Charset newValue) {
+            this.charset = newValue;
+            return this;
+        }
+
+        /**
+         * Sets the line separator.
+         * @param newValue the line separator
+         * @return this
+         */
+        public Builder withLineSeparator(LineSeparator newValue) {
+            this.lineSeparator = newValue;
+            return this;
+        }
+
+        /**
+         * Sets the field separator.
+         * @param newValue the field separator
+         * @return this
+         */
+        public Builder withFieldSeparator(char newValue) {
+            this.fieldSeparator = newValue;
+            return this;
+        }
+
+        /**
+         * Sets the quote character.
+         * @param newValue the quote character
+         * @return this
+         */
+        public Builder withQuoteCharacter(char newValue) {
+            this.quoteCharacter = newValue;
+            return this;
+        }
+
+        /**
+         * Sets whether or not line-feed characters can appear in fields.
+         * @param newValue {@code true} if it is enabled, otherwise {@code false}
+         * @return this
+         */
+        public Builder withAllowLineFeedInField(boolean newValue) {
+            this.allowLineFeedInField = newValue;
+            return this;
+        }
+
+        /**
+         * Sets the default quote style.
+         * @param newValue the quote style
+         * @return this
+         */
+        public Builder withDefaultQuoteStyle(QuoteStyle newValue) {
+            this.defaultQuoteStyle = newValue;
+            return this;
+        }
+
+        /**
+         * Sets the quote style for header fields.
+         * @param newValue the quote style
+         * @return this
+         */
+        public Builder withHeaderQuoteStyle(QuoteStyle newValue) {
+            this.headerQuoteStyle = Optional.ofNullable(newValue);
+            return this;
+        }
+
+        /**
+         * Sets the input transformer class.
+         * @param newValue the input transformer class
+         * @return this
+         */
+        public Builder withInputTransformer(Class<? extends UnaryOperator<CharSequence>> newValue) {
+            return withInputTransformer(asSupplier(newValue));
+        }
+
+        /**
+         * Sets the input transformer.
+         * @param newValue the input transformer
+         * @return this
+         */
+        public Builder withInputTransformer(Supplier<? extends UnaryOperator<CharSequence>> newValue) {
+            this.inputTransformer = newValue;
+            return this;
+        }
+
+        /**
+         * Sets the output transformer class.
+         * @param newValue the output transformer class
+         * @return this
+         */
+        public Builder withOutputTransformer(Class<? extends UnaryOperator<CharSequence>> newValue) {
+            return withOutputTransformer(asSupplier(newValue));
+        }
+
+        /**
+         * Sets the output transformer.
+         * @param newValue the output transformer
+         * @return this
+         */
+        public Builder withOutputTransformer(Supplier<? extends UnaryOperator<CharSequence>> newValue) {
+            this.outputTransformer = newValue;
+            return this;
+        }
+
+        private static Supplier<? extends UnaryOperator<CharSequence>> asSupplier(
+                Class<? extends UnaryOperator<CharSequence>> aClass) {
+            if (aClass == null) {
+                return null;
+            }
+            return () -> {
+                try {
+                    return aClass.newInstance();
+                } catch (ReflectiveOperationException e) {
+                    throw new IllegalArgumentException(MessageFormat.format(
+                            "failed to instantiate: {0}",
+                            aClass.getName()), e);
+                }
+            };
+        }
+
+        /**
+         * Builds a {@link CsvTextFormat}.
+         * @return the built object
+         */
+        public CsvTextFormat build() {
+            return new CsvTextFormat(
+                    charset,
+                    lineSeparator, fieldSeparator, quoteCharacter,
+                    allowLineFeedInField,
+                    defaultQuoteStyle, headerQuoteStyle.orElse(defaultQuoteStyle),
+                    inputTransformer, outputTransformer);
+        }
+    }
+}

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/csv/LineCursor.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/csv/LineCursor.java
@@ -1,0 +1,383 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.io.text.csv;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Reader;
+import java.text.MessageFormat;
+
+import com.asakusafw.runtime.io.text.TextFormatException;
+import com.asakusafw.runtime.io.text.TextUtil;
+
+/**
+ * Extracts records delimited by line separator characters.
+ * @since 0.9.1
+ */
+final class LineCursor implements Closeable {
+
+    static final int READ_BUFFER_SIZE = 4096;
+
+    private static final int EOF = -1;
+
+    private final Reader reader;
+
+    private final char quoteCharacter;
+
+    private final char fieldSeparator;
+
+    private final boolean denyLineFeedInQuote;
+
+    private final StringBuilder lineBuffer = new StringBuilder();
+
+    private final char[] readBuffer = new char[READ_BUFFER_SIZE];
+
+    private int readOffset = 0;
+
+    private int readLimit = 0;
+
+    private int emitOffset = 0;
+
+    private long currentLineNumber = -1L;
+
+    private long nextLineNumber = 0L;
+
+    private boolean sawInvalidLineFeed = false;
+
+    LineCursor(Reader reader, char quoteCharacter, char fieldSeparator, boolean allowLineFeed) {
+        this.reader = reader;
+        this.quoteCharacter = quoteCharacter;
+        this.fieldSeparator = fieldSeparator;
+        this.denyLineFeedInQuote = allowLineFeed == false;
+    }
+
+    public boolean next() throws IOException {
+        State state = State.BEGIN_RECORD;
+        lineBuffer.setLength(0);
+        currentLineNumber = nextLineNumber;
+        do {
+            int c = get();
+            switch (state) {
+            case BEGIN_RECORD:
+                state = doBeginRecord(c);
+                break;
+            case BEGIN_FIELD:
+                state = doBeginField(c);
+                break;
+            case BARE_BODY:
+                state = doBareBody(c);
+                break;
+            case BODY_SAW_CR:
+                state = doBodySawCr(c);
+                break;
+            case QUOTE_BODY:
+                state = doQuoteBody(c);
+                break;
+            case QUOTE_BODY_SAW_CR:
+                state = doQuoteBodySawCr(c);
+                break;
+            case QUOTE_BODY_SAW_QUOTE:
+                state = doQuoteBodySawQuote(c);
+                break;
+            default:
+                throw new AssertionError(state);
+            }
+        } while (state.more);
+        if (sawInvalidLineFeed) {
+            sawInvalidLineFeed = false;
+            throw new TextFormatException(MessageFormat.format(
+                    "no line-feed in quote is allowed: {0}",
+                    TextUtil.quote(lineBuffer)));
+        }
+        return state == State.END_OF_RECORD;
+    }
+
+    private State doBeginRecord(int c) {
+        if (c == EOF) {
+            return State.END_OF_CONTENT;
+        } else {
+            return doBeginField(c);
+        }
+    }
+
+    // ^ ...
+    private State doBeginField(int c) {
+        if (c == quoteCharacter) {
+            // ^ QUOTE
+            return State.QUOTE_BODY;
+        } else if (c == fieldSeparator) {
+            // ^ FS
+            return State.BEGIN_FIELD; // empty field
+        } else if (c == '\r') {
+            // ^ CR
+            return State.BODY_SAW_CR;
+        } else if (c == '\n') {
+            // ^ LF
+            nextLineNumber++;
+            emit(-1);
+            return State.END_OF_RECORD;
+        } else if (c == EOF) {
+            // ^ EOF
+            emit(0);
+            return State.END_OF_RECORD;
+        } else {
+            // ^ c
+            return State.BARE_BODY;
+        }
+    }
+
+    // ^ !QUOTE ...
+    private State doBareBody(int c) {
+        if (c == quoteCharacter) {
+            // QUOTE
+            // NOTE: unexpected quote in bare body
+            return State.BARE_BODY;
+        } else if (c == fieldSeparator) {
+            // FS
+            return State.BEGIN_FIELD;
+        } else if (c == '\r') {
+            // CR
+            return State.BODY_SAW_CR;
+        } else if (c == '\n') {
+            // LF
+            nextLineNumber++;
+            emit(-1);
+            return State.END_OF_RECORD;
+        } else if (c == EOF) {
+            // EOF
+            emit(0);
+            return State.END_OF_RECORD;
+        } else {
+            // c
+            return State.BARE_BODY;
+        }
+    }
+
+    // CR, ...
+    private State doBodySawCr(int c) {
+        nextLineNumber++;
+        if (c == '\n') {
+            // CR LF
+            emit(-2);
+            return State.END_OF_RECORD;
+        } else if (c == EOF) {
+            // CR EOF
+            emit(-1);
+            return State.END_OF_RECORD;
+        } else {
+            // CR c
+            // CR QUOTE
+            // CR FS
+            // CR CR
+            pushBack();
+            emit(-1);
+            return State.END_OF_RECORD;
+        }
+    }
+
+    // ^ QUOTE, *, ...
+    private State doQuoteBody(int c) {
+        if (c == quoteCharacter) {
+            // (in-quote) QUOTE
+            return State.QUOTE_BODY_SAW_QUOTE;
+        } else if (c == '\r') {
+            // (in-quote) CR
+            return State.QUOTE_BODY_SAW_CR;
+        } else if (c == '\n') {
+            // (in-quote) LF
+            recordLineFeedInQuote();
+            nextLineNumber++;
+            return State.QUOTE_BODY;
+        } else if (c == EOF) {
+            // (in-quote) EOF
+            // NOTE: unexpected end of file
+            emit(0);
+            return State.END_OF_RECORD;
+        } else {
+            // (in-quote) c
+            // (in-quote) FS
+            return State.QUOTE_BODY;
+        }
+    }
+
+    // ^ QUOTE, *, CR, ...
+    private State doQuoteBodySawCr(int c) {
+        nextLineNumber++;
+        if (c == quoteCharacter) {
+            // (in-quote) CR QUOTE
+            return State.QUOTE_BODY_SAW_QUOTE;
+        } else if (c == '\r') {
+            // (in-quote) CR CR
+            return State.QUOTE_BODY_SAW_CR;
+        } else if (c == '\n') {
+            // (in-quote) CR LF
+            recordLineFeedInQuote();
+            return State.QUOTE_BODY;
+        } else if (c == EOF) {
+            // (in-quote) EOF
+            // NOTE: unexpected end of file
+            emit(0);
+            return State.END_OF_RECORD;
+        } else {
+            // (in-quote) c
+            // (in-quote) FS
+            // (in-quote) LF
+            return State.QUOTE_BODY;
+        }
+    }
+
+    // ^ QUOTE, *, QUOTE, ...
+    private State doQuoteBodySawQuote(int c) {
+        if (c == quoteCharacter) {
+            // (in-quote) QUOTE QUOTE
+            return State.QUOTE_BODY;
+        } else if (c == fieldSeparator) {
+            // (in-quote) QUOTE FS
+            return State.BEGIN_FIELD;
+        } else if (c == '\r') {
+            // (in-quote) QUOTE CR
+            return State.BODY_SAW_CR;
+        } else if (c == '\n') {
+            // (in-quote) QUOTE LF
+            nextLineNumber++;
+            emit(-1);
+            return State.END_OF_RECORD;
+        } else if (c == EOF) {
+            // (in-quote) QUOTE EOF
+            emit(0);
+            return State.END_OF_RECORD;
+        } else {
+            // (in-quote) QUOTE c
+            // NOTE: unexpected end of quote
+            return State.QUOTE_BODY;
+        }
+    }
+
+    private void recordLineFeedInQuote() {
+        if (denyLineFeedInQuote) {
+            sawInvalidLineFeed = true;
+        }
+    }
+
+    private int get() throws IOException {
+        if (prepareBuffer()) {
+            return readBuffer[readOffset++];
+        }
+        return EOF;
+    }
+
+    private void pushBack() {
+        assert readOffset != 0;
+        readOffset--;
+    }
+
+    private void emit(int offset) {
+        assert offset <= 0;
+        int flushLimit = readOffset + offset;
+        if (flushLimit > emitOffset) {
+            // remains characters to emit
+            flush(flushLimit);
+        } else {
+            // some characters were already emitted
+            int dropCount = emitOffset - flushLimit;
+            if (dropCount > 0) {
+                assert lineBuffer.length() >= dropCount;
+                lineBuffer.delete(lineBuffer.length() - dropCount, lineBuffer.length());
+            }
+        }
+        emitOffset = readOffset;
+    }
+
+    private boolean prepareBuffer() throws IOException {
+        if (readOffset < readLimit) {
+            return true;
+        }
+        // is read buffer full?
+        if (readLimit == readBuffer.length) {
+            flush(readLimit);
+            emitOffset = 0;
+            readLimit = 0;
+            readOffset = 0;
+        }
+        // read to buffer
+        int count = reader.read(readBuffer, readLimit, readBuffer.length - readLimit);
+        if (count < 0) {
+            return false;
+        } else if (count > 0) {
+            readLimit += count;
+            return true;
+        }
+        // for non-blocking readers?
+        int c = reader.read();
+        if (c < 0) {
+            return false;
+        } else {
+            readBuffer[readLimit++] = (char) c;
+            return true;
+        }
+    }
+
+    private void flush(int end) {
+        int offset = emitOffset;
+        assert offset <= end;
+        if (offset < end) {
+            lineBuffer.append(readBuffer, offset, end - offset);
+        }
+        emitOffset = end;
+    }
+
+    public long getLineNumber() {
+        return currentLineNumber;
+    }
+
+    public CharSequence getContent() {
+        return lineBuffer;
+    }
+
+    @Override
+    public void close() throws IOException {
+        currentLineNumber = -1;
+        reader.close();
+    }
+
+    private enum State {
+
+        BEGIN_RECORD(true),
+
+        BEGIN_FIELD(true),
+
+        BARE_BODY(true),
+
+        BODY_SAW_CR(true),
+
+        QUOTE_BODY(true),
+
+        QUOTE_BODY_SAW_QUOTE(true),
+
+        QUOTE_BODY_SAW_CR(true),
+
+        END_OF_RECORD(false),
+
+        END_OF_CONTENT(false),
+        ;
+
+        final boolean more;
+
+        State(boolean more) {
+            this.more = more;
+        }
+    }
+}

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/csv/QuoteStyle.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/csv/QuoteStyle.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.io.text.csv;
+
+import com.asakusafw.runtime.io.text.driver.FieldOutput;
+
+/**
+ * Field quote style on output.
+ * @since 0.9.1
+ */
+public enum QuoteStyle implements FieldOutput.Option {
+
+    /**
+     * Always quote fields.
+     */
+    ALWAYS,
+
+    /**
+     * Never quote fields.
+     */
+    NEVER,
+
+    /**
+     * Quote only if needed.
+     */
+    NEEDED,
+}

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/csv/package-info.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/csv/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Extracting and generating CSV text files.
+ */
+package com.asakusafw.runtime.io.text.csv;

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/csv/CsvFieldReaderTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/csv/CsvFieldReaderTest.java
@@ -1,0 +1,333 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.io.text.csv;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.UnaryOperator;
+
+import org.junit.Test;
+
+import com.asakusafw.runtime.io.text.FieldReader;
+import com.asakusafw.runtime.io.text.TextFormatException;
+
+/**
+ * Test for {@link CsvFieldReader}.
+ */
+public class CsvFieldReaderTest {
+
+    private boolean allowLineFeed = true;
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        String[][] result = read("this is a test");
+        assertThat(result, is(new String[][] {
+            { "this is a test" },
+        }));
+    }
+
+    /**
+     * w/ field separator.
+     */
+    @Test
+    public void field_separator() {
+        String[][] result = read("this,is,a,test");
+        assertThat(result, is(new String[][] {
+            { "this", "is", "a", "test" },
+        }));
+    }
+
+    /**
+     * w/ record separator.
+     */
+    @Test
+    public void record_separator() {
+        String[][] result = read("this\nis\na\ntest\r\n");
+        assertThat(result, is(new String[][] {
+            { "this" },
+            { "is" },
+            { "a" },
+            { "test" },
+        }));
+    }
+
+    /**
+     * w/ quoted field.
+     */
+    @Test
+    public void quote() {
+        String[][] result = read("'this,is','a''test\n'");
+        assertThat(result, is(new String[][] {
+            { "this,is", "a'test\n" },
+        }));
+    }
+
+    /**
+     * begin_field - c.
+     */
+    @Test
+    public void begin_field_c() {
+        String[][] result = read("c");
+        assertThat(result, is(new String[][] {
+            { "c" },
+        }));
+    }
+
+    /**
+     * begin_field - quote.
+     */
+    @Test
+    public void begin_field_quote() {
+        String[][] result = read("''");
+        assertThat(result, is(new String[][] {
+            { "" },
+        }));
+    }
+
+    /**
+     * begin_field - field_separator.
+     */
+    @Test
+    public void begin_field_field_separator() {
+        String[][] result = read(",");
+        assertThat(result, is(new String[][] {
+            { "", "" },
+        }));
+    }
+
+    /**
+     * begin_field - EOF.
+     */
+    @Test
+    public void begin_field_eof() {
+        String[][] result = read("");
+        assertThat(result, is(new String[0][]));
+    }
+
+    /**
+     * bare_body - c.
+     */
+    @Test
+    public void bare_body_c() {
+        String[][] result = read("cc");
+        assertThat(result, is(new String[][] {
+            { "cc" },
+        }));
+    }
+
+    /**
+     * bare_body - quote.
+     */
+    @Test
+    public void bare_body_quote() {
+        String[][] result = read("c'");
+        assertThat(result, is(new String[][] {
+            { "c'" },
+        }));
+    }
+
+    /**
+     * bare_body - field_separator.
+     */
+    @Test
+    public void bare_body_field_separator() {
+        String[][] result = read("c,");
+        assertThat(result, is(new String[][] {
+            { "c", "" },
+        }));
+    }
+
+    /**
+     * bare_body - EOF.
+     */
+    @Test
+    public void bare_body_eof() {
+        String[][] result = read("c");
+        assertThat(result, is(new String[][] {
+            { "c" },
+        }));
+    }
+
+    /**
+     * quote_body - c.
+     */
+    @Test
+    public void quote_body_c() {
+        String[][] result = read("'c'");
+        assertThat(result, is(new String[][] {
+            { "c" },
+        }));
+    }
+
+    /**
+     * quote_body - quote.
+     */
+    @Test
+    public void quote_body_quote() {
+        String[][] result = read("''''");
+        assertThat(result, is(new String[][] {
+            { "'" },
+        }));
+    }
+
+    /**
+     * quote_body - field_separator.
+     */
+    @Test
+    public void quote_body_field_separator() {
+        String[][] result = read("','");
+        assertThat(result, is(new String[][] {
+            { "," },
+        }));
+    }
+
+    /**
+     * quote_body - EOF.
+     */
+    @Test
+    public void quote_body_eof() {
+        String[][] result = read("'");
+        assertThat(result, is(new String[][] {
+            { "" },
+        }));
+    }
+
+    /**
+     * quote_body - LF.
+     */
+    @Test
+    public void quote_body_lf_allow() {
+        String[][] result = read("'\n'");
+        assertThat(result, is(new String[][] {
+            { "\n" },
+        }));
+    }
+
+    /**
+     * quote_body - LF.
+     */
+    @Test(expected = TextFormatException.class)
+    public void quote_body_lf_deny() {
+        allowLineFeed = false;
+        read("'\n'");
+    }
+
+    /**
+     * quote_body_saw_quote - c.
+     */
+    @Test
+    public void quote_body_saw_quote_c() {
+        String[][] result = read("'c'c");
+        assertThat(result, is(new String[][] {
+            { "c'c" },
+        }));
+    }
+
+    /**
+     * quote_body_saw_quote - quote.
+     */
+    @Test
+    public void quote_body_saw_quote_quote() {
+        String[][] result = read("'c'''");
+        assertThat(result, is(new String[][] {
+            { "c'" },
+        }));
+    }
+
+    /**
+     * quote_body_saw_quote - field_separator.
+     */
+    @Test
+    public void quote_body_saw_quote_field_separator() {
+        String[][] result = read("'c',");
+        assertThat(result, is(new String[][] {
+            { "c", "" },
+        }));
+    }
+
+    /**
+     * quote_body_saw_quote - EOF.
+     */
+    @Test
+    public void quote_body_saw_quote_eof() {
+        String[][] result = read("'c'");
+        assertThat(result, is(new String[][] {
+            { "c" },
+        }));
+    }
+
+    /**
+     * transform w/ filter.
+     */
+    @Test
+    public void filter() {
+        String[][] result = read(s -> s.toString().equals("B") ? null : s, "A\nB\nC\n");
+        assertThat(result, is(new String[][] {
+            { "A" },
+            { "C" },
+        }));
+    }
+
+    /**
+     * transform w/ edit.
+     */
+    @Test
+    public void transform() {
+        String[][] result = read(s -> s + "!", "A\nB\nC\n");
+        assertThat(result, is(new String[][] {
+            { "A!" },
+            { "B!" },
+            { "C!" },
+        }));
+    }
+
+    private String[][] read(String... lines) {
+        return read(null, lines);
+    }
+
+    private String[][] read(UnaryOperator<CharSequence> transformer, String... lines) {
+        try (FieldReader reader = reader(transformer, lines)) {
+            List<List<String>> results = new ArrayList<>();
+            while (reader.nextRecord()) {
+                List<String> row = new ArrayList<>();
+                while (reader.nextField()) {
+                    CharSequence content = reader.getContent();
+                    row.add(content == null ? null : content.toString());
+                }
+                results.add(row);
+            }
+            return results.stream()
+                    .map(s -> s.stream().toArray(String[]::new))
+                    .toArray(String[][]::new);
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private FieldReader reader(UnaryOperator<CharSequence> transformer, String... lines) {
+        return new CsvFieldReader(
+                new StringReader(String.join("\n", lines)), ',', '\'',
+                allowLineFeed, transformer);
+    }
+}

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/csv/CsvFieldWriterTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/csv/CsvFieldWriterTest.java
@@ -1,0 +1,415 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.io.text.csv;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import com.asakusafw.runtime.io.text.FieldWriter;
+import com.asakusafw.runtime.io.text.LineSeparator;
+import com.asakusafw.runtime.io.text.UnmappableOutputException;
+import com.asakusafw.runtime.io.text.UnmappableOutput.ErrorCode;
+import com.asakusafw.runtime.io.text.driver.BasicFieldOutput;
+import com.asakusafw.runtime.io.text.driver.FieldOutput;
+import com.asakusafw.runtime.io.text.driver.StandardFieldOutputOption;
+
+/**
+ * Test for {@link CsvFieldWriter}.
+ */
+public class CsvFieldWriterTest {
+
+    private LineSeparator lineSeparator = LineSeparator.UNIX;
+
+    private boolean allowLineFeed = true;
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        String result = emit(null, w -> {
+            w.putField(wrap("this is a test"));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is("this is a test\n"));
+    }
+
+    /**
+     * w/ windows style line separator.
+     */
+    @Test
+    public void windows() {
+        lineSeparator = LineSeparator.WINDOWS;
+        String result = emit(null, w -> {
+            w.putField(wrap("this is a test"));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is("this is a test\r\n"));
+    }
+
+    /**
+     * w/ multiple columns.
+     */
+    @Test
+    public void multiple_columns() {
+        String result = emit(null, w -> {
+            w.putField(wrap("A"));
+            w.putField(wrap("B"));
+            w.putField(wrap("C"));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is(lines(new String[][] {
+            { "A", "B", "C", },
+        })));
+    }
+
+    /**
+     * w/ multiple rows.
+     */
+    @Test
+    public void multiple_rows() {
+        String result = emit(null, w -> {
+            w.putField(wrap("A"));
+            w.putEndOfRecord();
+            w.putField(wrap("B"));
+            w.putEndOfRecord();
+            w.putField(wrap("C"));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is(lines(new String[][] {
+            { "A", },
+            { "B", },
+            { "C", },
+        })));
+    }
+
+    /**
+     * w/ empty fields.
+     */
+    @Test
+    public void empty_field() {
+        String result = emit(null, w -> {
+            w.putField(wrap(""));
+            w.putField(wrap(""));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is(lines(new String[][] {
+            { "", "", },
+        })));
+    }
+
+    /**
+     * w/ empty records.
+     */
+    @Test
+    public void empty_record() {
+        String result = emit(null, w -> {
+            expectUnmappable(w, ErrorCode.EXTRA_EMPTY_FIELD);
+        });
+        assertThat(result, is(lines(new String[][] {
+            { "", },
+        })));
+    }
+
+    /**
+     * auto quote w/ CR.
+     */
+    @Test
+    public void quote_auto_cr() {
+        String result = emit(null, w -> {
+            w.putField(wrap("\r"));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is("'\r'\n"));
+    }
+
+    /**
+     * auto quote w/ LF.
+     */
+    @Test
+    public void quote_auto_lf() {
+        String result = emit(null, w -> {
+            w.putField(wrap("\n"));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is("'\n'\n"));
+    }
+
+    /**
+     * auto quote w/ CR LF.
+     */
+    @Test
+    public void quote_auto_crlf() {
+        String result = emit(null, w -> {
+            w.putField(wrap("\r\n"));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is("'\r\n'\n"));
+    }
+
+    /**
+     * auto quote w/ CR.
+     */
+    @Test
+    public void quote_auto_field_separator() {
+        String result = emit(null, w -> {
+            w.putField(wrap(","));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is("','\n"));
+    }
+
+    /**
+     * auto quote w/ quote character.
+     */
+    @Test
+    public void quote_auto_quote_character() {
+        String result = emit(null, w -> {
+            w.putField(wrap("'"));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is("''''\n"));
+    }
+
+    /**
+     * auto quote w/ LF.
+     */
+    @Test
+    public void quote_lf_deny() {
+        allowLineFeed = false;
+        String result = emit(null, w -> {
+            w.putField(wrap("\n"));
+            expectUnmappable(w, ErrorCode.RESTRICTED_SEQUENCE);
+        });
+        assertThat(result, is("'\n'\n"));
+    }
+
+    /**
+     * auto quote w/ CR LF.
+     */
+    @Test
+    public void quote_crlf_deny() {
+        allowLineFeed = false;
+        String result = emit(null, w -> {
+            w.putField(wrap("\r\n"));
+            expectUnmappable(w, ErrorCode.RESTRICTED_SEQUENCE);
+        });
+        assertThat(result, is("'\r\n'\n"));
+    }
+
+    /**
+     * as header.
+     */
+    @Test
+    public void header() {
+        String result = emit(null, w -> {
+            w.putField(wrap("hello").addOption(StandardFieldOutputOption.HEADER));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is("'hello'\n"));
+    }
+
+    /**
+     * always quote.
+     */
+    @Test
+    public void quote_always() {
+        String result = emit(null, w -> {
+            w.putField(wrap("hello").addOption(QuoteStyle.ALWAYS));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is("'hello'\n"));
+    }
+
+    /**
+     * always quote.
+     */
+    @Test
+    public void quote_always_field_separator() {
+        String result = emit(null, w -> {
+            w.putField(wrap("Hello, world!").addOption(QuoteStyle.ALWAYS));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is("'Hello, world!'\n"));
+    }
+
+    /**
+     * never quote.
+     */
+    @Test
+    public void quote_never() {
+        String result = emit(null, w -> {
+            w.putField(wrap("hello").addOption(QuoteStyle.NEVER));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is("hello\n"));
+    }
+
+    /**
+     * never quote w/ CR.
+     */
+    @Test
+    public void quote_never_cr() {
+        String result = emit(null, w -> {
+            w.putField(wrap("\r").addOption(QuoteStyle.NEVER));
+            expectUnmappable(w, ErrorCode.EXTRA_RECORD_SEPARATOR);
+        });
+        assertThat(result, is("\r\n"));
+    }
+
+    /**
+     * never quote w/ LF.
+     */
+    @Test
+    public void quote_never_lf() {
+        String result = emit(null, w -> {
+            w.putField(wrap("\n").addOption(QuoteStyle.NEVER));
+            expectUnmappable(w, ErrorCode.EXTRA_RECORD_SEPARATOR);
+        });
+        assertThat(result, is("\n\n"));
+    }
+
+    /**
+     * never quote w/ LF.
+     */
+    @Test
+    public void quote_never_crlf() {
+        String result = emit(null, w -> {
+            w.putField(wrap("\r\n").addOption(QuoteStyle.NEVER));
+            expectUnmappable(w, ErrorCode.EXTRA_RECORD_SEPARATOR);
+        });
+        assertThat(result, is("\r\n\n"));
+    }
+
+    /**
+     * never quote w/ field separator.
+     */
+    @Test
+    public void quote_never_field_separator() {
+        String result = emit(null, w -> {
+            w.putField(wrap(",").addOption(QuoteStyle.NEVER));
+            expectUnmappable(w, ErrorCode.EXTRA_FIELD_SEPARATOR);
+        });
+        assertThat(result, is(",\n"));
+    }
+
+    /**
+     * never quote w/ quote.
+     */
+    @Test
+    public void quote_never_quote_character() {
+        String result = emit(null, w -> {
+            w.putField(wrap("'").addOption(QuoteStyle.NEVER));
+            expectUnmappable(w, ErrorCode.RESTRICTED_SEQUENCE);
+        });
+        assertThat(result, is("'\n"));
+    }
+
+    /**
+     * invalid null.
+     */
+    @Test
+    public void invalid_null() {
+        String result = emit(null, w -> {
+            w.putField(wrap(null));
+            expectUnmappable(w, ErrorCode.UNDEFINED_NULL_SEQUENCE);
+        });
+        assertThat(result, is("\n"));
+    }
+
+    /**
+     * w/ filter.
+     */
+    @Test
+    public void filter() {
+        String result = emit(s -> "B".contentEquals(s) ? null : s, w -> {
+            w.putField(wrap("A"));
+            w.putEndOfRecord();
+            w.putField(wrap("B"));
+            w.putEndOfRecord();
+            w.putField(wrap("C"));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is(lines(new String[][] {
+            { "A", },
+            { "C", },
+        })));
+    }
+
+    /**
+     * w/ transform.
+     */
+    @Test
+    public void transform() {
+        String result = emit(s -> s.toString().toLowerCase(), w -> {
+            w.putField(wrap("A"));
+            w.putField(wrap("B"));
+            w.putField(wrap("C"));
+            w.putEndOfRecord();
+        });
+        assertThat(result, is(lines(new String[][] {
+            { "a", "b", "c", },
+        })));
+    }
+
+    private static void expectUnmappable(FieldWriter w, ErrorCode code) throws IOException {
+        try {
+            w.putEndOfRecord();
+            fail("expected: " + code);
+        } catch (UnmappableOutputException e) {
+            assertThat(e.getEntries(), hasSize(1));
+            assertThat(e.getEntries().get(0).getErrorCode(), is(code));
+        }
+    }
+
+    private static FieldOutput wrap(CharSequence contents) {
+        return new BasicFieldOutput().set(contents);
+    }
+
+    private String emit(UnaryOperator<CharSequence> transformer, Action action) {
+        StringWriter writer = new StringWriter();
+        try (FieldWriter w = new CsvFieldWriter(
+                writer,
+                lineSeparator, ',', '\'',
+                allowLineFeed, QuoteStyle.NEEDED, QuoteStyle.ALWAYS, transformer)) {
+            action.perform(w);
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+        return writer.toString();
+    }
+
+    private String lines(String[][] lines) {
+        return Arrays.stream(lines)
+                .map(fs -> String.join(",", fs))
+                .collect(Collectors.joining(
+                        lineSeparator.getSequence(),
+                        "", lineSeparator.getSequence()));
+    }
+
+    @FunctionalInterface
+    private interface Action {
+        void perform(FieldWriter writer) throws IOException;
+    }
+}

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/csv/CsvTextFormatTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/csv/CsvTextFormatTest.java
@@ -1,0 +1,407 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.io.text.csv;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.UnaryOperator;
+
+import org.junit.Test;
+
+import com.asakusafw.runtime.io.text.LineSeparator;
+import com.asakusafw.runtime.io.text.driver.BasicFieldOutput;
+
+/**
+ * Test for {@link CsvTextFormat}.
+ */
+public class CsvTextFormatTest {
+
+    /**
+     * input.
+     */
+    @Test
+    public void input() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .build();
+        String[][] results = read(format, new String[] {
+                "Hello!",
+        });
+        assertThat(results, is(new String[][] {
+            { "Hello!" },
+        }));
+    }
+
+    /**
+     * input - quoted.
+     */
+    @Test
+    public void input_quoted() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .build();
+        String[][] results = read(format, new String[] {
+                "\"Hello, world!\"",
+        });
+        assertThat(results, is(new String[][] {
+            { "Hello, world!" },
+        }));
+    }
+
+    /**
+     * input - delimited.
+     */
+    @Test
+    public void input_delimited() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .build();
+        String[][] results = read(format, new String[] {
+                "A,B",
+                "C,D",
+        });
+        assertThat(results, is(new String[][] {
+            { "A", "B", },
+            { "C", "D", },
+        }));
+    }
+
+    /**
+     * input - charset.
+     */
+    @Test
+    public void input_charset() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .withCharset("US-ASCII")
+                .build();
+        String[][] results = read(format, new String[] {
+                "A,B",
+                "C,D",
+        });
+        assertThat(results, is(new String[][] {
+            { "A", "B", },
+            { "C", "D", },
+        }));
+    }
+
+    /**
+     * input - w/ field separator.
+     */
+    @Test
+    public void input_field_separator() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .withFieldSeparator('\t')
+                .build();
+        String[][] results = read(format, new String[] {
+                "A\tB",
+                "C\tD",
+        });
+        assertThat(results, is(new String[][] {
+            { "A", "B", },
+            { "C", "D", },
+        }));
+    }
+
+    /**
+     * input - w/ quote character.
+     */
+    @Test
+    public void input_quote_character() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .withQuoteCharacter('%')
+                .build();
+        String[][] results = read(format, new String[] {
+                "%Hello, world!%",
+        });
+        assertThat(results, is(new String[][] {
+            { "Hello, world!", },
+        }));
+    }
+
+    /**
+     * input - w/ allow line feed in field.
+     */
+    @Test
+    public void input_allow_line_feed() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .withAllowLineFeedInField(true)
+                .build();
+        String[][] results = read(format, new String[] {
+                "\"A\nB\nC\n\"",
+        });
+        assertThat(results, is(new String[][] {
+            { "A\nB\nC\n", },
+        }));
+    }
+
+    /**
+     * input - w/ transformer.
+     */
+    @Test
+    public void input_transformer() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .withInputTransformer(LowerCaseTransformer.class)
+                .build();
+        String[][] results = read(format, new String[] {
+                "A,B",
+                "C,D",
+        });
+        assertThat(results, is(new String[][] {
+            { "a", "b", },
+            { "c", "d", },
+        }));
+    }
+
+    /**
+     * output.
+     */
+    @Test
+    public void output() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .build();
+        String[] results = write(format, new String[][] {
+            { "Hello!", },
+        });
+        assertThat(results, is(new String[] {
+                "Hello!",
+        }));
+    }
+
+    /**
+     * output - quote.
+     */
+    @Test
+    public void output_quoted() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .build();
+        String[] results = write(format, new String[][] {
+            { "Hello, world!!", },
+        });
+        assertThat(results, is(new String[] {
+                "\"Hello, world!!\"",
+        }));
+    }
+
+    /**
+     * output - delimited.
+     */
+    @Test
+    public void output_delimited() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .build();
+        String[] results = write(format, new String[][] {
+            { "A", "B", },
+            { "C", "D", },
+        });
+        assertThat(results, is(new String[] {
+                "A,B",
+                "C,D",
+        }));
+    }
+
+    /**
+     * output - charset.
+     */
+    @Test
+    public void output_charset() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .withCharset("US-ASCII")
+                .build();
+        String[] results = write(format, new String[][] {
+            { "A", "B", },
+            { "C", "D", },
+        });
+        assertThat(results, is(new String[] {
+                "A,B",
+                "C,D",
+        }));
+    }
+
+    /**
+     * output - w/ line separator.
+     */
+    @Test
+    public void output_line_separator() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .withLineSeparator(LineSeparator.UNIX)
+                .build();
+        String[] results = write(format, new String[][] {
+            { "A", "B", },
+            { "C", "D", },
+        });
+        assertThat(results, is(new String[] {
+                "A,B",
+                "C,D",
+        }));
+    }
+
+    /**
+     * output - w/ field separator.
+     */
+    @Test
+    public void output_field_separator() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .withFieldSeparator('\t')
+                .build();
+        String[] results = write(format, new String[][] {
+            { "A", "B", },
+            { "C", "D", },
+        });
+        assertThat(results, is(new String[] {
+                "A\tB",
+                "C\tD",
+        }));
+    }
+
+    /**
+     * output - w/ quote character.
+     */
+    @Test
+    public void output_quote_character() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .withQuoteCharacter('%')
+                .build();
+        String[] results = write(format, new String[][] {
+            { "Hello, world!", },
+        });
+        assertThat(results, is(new String[] {
+                "%Hello, world!%",
+        }));
+    }
+
+    /**
+     * output - w/ allow line feed in field.
+     */
+    @Test
+    public void output_allow_line_feed_in_field() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .withAllowLineFeedInField(true)
+                .build();
+        String[] results = write(format, new String[][] {
+            { "A\nB\nC\n", },
+        });
+        assertThat(results, is(new String[] {
+                "\"A\nB\nC\n\"",
+        }));
+    }
+
+    /**
+     * output - w/ default quote style.
+     */
+    @Test
+    public void output_default_quote_style() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .withDefaultQuoteStyle(QuoteStyle.ALWAYS)
+                .build();
+        String[] results = write(format, new String[][] {
+            { "Hello!", },
+        });
+        assertThat(results, is(new String[] {
+                "\"Hello!\"",
+        }));
+    }
+
+    /**
+     * output - w/ header quote style.
+     */
+    @Test
+    public void output_header_quote_style() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .withHeaderQuoteStyle(QuoteStyle.ALWAYS)
+                .build();
+        String[] results = write(format, new String[][] {
+            { "Hello!", },
+        });
+        assertThat(results, is(new String[] {
+                "Hello!",
+        }));
+    }
+
+    /**
+     * output - w/ transformer.
+     */
+    @Test
+    public void output_transformer() {
+        CsvTextFormat format = CsvTextFormat.builder()
+                .withOutputTransformer(LowerCaseTransformer.class)
+                .build();
+        String[] results = write(format, new String[][] {
+            { "A", "B", },
+            { "C", "D", },
+        });
+        assertThat(results, is(new String[] {
+                "a,b",
+                "c,d",
+        }));
+    }
+
+    private static String[][] read(CsvTextFormat format, String... lines) {
+        StringBuilder buffer = new StringBuilder();
+        for (String line : lines) {
+            buffer.append(line);
+            buffer.append(format.getLineSeparator().getSequence());
+        }
+        byte[] bytes = buffer.toString().getBytes(format.getCharset());
+        try (CsvFieldReader reader = format.open(new ByteArrayInputStream(bytes))) {
+            List<List<String>> results = new ArrayList<>();
+            while (reader.nextRecord()) {
+                List<String> row = new ArrayList<>();
+                while (reader.nextField()) {
+                    CharSequence content = reader.getContent();
+                    row.add(content == null ? null : content.toString());
+                }
+                results.add(row);
+            }
+            return results.stream()
+                    .map(s -> s.stream().toArray(String[]::new))
+                    .toArray(String[][]::new);
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static String[] write(CsvTextFormat format, String[][] fields) {
+        BasicFieldOutput fout = new BasicFieldOutput();
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (CsvFieldWriter writer = format.open(output)) {
+            for (String[] row : fields) {
+                for (String field : row) {
+                    writer.putField(fout.set(field));
+                }
+                writer.putEndOfRecord();
+            }
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+        String lines = new String(output.toByteArray(), format.getCharset());
+        return Arrays.stream(lines.split(format.getLineSeparator().getSequence()))
+                .filter(s -> s.isEmpty() == false)
+                .toArray(String[]::new);
+    }
+
+    @SuppressWarnings("javadoc")
+    public static class LowerCaseTransformer implements UnaryOperator<CharSequence> {
+        @Override
+        public CharSequence apply(CharSequence t) {
+            return t.toString().toLowerCase(Locale.ENGLISH);
+        }
+    }
+}

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/csv/LineCursorTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/csv/LineCursorTest.java
@@ -1,0 +1,248 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.io.text.csv;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * Test for {@code LineCursor}.
+ */
+public class LineCursorTest {
+
+    private final boolean allowLineFeed = true;
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        List<String> results = parse("Hello, world!");
+        assertThat(results, contains("Hello, world!"));
+    }
+
+    /**
+     * w/ LF.
+     */
+    @Test
+    public void lf() {
+        List<String> results = parse("hello\nworld\n\n!\n");
+        assertThat(results, contains("hello", "world", "", "!"));
+    }
+
+    /**
+     * w/ CR.
+     */
+    @Test
+    public void cr() {
+        List<String> results = parse("hello\rworld\r\r!\r");
+        assertThat(results, contains("hello", "world", "", "!"));
+    }
+
+    /**
+     * w/ CRLF.
+     */
+    @Test
+    public void crlf() {
+        List<String> results = parse("hello\r\nworld\r\n\r\n!\r\n");
+        assertThat(results, contains("hello", "world", "", "!"));
+    }
+
+    /**
+     * w/ quote.
+     */
+    @Test
+    public void quote() {
+        List<String> results = parse("'Hello, world!'\n");
+        assertThat(results, contains("'Hello, world!'"));
+    }
+
+    /**
+     * w/ field separator.
+     */
+    @Test
+    public void comma() {
+        List<String> results = parse("Hello, world!\n");
+        assertThat(results, contains("Hello, world!"));
+    }
+
+    /**
+     * invalid quote.
+     */
+    @Test
+    public void invalid_quote() {
+        List<String> results = parse("Hello' world!\n");
+        assertThat(results, contains("Hello' world!"));
+    }
+
+    /**
+     * empty file.
+     */
+    @Test
+    public void begin_eof() {
+        List<String> results = parse("");
+        assertThat(results, hasSize(0));
+    }
+
+    /**
+     * field separator follows EOF.
+     */
+    @Test
+    public void comma_eof() {
+        List<String> results = parse(",");
+        assertThat(results, contains(","));
+    }
+
+    /**
+     * empty file.
+     */
+    @Test
+    public void begin_lf() {
+        List<String> results = parse("\n");
+        assertThat(results, contains(""));
+    }
+
+    /**
+     * quote w/ quote.
+     */
+    @Test
+    public void quoted_quote() {
+        List<String> results = parse("'Hello'' world!'\n");
+        assertThat(results, contains("'Hello'' world!'"));
+    }
+
+    /**
+     * quote w/ field separator.
+     */
+    @Test
+    public void quoted_comma() {
+        List<String> results = parse("',',','\n");
+        assertThat(results, contains("',',','"));
+    }
+
+    /**
+     * quoted field ends with EOF.
+     */
+    @Test
+    public void quoted_quote_eof() {
+        List<String> results = parse("'Hello, world!'");
+        assertThat(results, contains("'Hello, world!'"));
+    }
+
+    /**
+     * quote w/ LF.
+     */
+    @Test
+    public void quoted_lf() {
+        List<String> results = parse("'\n'\n");
+        assertThat(results, contains("'\n'"));
+    }
+
+    /**
+     * quote w/ EOF.
+     */
+    @Test
+    public void quoted_eof() {
+        List<String> results = parse("'");
+        assertThat(results, contains("'"));
+    }
+
+    /**
+     * quote w/ CRLF.
+     */
+    @Test
+    public void quoted_cr_lf() {
+        List<String> results = parse("'\r\n'\n");
+        assertThat(results, contains("'\r\n'"));
+    }
+
+    /**
+     * quote w/ CR - c.
+     */
+    @Test
+    public void quoted_cr_c() {
+        List<String> results = parse("'\rc'\n");
+        assertThat(results, contains("'\rc'"));
+    }
+
+    /**
+     * quote w/ CR - quote.
+     */
+    @Test
+    public void quoted_cr_quote() {
+        List<String> results = parse("'\r'\n");
+        assertThat(results, contains("'\r'"));
+    }
+
+    /**
+     * quote w/ CR - CR.
+     */
+    @Test
+    public void quoted_cr_cr() {
+        List<String> results = parse("'\r\r'\n");
+        assertThat(results, contains("'\r\r'"));
+    }
+
+    /**
+     * quote w/ CR - EOF.
+     */
+    @Test
+    public void quoted_cr_eof() {
+        List<String> results = parse("'\r");
+        assertThat(results, contains("'\r"));
+    }
+
+    /**
+     * quote w/ quote - c.
+     */
+    @Test
+    public void quoted_quote_c() {
+        List<String> results = parse("'Hello' world!'\n");
+        assertThat(results, contains("'Hello' world!'"));
+    }
+
+    /**
+     * quoted field ends with CRLF.
+     */
+    @Test
+    public void quoted_field_cr_lf() {
+        List<String> results = parse("'Hello, world!'\r\n");
+        assertThat(results, contains("'Hello, world!'"));
+    }
+
+    private List<String> parse(String contents) {
+        return parse('\'', ',', contents);
+    }
+
+    private List<String> parse(char quote, char field, String contents) {
+        try (LineCursor cursor = new LineCursor(new StringReader(contents), quote, field, allowLineFeed)) {
+            List<String> results = new ArrayList<>();
+            while (cursor.next()) {
+                results.add(cursor.getContent().toString());
+            }
+            return results;
+        } catch (IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/AbstractTextStreamFormatGenerator.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/AbstractTextStreamFormatGenerator.java
@@ -383,6 +383,8 @@ public abstract class AbstractTextStreamFormatGenerator {
         default:
             throw new AssertionError(kind);
         }
+        settings.getQuoteStyle().ifPresent(v -> builder
+                .method("withOutputOption", resolve(v))); //$NON-NLS-1$
         return builder.method("lazy").toExpression(); //$NON-NLS-1$
     }
 

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/QuoteSettings.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/QuoteSettings.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dmdl.directio.text;
+
+import static com.asakusafw.dmdl.directio.text.TextFormatConstants.*;
+
+import java.util.Map;
+
+import com.asakusafw.dmdl.directio.util.Value;
+import com.asakusafw.dmdl.model.AstAttribute;
+import com.asakusafw.dmdl.model.AstAttributeElement;
+import com.asakusafw.dmdl.semantics.DmdlSemantics;
+import com.asakusafw.runtime.io.text.csv.QuoteStyle;
+
+/**
+ * Settings of quoting fields.
+ * @since 0.9.1
+ */
+public class QuoteSettings {
+
+    private Value<Character> character = Value.undefined();
+
+    private Value<Boolean> allowLineFeedInField = Value.undefined();
+
+    private Value<QuoteStyle> defaultStyle = Value.undefined();
+
+    private Value<QuoteStyle> headerStyle = Value.undefined();
+
+    /**
+     * Returns quote character.
+     * @return quote character
+     */
+    public Value<Character> getCharacter() {
+        return character;
+    }
+
+    /**
+     * Returns whether or not LF can appear as field values.
+     * @return {@code trur} if it is enabled, otherwise {@code false}
+     */
+    public Value<Boolean> getAllowLineFeedInField() {
+        return allowLineFeedInField;
+    }
+
+    /**
+     * Returns the default quote style.
+     * @return the default quote style
+     */
+    public Value<QuoteStyle> getDefaultStyle() {
+        return defaultStyle;
+    }
+
+    /**
+     * Returns the quote style for header fields.
+     * @return the quote style for header fields
+     */
+    public Value<QuoteStyle> getHeaderStyle() {
+        return headerStyle;
+    }
+
+    /**
+     * Consumes attribute elements about escape settings, and returns corresponding {@link QuoteSettings}.
+     * @param environment the current environment
+     * @param attribute the attribute
+     * @param elements the element map to be consumed
+     * @return corresponded {@link QuoteSettings}.
+     */
+    public static QuoteSettings consume(
+            DmdlSemantics environment, AstAttribute attribute,
+            Map<String, AstAttributeElement> elements) {
+        AttributeAnalyzer analyzer = new AttributeAnalyzer(environment, attribute);
+        QuoteSettings settings = new QuoteSettings();
+        consumeCharacter(settings, analyzer, elements.remove(ELEMENT_QUOTE_CHARACTER));
+        consumeDefaultStyle(settings, analyzer, elements.remove(ELEMENT_DEFAULT_QUOTE_STYLE));
+        consumeHeaderStyle(settings, analyzer, elements.remove(ELEMENT_HEADER_QUOTE_STYLE));
+        consumeAllowLineFeedInField(settings, analyzer, elements.remove(ELEMENT_ALLOW_LINE_FEED_IN_FIELD));
+        return settings;
+    }
+
+    private static void consumeCharacter(
+            QuoteSettings settings, AttributeAnalyzer analyzer, AstAttributeElement element) {
+        if (element != null) {
+            settings.character = analyzer.toCharacter(element);
+        }
+    }
+
+    private static void consumeDefaultStyle(
+            QuoteSettings settings, AttributeAnalyzer analyzer, AstAttributeElement element) {
+        if (element != null) {
+            settings.defaultStyle = analyzer.toEnumConstant(element, QuoteStyle.class);
+        }
+    }
+
+    private static void consumeHeaderStyle(
+            QuoteSettings settings, AttributeAnalyzer analyzer, AstAttributeElement element) {
+        if (element != null) {
+            settings.headerStyle = analyzer.toEnumConstant(element, QuoteStyle.class);
+        }
+    }
+
+    private static void consumeAllowLineFeedInField(
+            QuoteSettings settings, AttributeAnalyzer analyzer, AstAttributeElement element) {
+        if (element != null) {
+            settings.allowLineFeedInField = analyzer.toBoolean(element);
+        }
+    }
+
+    /**
+     * Verifies this settings.
+     * @param environment the current environment
+     * @param attribute the original attribute
+     * @return {@code true} if the settings seems valid, otherwise {@code false}
+     */
+    public boolean verify(DmdlSemantics environment, AstAttribute attribute) {
+        AttributeAnalyzer analyzer = new AttributeAnalyzer(environment, attribute);
+        if (isLineSeparator(character.getEntity())) {
+            analyzer.error(character.getDeclaration(),
+                    Messages.getString("QuoteSettings.diagnosticConflictLineSeparator")); //$NON-NLS-1$
+        }
+        return analyzer.hasError() == false;
+    }
+
+    private static boolean isLineSeparator(Character c) {
+        return c != null && (c == '\r' || c == '\n');
+    }
+}

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/TextFieldSettings.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/TextFieldSettings.java
@@ -25,6 +25,7 @@ import com.asakusafw.dmdl.directio.util.Value;
 import com.asakusafw.dmdl.model.AstAttribute;
 import com.asakusafw.dmdl.model.AstAttributeElement;
 import com.asakusafw.dmdl.semantics.DmdlSemantics;
+import com.asakusafw.runtime.io.text.csv.QuoteStyle;
 import com.asakusafw.runtime.io.text.driver.ErrorAction;
 import com.asakusafw.runtime.io.text.value.DecimalOptionFieldAdapter;
 
@@ -55,6 +56,8 @@ public class TextFieldSettings {
     private Value<ErrorAction> malformedInputAction = Value.undefined();
 
     private Value<ErrorAction> unmappableOutputAction = Value.undefined();
+
+    private Value<QuoteStyle> quoteStyle = Value.undefined();
 
     /**
      * Returns the field adapter class.
@@ -145,6 +148,14 @@ public class TextFieldSettings {
     }
 
     /**
+     * Returns the quote style.
+     * @return the quote style
+     */
+    public Value<QuoteStyle> getQuoteStyle() {
+        return quoteStyle;
+    }
+
+    /**
      * Consumes attribute elements about escape settings, and returns corresponding {@link EscapeSettings}.
      * @param environment the current environment
      * @param attribute the attribute
@@ -167,6 +178,7 @@ public class TextFieldSettings {
         consumeSkipEmptyInput(settings, analyzer, elements.remove(ELEMENT_SKIP_EMPTY_INPUT));
         consumeMalformedInputAction(settings, analyzer, elements.remove(ELEMENT_MALFORMED_INPUT_ACTION));
         consumeUnmappableOutputAction(settings, analyzer, elements.remove(ELEMENT_UNMAPPABLE_OUTPUT_ACTION));
+        consumeQuoteStyle(settings, analyzer, elements.remove(ELEMENT_QUOTE_STYLE));
         return settings;
     }
 
@@ -244,6 +256,13 @@ public class TextFieldSettings {
             TextFieldSettings settings, AttributeAnalyzer analyzer, AstAttributeElement element) {
         if (element != null) {
             settings.unmappableOutputAction = analyzer.toEnumConstant(element, ErrorAction.class);
+        }
+    }
+
+    private static void consumeQuoteStyle(
+            TextFieldSettings settings, AttributeAnalyzer analyzer, AstAttributeElement element) {
+        if (element != null) {
+            settings.quoteStyle = analyzer.toEnumConstant(element, QuoteStyle.class);
         }
     }
 

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/TextFormatConstants.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/TextFormatConstants.java
@@ -217,20 +217,47 @@ public final class TextFormatConstants {
      */
     public static final String VALUE_FALSE = "false"; //$NON-NLS-1$
 
+    // CSV
+
+    /**
+     * The element name of quote style.
+     */
+    public static final String ELEMENT_QUOTE_STYLE = "quote_style"; //$NON-NLS-1$
+
+    /**
+     * The element name of quote character.
+     */
+    public static final String ELEMENT_QUOTE_CHARACTER = "quote_character"; //$NON-NLS-1$
+
+    /**
+     * The element name of whether or not LF character can appear as field value.
+     */
+    public static final String ELEMENT_ALLOW_LINE_FEED_IN_FIELD = "allow_linefeed"; //$NON-NLS-1$
+
+    /**
+     * The element name of default quote style.
+     */
+    public static final String ELEMENT_DEFAULT_QUOTE_STYLE = ELEMENT_QUOTE_STYLE;
+
+    /**
+     * The element name of header quote style.
+     */
+    public static final String ELEMENT_HEADER_QUOTE_STYLE = "header_" + ELEMENT_QUOTE_STYLE; //$NON-NLS-1$
+
     // delimited text
 
     /**
-     * The element name of .
+     * The element name of escape character.
      */
     public static final String ELEMENT_ESCAPE_CHARACTER = "escape_character"; //$NON-NLS-1$
 
     /**
-     * The element name of .
+     * The element name of escape sequence map.
      */
     public static final String ELEMENT_ESCAPE_SEQUENCE_MAP = "escape_sequence"; //$NON-NLS-1$
 
     /**
-     * The element name of .
+     * The element name of whether or not escape line separators.
      */
     public static final String ELEMENT_ESCAPE_LINE_SEPARATOR = "escape_line_separator"; //$NON-NLS-1$
 }

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/csv/CsvTextDriver.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/csv/CsvTextDriver.java
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dmdl.directio.text.csv;
+
+import static com.asakusafw.dmdl.directio.text.TextFormatConstants.*;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import com.asakusafw.dmdl.Diagnostic;
+import com.asakusafw.dmdl.directio.text.QuoteSettings;
+import com.asakusafw.dmdl.directio.text.TextFieldSettings;
+import com.asakusafw.dmdl.directio.text.TextFieldTrait;
+import com.asakusafw.dmdl.directio.text.TextFormatConstants;
+import com.asakusafw.dmdl.directio.text.TextFormatSettings;
+import com.asakusafw.dmdl.directio.util.Value;
+import com.asakusafw.dmdl.model.AstAttribute;
+import com.asakusafw.dmdl.model.AstAttributeElement;
+import com.asakusafw.dmdl.model.BasicTypeKind;
+import com.asakusafw.dmdl.semantics.DmdlSemantics;
+import com.asakusafw.dmdl.semantics.ModelDeclaration;
+import com.asakusafw.dmdl.semantics.PropertyDeclaration;
+import com.asakusafw.dmdl.spi.ModelAttributeDriver;
+import com.asakusafw.dmdl.util.AttributeUtil;
+
+/**
+ * Processes <code>&#64;directio.text.csv</code> attributes.
+ * @since 0.9.1
+ * @see TextFormatConstants
+ */
+public class CsvTextDriver extends ModelAttributeDriver {
+
+    /**
+     * The attribute name.
+     */
+    public static final String NAME = PREFIX_NAMESPACE + "csv"; //$NON-NLS-1$
+
+    @Override
+    public String getTargetName() {
+        return NAME;
+    }
+
+    @Override
+    public void process(DmdlSemantics environment, ModelDeclaration declaration, AstAttribute attribute) {
+        Map<String, AstAttributeElement> elements = AttributeUtil.getElementMap(attribute);
+        TextFormatSettings format = TextFormatSettings.consume(environment, attribute, elements);
+        QuoteSettings quote = QuoteSettings.consume(environment, attribute, elements);
+        TextFieldSettings field = TextFieldSettings.consume(environment, attribute, elements);
+        environment.reportAll(AttributeUtil.reportInvalidElements(attribute, elements.values()));
+        CsvTextTrait trait = new CsvTextTrait(attribute, format, quote, field);
+        if (trait.verify(environment, declaration)) {
+            CsvTextTrait.register(environment, declaration, trait);
+        }
+    }
+
+    @Override
+    public void verify(DmdlSemantics environment, ModelDeclaration declaration, AstAttribute attribute) {
+        CsvTextTrait parent = CsvTextTrait.get(declaration);
+        verifyModel(environment, declaration, parent);
+        declaration.getDeclaredProperties().stream()
+            .filter(p -> TextFieldTrait.find(p).isPresent())
+            .filter(p -> TextFieldTrait.get(p).getKind() == TextFieldTrait.Kind.VALUE)
+            .forEachOrdered(property -> verifyField(
+                    environment,
+                    property,
+                    parent.getFieldSettings(),
+                    TextFieldTrait.get(property).getSettings()));
+    }
+
+    private static void verifyModel(DmdlSemantics environment, ModelDeclaration declaration, CsvTextTrait trait) {
+        if (declaration.getDeclaredProperties().stream()
+                .noneMatch(p -> TextFieldTrait.getKind(p) == TextFieldTrait.Kind.VALUE)) {
+            environment.report(new Diagnostic(
+                    Diagnostic.Level.ERROR, trait.getOriginalAst().name,
+                    Messages.getString("CsvTextDriver.diagnosticNoAvailableField"), //$NON-NLS-1$
+                    declaration.getName(),
+                    trait.getOriginalAst().name));
+        }
+    }
+
+    private static void verifyField(
+            DmdlSemantics environment, PropertyDeclaration property,
+            TextFieldSettings parent, TextFieldSettings child) {
+        if (AttributeUtil.hasFieldType(property, BasicTypeKind.BOOLEAN)) {
+            String nullFormat = resolve(parent, child, TextFieldSettings::getNullFormat, DEFAULT_NULL_FORMAT);
+            String trueFormat = resolve(parent, child, TextFieldSettings::getTrueFormat, DEFAULT_TRUE_FORMAT);
+            String falseFormat = resolve(parent, child, TextFieldSettings::getFalseFormat, DEFAULT_FALSE_FORMAT);
+            if (trueFormat.equals(nullFormat)) {
+                errorConflict(environment, property, ELEMENT_TRUE_FORMAT, ELEMENT_NULL_FORMAT);
+            }
+            if (falseFormat.equals(nullFormat)) {
+                errorConflict(environment, property, ELEMENT_FALSE_FORMAT, ELEMENT_NULL_FORMAT);
+            }
+            if (falseFormat.equals(trueFormat)) {
+                errorConflict(environment, property, ELEMENT_FALSE_FORMAT, ELEMENT_TRUE_FORMAT);
+            }
+        }
+    }
+
+    private static void errorConflict(
+            DmdlSemantics environment,
+            PropertyDeclaration property,
+            String a, String b) {
+        environment.report(new Diagnostic(
+                Diagnostic.Level.ERROR, property.getName(),
+                Messages.getString("CsvTextDriver.diagnosticConflictFormat"), //$NON-NLS-1$
+                property.getOwner().getName(),
+                property.getName(),
+                a, b));
+    }
+
+    private static <T> T resolve(
+            TextFieldSettings parent, TextFieldSettings child,
+            Function<TextFieldSettings, Value<T>> property, T defaultValue) {
+        return property.apply(child).orDefault(property.apply(parent)).orElse(defaultValue);
+    }
+
+}

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/csv/CsvTextEmitter.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/csv/CsvTextEmitter.java
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dmdl.directio.text.csv;
+
+import static com.asakusafw.dmdl.directio.text.TextFormatConstants.*;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.dmdl.directio.text.AbstractTextStreamFormatGenerator;
+import com.asakusafw.dmdl.directio.text.QuoteSettings;
+import com.asakusafw.dmdl.directio.text.TextFormatSettings;
+import com.asakusafw.dmdl.directio.util.DirectFileInputDescriptionGenerator;
+import com.asakusafw.dmdl.directio.util.DirectFileOutputDescriptionGenerator;
+import com.asakusafw.dmdl.java.emitter.EmitContext;
+import com.asakusafw.dmdl.java.spi.JavaDataModelDriver;
+import com.asakusafw.dmdl.semantics.ModelDeclaration;
+import com.asakusafw.runtime.io.text.csv.CsvTextFormat;
+import com.asakusafw.utils.java.model.syntax.ModelFactory;
+import com.asakusafw.utils.java.model.syntax.Name;
+import com.asakusafw.utils.java.model.syntax.SimpleName;
+import com.asakusafw.utils.java.model.syntax.Statement;
+import com.asakusafw.utils.java.model.util.ExpressionBuilder;
+import com.asakusafw.utils.java.model.util.TypeBuilder;
+
+/**
+ * Emits Direct I/O data format classes about CSV text.
+ * @since 0.9.1
+ */
+public class CsvTextEmitter extends JavaDataModelDriver {
+
+    static final Logger LOG = LoggerFactory.getLogger(CsvTextEmitter.class);
+
+    @Override
+    public void generateResources(EmitContext context, ModelDeclaration model) throws IOException {
+        if (CsvTextTrait.find(model).isPresent() == false) {
+            return;
+        }
+        Name supportName = generateFormat(context, model);
+        generateInputDescription(context, supportName, model);
+        generateOutputDescription(context, supportName, model);
+    }
+
+    private static Name generateFormat(EmitContext context, ModelDeclaration model) throws IOException {
+        assert context != null;
+        assert model != null;
+        CsvTextTrait trait = CsvTextTrait.get(model);
+        EmitContext next = new EmitContext(
+                context.getSemantics(),
+                context.getConfiguration(),
+                model,
+                PACKAGE_SEGMENT,
+                "{0}CsvTextFormat"); //$NON-NLS-1$
+        LOG.debug("Generating delimited text format for {}", //$NON-NLS-1$
+                context.getQualifiedTypeName().toNameString());
+        FormatGenerator.emit(next, model, trait);
+        LOG.debug("Generated delimited text format for {}: {}", //$NON-NLS-1$
+                context.getQualifiedTypeName().toNameString(),
+                next.getQualifiedTypeName().toNameString());
+        return next.getQualifiedTypeName();
+    }
+
+    private static void generateInputDescription(
+            EmitContext context, Name formatClassName, ModelDeclaration model) throws IOException {
+        EmitContext next = new EmitContext(
+                context.getSemantics(),
+                context.getConfiguration(),
+                model,
+                PACKAGE_SEGMENT,
+                "Abstract{0}CsvTextInputDescription"); //$NON-NLS-1$
+        DirectFileInputDescriptionGenerator.Description desc = new DirectFileInputDescriptionGenerator.Description(
+                "CSV text file input", context.getQualifiedTypeName()); //$NON-NLS-1$
+        desc.setFormatClassName(formatClassName);
+        DirectFileInputDescriptionGenerator.generate(next, desc);
+    }
+
+    private static void generateOutputDescription(
+            EmitContext context, Name formatClassName, ModelDeclaration model) throws IOException {
+        EmitContext next = new EmitContext(
+                context.getSemantics(),
+                context.getConfiguration(),
+                model,
+                PACKAGE_SEGMENT,
+                "Abstract{0}CsvTextOutputDescription"); //$NON-NLS-1$
+        DirectFileOutputDescriptionGenerator.Description desc = new DirectFileOutputDescriptionGenerator.Description(
+                "CSV text file output", context.getQualifiedTypeName()); //$NON-NLS-1$
+        desc.setFormatClassName(formatClassName);
+        DirectFileOutputDescriptionGenerator.generate(next, desc);
+    }
+
+    private static final class FormatGenerator extends AbstractTextStreamFormatGenerator {
+
+        private final CsvTextTrait root;
+
+        private final ModelFactory f;
+
+        private FormatGenerator(EmitContext context, ModelDeclaration model, CsvTextTrait root) {
+            super(context, model, root.getFormatSettings(), root.getFieldSettings());
+            this.root = root;
+            this.f = context.getModelFactory();
+        }
+
+        static void emit(EmitContext context, ModelDeclaration model, CsvTextTrait trait) throws IOException {
+            new FormatGenerator(context, model, trait).emit(Messages.getString("CsvTextEmitter.javadocTitle")); //$NON-NLS-1$
+        }
+
+        @Override
+        protected List<Statement> createGetTextFormatInternal() {
+            SimpleName builder = f.newSimpleName("builder"); //$NON-NLS-1$
+            List<Statement> statements = new ArrayList<>();
+            statements.add(new TypeBuilder(f, context.resolve(CsvTextFormat.class))
+                    .method("builder") //$NON-NLS-1$
+                    .toLocalVariableDeclaration(context.resolve(CsvTextFormat.Builder.class), builder));
+            buildTextFormat(statements, builder);
+            statements.add(new ExpressionBuilder(f, builder)
+                    .method("build") //$NON-NLS-1$
+                    .toReturnStatement());
+            return statements;
+        }
+
+        private void buildTextFormat(List<Statement> statements, SimpleName builder) {
+            TextFormatSettings formats = root.getFormatSettings();
+            formats.getCharset().ifPresent(v -> statements.add(new ExpressionBuilder(f, builder)
+                    .method("withCharset", resolve(v.name())) //$NON-NLS-1$
+                    .toStatement()));
+            formats.getLineSeparator().ifPresent(v -> statements.add(new ExpressionBuilder(f, builder)
+                    .method("withLineSeparator", resolve(v)) //$NON-NLS-1$
+                    .toStatement()));
+            formats.getFieldSeparator().ifPresent(v -> statements.add(new ExpressionBuilder(f, builder)
+                    .method("withFieldSeparator", resolve(v)) //$NON-NLS-1$
+                    .toStatement()));
+            formats.getInputTransformerClass().ifPresent(v -> statements.add(new ExpressionBuilder(f, builder)
+                    .method("withInputTransformer", new TypeBuilder(f, resolve(v)) //$NON-NLS-1$
+                            .constructorReference()
+                            .toExpression())
+                    .toStatement()));
+            formats.getOutputTransformerClass().ifPresent(v -> statements.add(new ExpressionBuilder(f, builder)
+                    .method("withOutputTransformer", new TypeBuilder(f, resolve(v)) //$NON-NLS-1$
+                            .constructorReference()
+                            .toExpression())
+                    .toStatement()));
+
+            QuoteSettings quotes = root.getQuoteSettings();
+            quotes.getCharacter().ifPresent(v -> statements.add(new ExpressionBuilder(f, builder)
+                    .method("withQuoteCharacter", resolve(v)) //$NON-NLS-1$
+                    .toStatement()));
+            quotes.getAllowLineFeedInField().ifPresent(v -> statements.add(new ExpressionBuilder(f, builder)
+                    .method("withAllowLineFeedInField", resolve(v)) //$NON-NLS-1$
+                    .toStatement()));
+            quotes.getDefaultStyle().ifPresent(v -> statements.add(new ExpressionBuilder(f, builder)
+                    .method("withDefaultQuoteStyle", resolve(v)) //$NON-NLS-1$
+                    .toStatement()));
+            quotes.getHeaderStyle().ifPresent(v -> statements.add(new ExpressionBuilder(f, builder)
+                    .method("withHeaderQuoteStyle", resolve(v)) //$NON-NLS-1$
+                    .toStatement()));
+        }
+
+        @Override
+        protected boolean isSplittableInternal() {
+            return root.getQuoteSettings().getAllowLineFeedInField()
+                    .orElse(CsvTextFormat.DEFAULT_ALLOW_LINE_FEED_IN_FIELD) == false;
+        }
+    }
+}

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/csv/CsvTextTrait.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/csv/CsvTextTrait.java
@@ -1,0 +1,138 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dmdl.directio.text.csv;
+
+import static com.asakusafw.dmdl.directio.text.TextFormatConstants.*;
+
+import java.util.Optional;
+
+import com.asakusafw.dmdl.Diagnostic;
+import com.asakusafw.dmdl.directio.text.AttributeAnalyzer;
+import com.asakusafw.dmdl.directio.text.QuoteSettings;
+import com.asakusafw.dmdl.directio.text.TextFieldSettings;
+import com.asakusafw.dmdl.directio.text.TextFormatSettings;
+import com.asakusafw.dmdl.model.AstAttribute;
+import com.asakusafw.dmdl.semantics.DmdlSemantics;
+import com.asakusafw.dmdl.semantics.ModelDeclaration;
+import com.asakusafw.dmdl.semantics.Trait;
+import com.asakusafw.runtime.io.text.csv.CsvTextFormat;
+
+/**
+ * Attributes of CSV models.
+ * @since 0.9.1
+ */
+public class CsvTextTrait implements Trait<CsvTextTrait> {
+
+    static final char DEFAULT_FIELD_SEPARATOR = CsvTextFormat.DEFAULT_FIELD_SEPARATOR;
+
+    private final AstAttribute attribute;
+
+    private final TextFormatSettings formatSettings;
+
+    private final QuoteSettings quoteSettings;
+
+    private final TextFieldSettings fieldSettings;
+
+    /**
+     * Creates a new instance.
+     * @param attribute the original attribute
+     * @param formatSettings the format settings
+     * @param quoteSettings the quote settings
+     * @param fieldSettings the field settings
+     */
+    public CsvTextTrait(
+            AstAttribute attribute,
+            TextFormatSettings formatSettings,
+            QuoteSettings quoteSettings,
+            TextFieldSettings fieldSettings) {
+        this.attribute = attribute;
+        this.formatSettings = formatSettings;
+        this.quoteSettings = quoteSettings;
+        this.fieldSettings = fieldSettings;
+    }
+
+    static Optional<CsvTextTrait> find(ModelDeclaration declaration) {
+        return Optional.ofNullable(declaration.getTrait(CsvTextTrait.class));
+    }
+
+    static CsvTextTrait get(ModelDeclaration declaration) {
+        return Optional.ofNullable(declaration.getTrait(CsvTextTrait.class))
+                .orElseThrow(IllegalStateException::new);
+    }
+
+    static void register(DmdlSemantics environment, ModelDeclaration declaration, CsvTextTrait trait) {
+        if (find(declaration).isPresent()) {
+            environment.report(new Diagnostic(
+                    Diagnostic.Level.ERROR, trait.attribute.name,
+                    Messages.getString("CsvTextTrait.diagnosticDuplicateAttribute"), //$NON-NLS-1$
+                    trait.attribute.name,
+                    declaration.getName().identifier));
+        } else {
+            declaration.putTrait(CsvTextTrait.class, trait);
+        }
+    }
+
+    @Override
+    public AstAttribute getOriginalAst() {
+        return attribute;
+    }
+
+    /**
+     * Returns the format settings.
+     * @return the format settings
+     */
+    public TextFormatSettings getFormatSettings() {
+        return formatSettings;
+    }
+
+    /**
+     * Returns the quote settings.
+     * @return the quote settings
+     */
+    public QuoteSettings getQuoteSettings() {
+        return quoteSettings;
+    }
+
+    /**
+     * Returns the field settings.
+     * @return the field settings
+     */
+    public TextFieldSettings getFieldSettings() {
+        return fieldSettings;
+    }
+
+    boolean verify(DmdlSemantics environment, ModelDeclaration declaration) {
+        boolean valid = true;
+        valid &= formatSettings.verify(environment, attribute);
+        valid &= quoteSettings.verify(environment, attribute);
+        valid &= fieldSettings.verify(environment, attribute);
+        if (valid == false) {
+            return false;
+        }
+        AttributeAnalyzer analyzer = new AttributeAnalyzer(environment, attribute);
+        if (quoteSettings.getCharacter().isPresent()) {
+            char fieldSeparator = formatSettings.getFieldSeparator().orElse(DEFAULT_FIELD_SEPARATOR);
+            char quoteCharacter = quoteSettings.getCharacter().getEntity();
+            if (fieldSeparator == quoteCharacter) {
+                analyzer.error(
+                        quoteSettings.getCharacter().getDeclaration(),
+                        Messages.getString("CsvTextTrait.diagnosticConflictCharacter"), //$NON-NLS-1$
+                        ELEMENT_FIELD_SEPARATOR);
+            }
+        }
+        return analyzer.hasError() == false;
+    }
+}

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/csv/Messages.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/csv/Messages.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dmdl.directio.text.csv;
+
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+final class Messages {
+    private static final String BUNDLE_NAME = "com.asakusafw.dmdl.directio.text.csv.messages"; //$NON-NLS-1$
+
+    private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
+
+    private Messages() {
+        return;
+    }
+
+    public static String getString(String key) {
+        try {
+            return RESOURCE_BUNDLE.getString(key);
+        } catch (MissingResourceException e) {
+            return '!' + key + '!';
+        }
+    }
+}

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/csv/package-info.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/csv/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * CSV support for Direct I/O.
+ */
+package com.asakusafw.dmdl.directio.text.csv;

--- a/directio-project/asakusa-directio-dmdl/src/main/resources/META-INF/services/com.asakusafw.dmdl.java.spi.JavaDataModelDriver
+++ b/directio-project/asakusa-directio-dmdl/src/main/resources/META-INF/services/com.asakusafw.dmdl.java.spi.JavaDataModelDriver
@@ -1,4 +1,5 @@
 com.asakusafw.dmdl.directio.csv.driver.CsvFormatEmitter
 com.asakusafw.dmdl.directio.text.delimited.DelimitedTextEmitter
+com.asakusafw.dmdl.directio.text.csv.CsvTextEmitter
 com.asakusafw.dmdl.directio.sequencefile.driver.SequenceFileFormatEmitter
 com.asakusafw.dmdl.directio.line.driver.LineFormatEmitter

--- a/directio-project/asakusa-directio-dmdl/src/main/resources/META-INF/services/com.asakusafw.dmdl.spi.AttributeDriver
+++ b/directio-project/asakusa-directio-dmdl/src/main/resources/META-INF/services/com.asakusafw.dmdl.spi.AttributeDriver
@@ -16,6 +16,9 @@ com.asakusafw.dmdl.directio.text.TextIgnoreDriver
 # Delimited Text
 com.asakusafw.dmdl.directio.text.delimited.DelimitedTextDriver
 
+# CSV Text
+com.asakusafw.dmdl.directio.text.csv.CsvTextDriver
+
 # Sequence File
 com.asakusafw.dmdl.directio.sequencefile.driver.SequenceFileFormatDriver
 

--- a/directio-project/asakusa-directio-dmdl/src/main/resources/com/asakusafw/dmdl/directio/text/csv/messages.properties
+++ b/directio-project/asakusa-directio-dmdl/src/main/resources/com/asakusafw/dmdl/directio/text/csv/messages.properties
@@ -1,0 +1,5 @@
+CsvTextDriver.diagnosticConflictFormat="{2}" must not equal to "{3}" (in {0}.{1})
+CsvTextDriver.diagnosticNoAvailableField={0} does not have any available fields for @{1}
+CsvTextEmitter.javadocTitle=CSV text
+CsvTextTrait.diagnosticConflictCharacter={0} must not equal to "{1}"
+CsvTextTrait.diagnosticDuplicateAttribute=@{0} is already declared in {2}

--- a/directio-project/asakusa-directio-dmdl/src/main/resources/com/asakusafw/dmdl/directio/text/messages.properties
+++ b/directio-project/asakusa-directio-dmdl/src/main/resources/com/asakusafw/dmdl/directio/text/messages.properties
@@ -15,6 +15,7 @@ EscapeSettings.diagnosticConflictLineSeparator={0} must not be line separator ch
 EscapeSettings.diagnosticEscapeSequenceDuplicateKey={0} has duplicated key: {1}
 EscapeSettings.diagnosticEscapeSequenceDuplicateValue={0} has duplicated value: {1}
 EscapeSettings.diagnosticMissingRelatedAttribute={0} requires "{1}"
+QuoteSettings.diagnosticConflictLineSeparator={0} must not be line separator characters
 TextFieldDriver.diagnosticInvalidType=@{0}({1}) (at {2}.{3}) is only for {4} type
 TextFieldSettings.diagnosticConflictFormat={0} must not equal to "{1}"
 TextFieldTrait.diagnosticDuplicateAttribute={0}.{1} has conflict attributes @{2} and @{3}

--- a/directio-project/asakusa-directio-dmdl/src/test/java/com/asakusafw/dmdl/directio/text/csv/CsvTextEmitterTest.java
+++ b/directio-project/asakusa-directio-dmdl/src/test/java/com/asakusafw/dmdl/directio/text/csv/CsvTextEmitterTest.java
@@ -1,0 +1,802 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.dmdl.directio.text.csv;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+import java.util.function.Consumer;
+import java.util.zip.GZIPInputStream;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.asakusafw.dmdl.directio.common.driver.GeneratorTesterRoot;
+import com.asakusafw.dmdl.directio.text.delimited.DelimitedTextEmitterTest;
+import com.asakusafw.dmdl.directio.text.mock.EmptyLineFilter;
+import com.asakusafw.dmdl.directio.text.mock.UpperCaseTransformer;
+import com.asakusafw.dmdl.java.emitter.driver.ObjectDriver;
+import com.asakusafw.runtime.directio.BinaryStreamFormat;
+import com.asakusafw.runtime.io.ModelInput;
+import com.asakusafw.runtime.io.ModelOutput;
+import com.asakusafw.runtime.value.IntOption;
+import com.asakusafw.runtime.value.LongOption;
+import com.asakusafw.runtime.value.StringOption;
+
+/**
+ * Test for {@link CsvTextEmitter}.
+ * @see DelimitedTextEmitterTest
+ */
+public class CsvTextEmitterTest extends GeneratorTesterRoot {
+
+    /**
+     * Initializes the test.
+     * @throws Exception if some errors were occurred
+     */
+    @Before
+    public void setUp() throws Exception {
+        emitDrivers.add(new CsvTextEmitter());
+        emitDrivers.add(new ObjectDriver());
+    }
+
+    /**
+     * simple case.
+     * @throws Exception if failed
+     */
+    @Test
+    public void simple() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv",
+                "simple = { value : TEXT; };",
+        });
+        ModelWrapper model = loaded.newModel("Simple")
+                .setOption("value", new StringOption("Hello, world!"));
+
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleCsvTextFormat");
+        assertThat(support.getSupportedType(), is((Object) model.unwrap().getClass()));
+        assertThat(support.getMinimumFragmentSize(), is(not(-1L)));
+
+        BinaryStreamFormat<Object> unsafe = unsafe(support);
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ModelOutput<Object> writer = unsafe.createOutput(unsafe.getSupportedType(), "hello", output)) {
+            writer.write(model.unwrap());
+        }
+
+        assertThat(text(output), is("\"Hello, world!\"\r\n"));
+
+        Object buffer = loaded.newModel("Simple").unwrap();
+        try (ModelInput<Object> reader = unsafe.createInput(unsafe.getSupportedType(), "hello", in(output))) {
+            assertThat(reader.readTo(buffer), is(true));
+            assertThat(buffer, is(model.unwrap()));
+
+            assertThat(reader.readTo(buffer), is(false));
+        }
+    }
+
+    /**
+     * w/ multiple rows/cols.
+     * @throws Exception if failed
+     */
+    @Test
+    public void multiple() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv",
+                "simple = {",
+                "  a : TEXT;",
+                "  b : TEXT;",
+                "  c : TEXT;",
+                "};",
+        });
+        byte[] contents = restore(loaded,
+                loaded.newModel("Simple")
+                        .setOption("a", new StringOption("0a"))
+                        .setOption("b", new StringOption("0b"))
+                        .setOption("c", new StringOption("0c")),
+                loaded.newModel("Simple")
+                        .setOption("a", new StringOption("1a"))
+                        .setOption("b", new StringOption("1b"))
+                        .setOption("c", new StringOption("1c")),
+                loaded.newModel("Simple")
+                        .setOption("a", new StringOption("2a"))
+                        .setOption("b", new StringOption("2b"))
+                        .setOption("c", new StringOption("2c")));
+        assertThat(text(contents), is("0a,0b,0c\r\n1a,1b,1c\r\n2a,2b,2c\r\n"));
+    }
+
+    /**
+     * w/ {@code charset}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void charset() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  charset = 'UTF-16LE',",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "};",
+        });
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleCsvTextFormat");
+        assertThat(support.getMinimumFragmentSize(), is(-1L));
+
+        ModelWrapper model = loaded.newModel("Simple")
+                .setOption("a", new StringOption("Hello, world!"));
+        byte[] contents = write(loaded, model);
+        assertThat(new String(contents, StandardCharsets.UTF_16LE), is("\"Hello, world!\"\r\n"));
+    }
+
+    /**
+     * w/ {@code compression}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void compression() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  compression = gzip,",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "};",
+        });
+        ModelWrapper model = loaded.newModel("Simple")
+                .setOption("a", new StringOption("Hello, world!"));
+        byte[] contents = write(loaded, model);
+
+        ByteArrayInputStream input = new ByteArrayInputStream(contents);
+        try (Scanner s = new Scanner(new GZIPInputStream(input), StandardCharsets.UTF_8.name())) {
+            assertThat(s.hasNextLine(), is(true));
+            assertThat(s.nextLine(), is("\"Hello, world!\""));
+
+            assertThat(s.hasNextLine(), is(false));
+        }
+    }
+
+    /**
+     * w/ {@code line_separator}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void line_separator() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  line_separator = unix,",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "};",
+        });
+        ModelWrapper model = loaded.newModel("Simple")
+                .setOption("a", new StringOption("Hello, world!"));
+        byte[] contents = restore(loaded, model);
+        assertThat(text(contents), is("\"Hello, world!\"\n"));
+    }
+
+    /**
+     * w/ {@code field_separator}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void field_separator() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  field_separator = ':',",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "  b : TEXT;",
+                "  c : TEXT;",
+                "};",
+        });
+        ModelWrapper model = loaded.newModel("Simple")
+                .setOption("a", new StringOption("A"))
+                .setOption("b", new StringOption("B"))
+                .setOption("c", new StringOption("C"));
+        byte[] contents = restore(loaded, model);
+        assertThat(text(contents), is("A:B:C\r\n"));
+    }
+
+    /**
+     * w/ {@code quote_character}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void quote_character() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  quote_character = '%',",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "};",
+        });
+        ModelWrapper model = loaded.newModel("Simple")
+                .setOption("a", new StringOption("Hello, world!"));
+        byte[] contents = restore(loaded, model);
+        assertThat(text(contents), is("%Hello, world!%\r\n"));
+    }
+
+    /**
+     * w/ {@code allow_linefeed}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void allow_linefeed() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  allow_linefeed = true,",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "};",
+        });
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleCsvTextFormat");
+        assertThat(support.getMinimumFragmentSize(), is(-1L));
+
+        ModelWrapper model = loaded.newModel("Simple")
+                .setOption("a", new StringOption("Hello\nworld!"));
+        byte[] contents = restore(loaded, model);
+        assertThat(text(contents), is("\"Hello\nworld!\"\r\n"));
+    }
+
+    /**
+     * w/ {@code quote_style}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void quote_style() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  quote_style = always,",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "};",
+        });
+        ModelWrapper model = loaded.newModel("Simple")
+                .setOption("a", new StringOption("Hello!"));
+        byte[] contents = restore(loaded, model);
+        assertThat(text(contents), is("\"Hello!\"\r\n"));
+    }
+
+    /**
+     * w/ {@code quote_style}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void quote_style_field() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv",
+                "simple = {",
+                "  a : TEXT;",
+                "  @directio.text.field(quote_style = always)",
+                "  b : TEXT;",
+                "};",
+        });
+        ModelWrapper model = loaded.newModel("Simple")
+                .setOption("a", new StringOption("A"))
+                .setOption("b", new StringOption("B"));
+        byte[] contents = restore(loaded, model);
+        assertThat(text(contents), is("A,\"B\"\r\n"));
+    }
+
+    /**
+     * w/ {@code header}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void header() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  header = force,",
+                ")",
+                "simple = {",
+                "  @directio.text.field(name = 'Hello, world!')",
+                "  a : TEXT;",
+                "  b : TEXT;",
+                "};",
+        });
+        byte[] contents = restore(loaded, loaded.newModel("Simple")
+                .setOption("a", new StringOption("A"))
+                .setOption("b", new StringOption("B")));
+        assertThat(text(contents), is("\"Hello, world!\",b\r\nA,B\r\n"));
+    }
+
+    /**
+     * w/ {@code header_quote_style}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void header_quote_style() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  header = force,",
+                "  header_quote_style = always,",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "  b : TEXT;",
+                "};",
+        });
+        byte[] contents = restore(loaded, loaded.newModel("Simple")
+                .setOption("a", new StringOption("A"))
+                .setOption("b", new StringOption("B")));
+        assertThat(text(contents), is("\"a\",\"b\"\r\nA,B\r\n"));
+    }
+
+    /**
+     * w/ {@code quote_style} inherits to header.
+     * @throws Exception if failed
+     */
+    @Test
+    public void quote_style_inherit_header() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  header = force,",
+                "  quote_style = always,",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "  b : TEXT;",
+                "};",
+        });
+        byte[] contents = restore(loaded, loaded.newModel("Simple")
+                .setOption("a", new StringOption("A"))
+                .setOption("b", new StringOption("B")));
+        assertThat(text(contents), is("\"a\",\"b\"\r\n\"A\",\"B\"\r\n"));
+    }
+
+    /**
+     * w/ {@code input_transformer}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void input_transformer() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  input_transformer = '" + EmptyLineFilter.class.getName() + "'",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "};",
+        });
+        read(loaded, "\n\nHello!\n\n", wrapper -> {
+            assertThat(wrapper.getOption("a"), is(new StringOption("Hello!")));
+        });
+    }
+
+    /**
+     * w/ {@code output_transformer}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void output_transformer() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  output_transformer = '" + UpperCaseTransformer.class.getName() + "'",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "};",
+        });
+        ModelWrapper model = loaded.newModel("Simple")
+                .setOption("a", new StringOption("hello"));
+        byte[] contents = write(loaded, model);
+        assertThat(text(contents), is("HELLO\r\n"));
+    }
+
+    /**
+     * w/ {@code directio.text.field}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void field_field() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv",
+                "simple = {",
+                "  @directio.text.field",
+                "  a : TEXT;",
+                "};",
+        });
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleCsvTextFormat");
+        assertThat(support.getMinimumFragmentSize(), is(not(-1L)));
+
+        byte[] contents = write(loaded, loaded.newModel("Simple")
+                .setOption("a", new StringOption("A")));
+        read(contents, loaded, loaded.newModel("Simple")
+                .setOption("a", new StringOption("A")));
+        assertThat(text(contents), is("A\r\n"));
+    }
+
+    /**
+     * w/ {@code directio.text.ignore}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void field_ignore() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv",
+                "simple = {",
+                "  a : TEXT;",
+                "  @directio.text.ignore",
+                "  b : TEXT;",
+                "};",
+        });
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleCsvTextFormat");
+        assertThat(support.getMinimumFragmentSize(), is(not(-1L)));
+
+        byte[] contents = write(loaded, loaded.newModel("Simple")
+                .setOption("a", new StringOption("A"))
+                .setOption("b", new StringOption("B")));
+        read(contents, loaded, loaded.newModel("Simple")
+                .setOption("a", new StringOption("A"))
+                .setOption("b", new StringOption()));
+        assertThat(text(contents), is("A\r\n"));
+    }
+
+    /**
+     * w/ {@code directio.text.file_name}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void field_file_name() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv",
+                "simple = {",
+                "  a : TEXT;",
+                "  @directio.text.file_name",
+                "  b : TEXT;",
+                "};",
+        });
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleCsvTextFormat");
+        assertThat(support.getMinimumFragmentSize(), is(not(-1L)));
+
+        byte[] contents = write(loaded, loaded.newModel("Simple")
+                .setOption("a", new StringOption("A"))
+                .setOption("b", new StringOption("B")));
+        read(contents, loaded, loaded.newModel("Simple")
+                .setOption("a", new StringOption("A"))
+                .setOption("b", new StringOption("testing")));
+        assertThat(text(contents), is("A\r\n"));
+    }
+
+    /**
+     * w/ {@code directio.text.line_number}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void field_line_number() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  input_transformer = '" + EmptyLineFilter.class.getName() + "'",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "  @directio.text.line_number",
+                "  b : LONG;",
+                "};",
+        });
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleCsvTextFormat");
+        assertThat(support.getMinimumFragmentSize(), is(-1L));
+
+        byte[] contents = write(loaded, loaded.newModel("Simple")
+                .setOption("a", new StringOption("A"))
+                .setOption("b", new LongOption(-1)));
+        assertThat(text(contents), is("A\r\n"));
+
+        read(loaded, "\n\nHello!\n\n", wrapper -> {
+            assertThat(wrapper.getOption("a"), is(new StringOption("Hello!")));
+            assertThat(wrapper.getOption("b"), is(new LongOption(3)));
+        });
+    }
+
+    /**
+     * w/ {@code directio.text.line_number}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void field_line_number_int() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  input_transformer = '" + EmptyLineFilter.class.getName() + "'",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "  @directio.text.line_number",
+                "  b : INT;",
+                "};",
+        });
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleCsvTextFormat");
+        assertThat(support.getMinimumFragmentSize(), is(-1L));
+
+        byte[] contents = write(loaded, loaded.newModel("Simple")
+                .setOption("a", new StringOption("A"))
+                .setOption("b", new IntOption(-1)));
+        assertThat(text(contents), is("A\r\n"));
+
+        read(loaded, "\n\nHello!\n\n", wrapper -> {
+            assertThat(wrapper.getOption("a"), is(new StringOption("Hello!")));
+            assertThat(wrapper.getOption("b"), is(new IntOption(3)));
+        });
+    }
+
+    /**
+     * w/ {@code directio.text.record_number}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void field_record_number() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  input_transformer = '" + EmptyLineFilter.class.getName() + "'",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "  @directio.text.record_number",
+                "  b : LONG;",
+                "};",
+        });
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleCsvTextFormat");
+        assertThat(support.getMinimumFragmentSize(), is(-1L));
+
+        byte[] contents = write(loaded, loaded.newModel("Simple")
+                .setOption("a", new StringOption("A"))
+                .setOption("b", new LongOption(-1)));
+        assertThat(text(contents), is("A\r\n"));
+
+        read(loaded, "\n\nHello!\n\n", wrapper -> {
+            assertThat(wrapper.getOption("a"), is(new StringOption("Hello!")));
+            assertThat(wrapper.getOption("b"), is(new LongOption(1)));
+        });
+    }
+
+    /**
+     * w/ {@code directio.text.record_number}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void field_record_number_int() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  input_transformer = '" + EmptyLineFilter.class.getName() + "'",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "  @directio.text.record_number",
+                "  b : INT;",
+                "};",
+        });
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleCsvTextFormat");
+        assertThat(support.getMinimumFragmentSize(), is(-1L));
+
+        byte[] contents = write(loaded, loaded.newModel("Simple")
+                .setOption("a", new StringOption("A"))
+                .setOption("b", new IntOption(-1)));
+        assertThat(text(contents), is("A\r\n"));
+
+        read(loaded, "\n\nHello!\n\n", wrapper -> {
+            assertThat(wrapper.getOption("a"), is(new StringOption("Hello!")));
+            assertThat(wrapper.getOption("b"), is(new IntOption(1)));
+        });
+    }
+
+    /**
+     * w/ malformed quote_character.
+     * @throws Exception if failed
+     */
+    @Test
+    public void invalid_quote_character_malformed() throws Exception {
+        shouldSemanticErrorFromLines(new String[] {
+                "@directio.text.csv(",
+                "  quote_character = '<>',",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "};",
+        });
+    }
+
+    /**
+     * quote_character conflict w/ line separator.
+     * @throws Exception if failed
+     */
+    @Test
+    public void invalid_quote_character_conflict_line_separator() throws Exception {
+        shouldSemanticErrorFromLines(new String[] {
+                "@directio.text.csv(",
+                "  quote_character = '\\r',",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "};",
+        });
+        shouldSemanticErrorFromLines(new String[] {
+                "@directio.text.csv(",
+                "  quote_character = '\\n',",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "};",
+        });
+    }
+
+    /**
+     * quote_character conflict w/ line separator.
+     * @throws Exception if failed
+     */
+    @Test
+    public void invalid_quote_character_conflict_field_separator() throws Exception {
+        shouldSemanticErrorFromLines(new String[] {
+                "@directio.text.csv(",
+                "  field_separator = ':',",
+                "  quote_character = ':',",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "};",
+        });
+        shouldSemanticErrorFromLines(new String[] {
+                "@directio.text.csv(",
+                "  quote_character = ',',",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "};",
+        });
+    }
+
+    /**
+     * true_format conflict w/ null_format.
+     * @throws Exception if failed
+     */
+    @Test
+    public void invalid_true_format_conflict_null_format_inherited() throws Exception {
+        shouldSemanticErrorFromLines(new String[] {
+                "@directio.text.csv(",
+                "  null_format = 'a',",
+                ")",
+                "simple = {",
+                "  @directio.text.field(true_format = 'a')",
+                "  a : BOOLEAN;",
+                "};",
+        });
+    }
+
+    /**
+     * false_format conflict w/ null_format.
+     * @throws Exception if failed
+     */
+    @Test
+    public void invalid_false_format_conflict_null_format_inherited() throws Exception {
+        shouldSemanticErrorFromLines(new String[] {
+                "@directio.text.csv(",
+                "  null_format = 'a',",
+                ")",
+                "simple = {",
+                "  @directio.text.field(false_format = 'a')",
+                "  a : BOOLEAN;",
+                "};",
+        });
+    }
+
+    /**
+     * false_format conflict w/ true_format.
+     * @throws Exception if failed
+     */
+    @Test
+    public void invalid_false_format_conflict_true_format_inherited() throws Exception {
+        shouldSemanticErrorFromLines(new String[] {
+                "@directio.text.csv(",
+                "  true_format = 'a',",
+                ")",
+                "simple = {",
+                "  @directio.text.field(false_format = 'a')",
+                "  a : BOOLEAN;",
+                "};",
+        });
+    }
+
+    /**
+     * w/o valid fields.
+     * @throws Exception if failed
+     */
+    @Test
+    public void invalid_field_empty() throws Exception {
+        shouldSemanticErrorFromLines(new String[] {
+                "@directio.text.delimited",
+                "simple = {",
+                "  @directio.text.ignore",
+                "  a : TEXT;",
+                "};",
+        });
+    }
+
+    private static byte[] write(ModelLoader loaded, ModelWrapper... objects) {
+        String name = objects[0].getModelClass().getSimpleName();
+        BinaryStreamFormat<Object> unsafe = unsafe(loaded.newObject("text", name + "CsvTextFormat"));
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ModelOutput<Object> writer = unsafe.createOutput(unsafe.getSupportedType(), "testing", output)) {
+            for (ModelWrapper object : objects) {
+                writer.write(object.unwrap());
+            }
+        } catch (IOException | InterruptedException e) {
+            throw new AssertionError(e);
+        }
+        return output.toByteArray();
+    }
+
+    private static void read(ModelLoader loaded, String contents, Consumer<ModelWrapper> tester) {
+        BinaryStreamFormat<Object> unsafe = unsafe(loaded.newObject("text", "SimpleCsvTextFormat"));
+        ModelWrapper wrapper = loaded.newModel("Simple");
+        Object buffer = wrapper.unwrap();
+        try (ModelInput<Object> reader = unsafe.createInput(unsafe.getSupportedType(), "testing", in(contents))) {
+            assertThat(reader.readTo(buffer), is(true));
+            tester.accept(wrapper);
+
+            assertThat(reader.readTo(buffer), is(false));
+        } catch (IOException | InterruptedException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static void read(
+            byte[] contents, ModelLoader loaded, ModelWrapper... objects) throws IOException, InterruptedException {
+        String name = objects[0].getModelClass().getSimpleName();
+        BinaryStreamFormat<Object> unsafe = unsafe(loaded.newObject("text", name + "CsvTextFormat"));
+        Object buffer = loaded.newModel(name).unwrap();
+        try (ModelInput<Object> reader = unsafe.createInput(unsafe.getSupportedType(), "testing",
+                new ByteArrayInputStream(contents))) {
+            for (ModelWrapper object : objects) {
+                assertThat(reader.readTo(buffer), is(true));
+                assertThat(buffer, is(object.unwrap()));
+            }
+            assertThat(reader.readTo(buffer), is(false));
+        }
+    }
+
+    private byte[] restore(ModelLoader loaded, ModelWrapper... objects) throws IOException, InterruptedException {
+        byte[] contents = write(loaded, objects);
+        read(contents, loaded, objects);
+        return contents;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static BinaryStreamFormat<Object> unsafe(Object support) {
+        return (BinaryStreamFormat<Object>) support;
+    }
+
+    private static ByteArrayInputStream in(String contents) {
+        return new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static ByteArrayInputStream in(ByteArrayOutputStream output) {
+        return new ByteArrayInputStream(output.toByteArray());
+    }
+
+    private static String text(ByteArrayOutputStream output) {
+        return text(output.toByteArray());
+    }
+
+    private static String text(byte[] contents) {
+        return new String(contents, StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
## Summary

This PR introduces a brand new implementation of CSV format support to Direct I/O.
This implementation is more customizable than the existing CSV implementation.

## Background, Problem or Goal of the patch

The new implementation is easier to customize its format than the existing one. It shares almost implementation with Direct I/O delimited text (#713), and has the following features:

* record separated by line delimiter (LF, CR, or CR+LF)
* configurable field separator
* configurable quote style
* configurable file header
* configurable value format
* configurable error actions
* and more

Note that, the new implementation will be a bit slower than the existing implementation. Please continue to use the existing implementation if it is enough.

## Design of the fix, or a new feature

This introduces a new DMDL attribute `@directio.text.csv` for data models (the existing is `@directio.csv`). It is similar to `@directio.text.delimited` but it settings contains about quoting fields instead of escape characters.

Application developers can declare the following elements in the attribute:

* `charset : string`
* `header : {nothing,force,skip,auto}`
* `compression : string`
* `line_separator : {unix,windows}`
* `field_separator : char`
* `quote_character : char`
* `allow_linefeed : boolean`
* `quote_style : {always,never,needed}`
* `header_quote_style : {always,never,needed}`
* `true_format : string`
* `false_format : string`
* `date_format : string`
* `decimal_format : {plain,scientific,engineering}`
* `null_format : {string,null}`
* `trim_input : boolean`
* `skip_empty_input : boolean`
* `on_malformed_input : {error,report,ignore}`
* `on_more_input : {error,report,ignore}`
* `on_less_input : {error,report,ignore}`
* `on_unmappable_output : {error,report,ignore}`
* `input_transformer : class-name`
* `output_transformer : class-name`

Additionally, each property have one of following attributes which are common to delimited text.

* `@directio.text.field`
* `@directio.text.ignore`
* `@directio.text.file_name`
* `@directio.text.line_number`
* `@directio.text.record_number`

The DMDL compiler additionally produces the following classes for data models with `@directio.text.csv` attribute.

* `...text.<name>CsvTextFormat`
* `...text.Abstract<name>CsvTextInputDescription`
* `...text.Abstract<name>CsvTextOutputDescription`

## Related Issue, Pull Request or Code

* #713 
* #714 

## Wanted reviewer

@akirakw 