### PR TITLE
Fix `escape_line_separator=false`.

### DIFF
--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/AttributeAnalyzer.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/AttributeAnalyzer.java
@@ -214,16 +214,15 @@ public class AttributeAnalyzer {
             return Value.of(element, null);
         }
         return parseStringLiteral(element.value)
-                .filter(s -> {
+                .flatMap(s -> {
                     try {
-                        ZoneId.of(s);
-                        return true;
+                        return Optional.of(ZoneId.of(s));
                     } catch (DateTimeException e) {
                         LOG.trace("invalid time zone: {}", s, e); //$NON-NLS-1$
-                        return false;
+                        return Optional.empty();
                     }
                 })
-                .map(s -> Value.of(element, ZoneId.of(s)))
+                .map(v -> Value.of(element, v))
                 .orElseGet(() -> {
                     error(element, Messages.getString("AttributeAnalyzer.diagnosticNotTimeZoneId")); //$NON-NLS-1$
                     return Value.undefined();

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/delimited/DelimitedTextEmitter.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/delimited/DelimitedTextEmitter.java
@@ -153,7 +153,11 @@ public class DelimitedTextEmitter extends JavaDataModelDriver {
             escapes.getCharacter().ifPresent(c -> {
                 ExpressionBuilder escapeBuilder = new TypeBuilder(f, context.resolve(EscapeSequence.class))
                         .method("builder", resolve(c)); //$NON-NLS-1$
-                escapes.getEscapeLineSeparator().ifPresent(v -> escapeBuilder.method("addLineSeparator")); //$NON-NLS-1$
+                escapes.getEscapeLineSeparator().ifPresent(v -> {
+                    if (v) {
+                        escapeBuilder.method("addLineSeparator"); //$NON-NLS-1$
+                    }
+                });
                 for (MapValue.Entry<Character, Character> entry : escapes.getSequences()) {
                     Character key = entry.getKey();
                     Character value = entry.getValue();

--- a/directio-project/asakusa-directio-dmdl/src/test/java/com/asakusafw/dmdl/directio/text/delimited/DelimitedTextEmitterTest.java
+++ b/directio-project/asakusa-directio-dmdl/src/test/java/com/asakusafw/dmdl/directio/text/delimited/DelimitedTextEmitterTest.java
@@ -505,6 +505,26 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     }
 
     /**
+     * w/ {@code escape_line_separator}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void escape_line_separator_false() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.delimited(",
+                "  escape_character = '^',",
+                "  escape_line_separator = false,",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "};",
+        });
+        read("a^\nb\n".getBytes(StandardCharsets.UTF_8), loaded,
+                loaded.newModel("Simple").setOption("a", new StringOption("a^")),
+                loaded.newModel("Simple").setOption("a", new StringOption("b")));
+    }
+
+    /**
      * w/ {@code input_transformer}.
      * @throws Exception if failed
      */
@@ -1743,6 +1763,22 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
         shouldSemanticErrorFromLines(new String[] {
                 "@directio.text.delimited(",
                 "  escape_character = '<>',",
+                ")",
+                "simple = {",
+                "  a : TEXT;",
+                "};",
+        });
+    }
+
+    /**
+     * w/ malformed escape_line_separator.
+     * @throws Exception if failed
+     */
+    @Test
+    public void invalid_escape_line_separator_malformed() throws Exception {
+        shouldSemanticErrorFromLines(new String[] {
+                "@directio.text.delimited(",
+                "  escape_line_separator = unknown,",
                 ")",
                 "simple = {",
                 "  a : TEXT;",


### PR DESCRIPTION
## Summary

`@directio.text.delimited(escape_line_separator)` does not work correct for `false`.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #713 

## Wanted reviewer

@akirakw 