### PR TITLE
Resource pattern of direct output now can accept decimal format.

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/stage/directio/StringTemplate.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/stage/directio/StringTemplate.java
@@ -18,8 +18,11 @@ package com.asakusafw.runtime.stage.directio;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.text.DateFormat;
+import java.text.DecimalFormat;
 import java.text.MessageFormat;
+import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -30,11 +33,19 @@ import org.apache.hadoop.io.WritableComparator;
 import org.apache.hadoop.io.WritableUtils;
 
 import com.asakusafw.runtime.io.util.WritableRawComparable;
+import com.asakusafw.runtime.value.ByteOption;
 import com.asakusafw.runtime.value.Date;
 import com.asakusafw.runtime.value.DateOption;
 import com.asakusafw.runtime.value.DateTime;
 import com.asakusafw.runtime.value.DateTimeOption;
 import com.asakusafw.runtime.value.DateUtil;
+import com.asakusafw.runtime.value.DecimalOption;
+import com.asakusafw.runtime.value.DoubleOption;
+import com.asakusafw.runtime.value.FloatOption;
+import com.asakusafw.runtime.value.IntOption;
+import com.asakusafw.runtime.value.LongOption;
+import com.asakusafw.runtime.value.ShortOption;
+import com.asakusafw.runtime.value.ValueOption;
 
 /**
  * Generates a string for the object.
@@ -191,6 +202,7 @@ public abstract class StringTemplate implements WritableRawComparable {
     /**
      * Format of each generator element.
      * @since 0.2.5
+     * @version 0.9.1
      */
     public enum Format {
 
@@ -202,7 +214,6 @@ public abstract class StringTemplate implements WritableRawComparable {
             public PropertyFormatter newFormatter(String formatString) {
                 return new Constant(formatString);
             }
-
             @Override
             public void check(java.lang.reflect.Type valueType, String formatString) {
                 if (formatString == null) {
@@ -224,7 +235,6 @@ public abstract class StringTemplate implements WritableRawComparable {
                     }
                 };
             }
-
             @Override
             public void check(java.lang.reflect.Type valueType, String formatString) {
                 if (formatString != null) {
@@ -234,39 +244,161 @@ public abstract class StringTemplate implements WritableRawComparable {
         },
 
         /**
+         * Converts numeric value (use {@link DecimalFormat}).
+         * @since 0.9.1
+         */
+        BYTE {
+            @Override
+            public PropertyFormatter newFormatter(String formatString) {
+                return new NumericVariable<ByteOption>(new DecimalFormat(formatString)) {
+                    @Override
+                    void doUpdate(ByteOption option) {
+                        setValue(option.get());
+                    }
+                };
+            }
+            @Override
+            public void check(java.lang.reflect.Type valueType, String formatString) {
+                NumericVariable.check(ByteOption.class, valueType, formatString);
+            }
+        },
+
+        /**
+         * Converts numeric value (use {@link DecimalFormat}).
+         * @since 0.9.1
+         */
+        SHORT {
+            @Override
+            public PropertyFormatter newFormatter(String formatString) {
+                return new NumericVariable<ShortOption>(new DecimalFormat(formatString)) {
+                    @Override
+                    void doUpdate(ShortOption option) {
+                        setValue(option.get());
+                    }
+                };
+            }
+            @Override
+            public void check(java.lang.reflect.Type valueType, String formatString) {
+                NumericVariable.check(ShortOption.class, valueType, formatString);
+            }
+        },
+
+        /**
+         * Converts numeric value (use {@link DecimalFormat}).
+         * @since 0.9.1
+         */
+        INT {
+            @Override
+            public PropertyFormatter newFormatter(String formatString) {
+                return new NumericVariable<IntOption>(new DecimalFormat(formatString)) {
+                    @Override
+                    void doUpdate(IntOption option) {
+                        setValue(option.get());
+                    }
+                };
+            }
+            @Override
+            public void check(java.lang.reflect.Type valueType, String formatString) {
+                NumericVariable.check(IntOption.class, valueType, formatString);
+            }
+        },
+
+        /**
+         * Converts numeric value (use {@link DecimalFormat}).
+         * @since 0.9.1
+         */
+        LONG {
+            @Override
+            public PropertyFormatter newFormatter(String formatString) {
+                return new NumericVariable<LongOption>(new DecimalFormat(formatString)) {
+                    @Override
+                    void doUpdate(LongOption option) {
+                        setValue(option.get());
+                    }
+                };
+            }
+            @Override
+            public void check(java.lang.reflect.Type valueType, String formatString) {
+                NumericVariable.check(LongOption.class, valueType, formatString);
+            }
+        },
+
+        /**
+         * Converts numeric value (use {@link DecimalFormat}).
+         * @since 0.9.1
+         */
+        FLOAT {
+            @Override
+            public PropertyFormatter newFormatter(String formatString) {
+                return new NumericVariable<FloatOption>(new DecimalFormat(formatString)) {
+                    @Override
+                    void doUpdate(FloatOption option) {
+                        setValue(option.get());
+                    }
+                };
+            }
+            @Override
+            public void check(java.lang.reflect.Type valueType, String formatString) {
+                NumericVariable.check(FloatOption.class, valueType, formatString);
+            }
+        },
+
+        /**
+         * Converts numeric value (use {@link DecimalFormat}).
+         * @since 0.9.1
+         */
+        DOUBLE {
+            @Override
+            public PropertyFormatter newFormatter(String formatString) {
+                return new NumericVariable<DoubleOption>(new DecimalFormat(formatString)) {
+                    @Override
+                    void doUpdate(DoubleOption option) {
+                        setValue(option.get());
+                    }
+                };
+            }
+            @Override
+            public void check(java.lang.reflect.Type valueType, String formatString) {
+                NumericVariable.check(DoubleOption.class, valueType, formatString);
+            }
+        },
+
+        /**
+         * Converts numeric value (use {@link DecimalFormat}).
+         * @since 0.9.1
+         */
+        DECIMAL {
+            @Override
+            public PropertyFormatter newFormatter(String formatString) {
+                return new NumericVariable<DecimalOption>(new DecimalFormat(formatString)) {
+                    @Override
+                    void doUpdate(DecimalOption option) {
+                        setValue(option.get());
+                    }
+                };
+            }
+            @Override
+            public void check(java.lang.reflect.Type valueType, String formatString) {
+                NumericVariable.check(DecimalOption.class, valueType, formatString);
+            }
+        },
+
+        /**
          * Converts {@link Date} date (use {@link SimpleDateFormat}).
          */
         DATE {
             @Override
             public PropertyFormatter newFormatter(String formatString) {
-                final Calendar calendar = Calendar.getInstance();
-                final DateFormat dateFormat = new SimpleDateFormat(formatString);
-                return new Variable() {
-
+                return new DateVariable<DateOption>(new SimpleDateFormat(formatString)) {
                     @Override
-                    void set(Object propertyValue) {
-                        DateOption option = (DateOption) propertyValue;
-                        if (option.isNull()) {
-                            representation.set(String.valueOf(option));
-                        } else {
-                            Date date = option.get();
-                            DateUtil.setDayToCalendar(date.getElapsedDays(), calendar);
-                            representation.set(String.valueOf(dateFormat.format(calendar.getTime())));
-                        }
+                    void doUpdate(DateOption option) {
+                        setValue(option.get());
                     }
                 };
             }
-
             @Override
             public void check(java.lang.reflect.Type valueType, String formatString) {
-                if (valueType != DateOption.class) {
-                    throw new IllegalArgumentException("type must be Date");
-                }
-                if (formatString == null) {
-                    throw new IllegalArgumentException("format string must not be null");
-                }
-                SimpleDateFormat format = new SimpleDateFormat();
-                format.applyPattern(formatString);
+                DateVariable.check(DateOption.class, valueType, formatString);
             }
         },
 
@@ -276,34 +408,16 @@ public abstract class StringTemplate implements WritableRawComparable {
         DATETIME {
             @Override
             public PropertyFormatter newFormatter(String formatString) {
-                final Calendar calendar = Calendar.getInstance();
-                final DateFormat dateFormat = new SimpleDateFormat(formatString);
-                return new Variable() {
-
+                return new DateVariable<DateTimeOption>(new SimpleDateFormat(formatString)) {
                     @Override
-                    void set(Object propertyValue) {
-                        DateTimeOption option = (DateTimeOption) propertyValue;
-                        if (option.isNull()) {
-                            representation.set(String.valueOf(option));
-                        } else {
-                            DateTime date = option.get();
-                            DateUtil.setSecondToCalendar(date.getElapsedSeconds(), calendar);
-                            representation.set(String.valueOf(dateFormat.format(calendar.getTime())));
-                        }
+                    void doUpdate(DateTimeOption option) {
+                        setValue(option.get());
                     }
                 };
             }
-
             @Override
             public void check(java.lang.reflect.Type valueType, String formatString) {
-                if (valueType != DateTimeOption.class) {
-                    throw new IllegalArgumentException("type must be DateTime");
-                }
-                if (formatString == null) {
-                    throw new IllegalArgumentException("format string must not be null");
-                }
-                SimpleDateFormat format = new SimpleDateFormat();
-                format.applyPattern(formatString);
+                DateVariable.check(DateTimeOption.class, valueType, formatString);
             }
         },
         ;
@@ -476,18 +590,109 @@ public abstract class StringTemplate implements WritableRawComparable {
 
     private abstract static class Variable extends PropertyFormatter {
 
+        private static final Text NULL = new Text("null"); //$NON-NLS-1$
+
         Variable() {
             return;
         }
 
+        final void setNull() {
+            representation.set(NULL);
+        }
+
         @Override
-        public void write(DataOutput out) throws IOException {
+        public final void write(DataOutput out) throws IOException {
             representation.write(out);
         }
 
         @Override
-        public void readFields(DataInput in) throws IOException {
+        public final void readFields(DataInput in) throws IOException {
             representation.readFields(in);
+        }
+    }
+
+    private abstract static class PropertyVariable<T extends ValueOption<T>> extends Variable {
+
+        PropertyVariable() {
+            return;
+        }
+
+        @Override
+        final void set(Object propertyValue) {
+            @SuppressWarnings("unchecked")
+            T option = (T) propertyValue;
+            if (option.isNull()) {
+                setNull();
+            } else {
+                doUpdate(option);
+            }
+        }
+
+        abstract void doUpdate(T option);
+
+        static void check0(Class<?> required, java.lang.reflect.Type valueType, String formatString) {
+            if (valueType != required) {
+                throw new IllegalArgumentException(MessageFormat.format(
+                        "type must be {0}", //$NON-NLS-1$
+                        required.getSimpleName()));
+            }
+            if (formatString == null) {
+                throw new IllegalArgumentException("format string must not be null");
+            }
+        }
+    }
+
+    private abstract static class NumericVariable<T extends ValueOption<T>> extends PropertyVariable<T> {
+
+        private final NumberFormat format;
+
+        NumericVariable(NumberFormat format) {
+            this.format = format;
+        }
+
+        static void check(Class<?> required, java.lang.reflect.Type valueType, String formatString) {
+            check0(required, valueType, formatString);
+            DecimalFormat format = new DecimalFormat();
+            format.applyPattern(formatString);
+        }
+
+        final void setValue(long value) {
+            representation.set(format.format(value));
+        }
+
+        final void setValue(double value) {
+            representation.set(format.format(value));
+        }
+
+        final void setValue(BigDecimal value) {
+            representation.set(format.format(value));
+        }
+    }
+
+    private abstract static class DateVariable<T extends ValueOption<T>> extends PropertyVariable<T> {
+
+        private final DateFormat format;
+
+        private final Calendar calendarBuffer = Calendar.getInstance();
+
+        DateVariable(DateFormat format) {
+            this.format = format;
+        }
+
+        static void check(Class<?> required, java.lang.reflect.Type valueType, String formatString) {
+            check0(required, valueType, formatString);
+            SimpleDateFormat format = new SimpleDateFormat();
+            format.applyPattern(formatString);
+        }
+
+        final void setValue(Date value) {
+            DateUtil.setDayToCalendar(value.getElapsedDays(), calendarBuffer);
+            representation.set(format.format(calendarBuffer.getTime()));
+        }
+
+        final void setValue(DateTime value) {
+            DateUtil.setSecondToCalendar(value.getElapsedSeconds(), calendarBuffer);
+            representation.set(String.valueOf(format.format(calendarBuffer.getTime())));
         }
     }
 }

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/stage/directio/StringTemplateTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/stage/directio/StringTemplateTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.Arrays;
 
 import org.apache.hadoop.io.DataInputBuffer;
@@ -30,10 +31,17 @@ import org.junit.Test;
 import com.asakusafw.runtime.io.util.WritableRawComparable;
 import com.asakusafw.runtime.stage.directio.StringTemplate.Format;
 import com.asakusafw.runtime.stage.directio.StringTemplate.FormatSpec;
+import com.asakusafw.runtime.value.ByteOption;
 import com.asakusafw.runtime.value.Date;
 import com.asakusafw.runtime.value.DateOption;
 import com.asakusafw.runtime.value.DateTime;
 import com.asakusafw.runtime.value.DateTimeOption;
+import com.asakusafw.runtime.value.DecimalOption;
+import com.asakusafw.runtime.value.DoubleOption;
+import com.asakusafw.runtime.value.FloatOption;
+import com.asakusafw.runtime.value.IntOption;
+import com.asakusafw.runtime.value.LongOption;
+import com.asakusafw.runtime.value.ShortOption;
 
 /**
  * Test for {@link StringTemplate}.
@@ -59,6 +67,83 @@ public class StringTemplateTest {
         Mock mock = new Mock(spec(NATURAL));
         mock.setMock("Hello, world!");
         assertThat(mock.apply(), is("Hello, world!"));
+    }
+
+    /**
+     * date placeholder.
+     * @throws Exception if failed
+     */
+    @Test
+    public void placeholder_byte() throws Exception {
+        Mock mock = new Mock(spec(BYTE, "0000"));
+        mock.setMock(new ByteOption((byte) 1));
+        assertThat(mock.apply(), is("0001"));
+    }
+
+    /**
+     * short placeholder.
+     * @throws Exception if failed
+     */
+    @Test
+    public void placeholder_short() throws Exception {
+        Mock mock = new Mock(spec(SHORT, "0000"));
+        mock.setMock(new ShortOption((short) 1));
+        assertThat(mock.apply(), is("0001"));
+    }
+
+    /**
+     * int placeholder.
+     * @throws Exception if failed
+     */
+    @Test
+    public void placeholder_int() throws Exception {
+        Mock mock = new Mock(spec(INT, "0000"));
+        mock.setMock(new IntOption(1));
+        assertThat(mock.apply(), is("0001"));
+    }
+
+    /**
+     * long placeholder.
+     * @throws Exception if failed
+     */
+    @Test
+    public void placeholder_long() throws Exception {
+        Mock mock = new Mock(spec(LONG, "0000"));
+        mock.setMock(new LongOption(1));
+        assertThat(mock.apply(), is("0001"));
+    }
+
+    /**
+     * float placeholder.
+     * @throws Exception if failed
+     */
+    @Test
+    public void placeholder_float() throws Exception {
+        Mock mock = new Mock(spec(FLOAT, "0000"));
+        mock.setMock(new FloatOption(1));
+        assertThat(mock.apply(), is("0001"));
+    }
+
+    /**
+     * double placeholder.
+     * @throws Exception if failed
+     */
+    @Test
+    public void placeholder_double() throws Exception {
+        Mock mock = new Mock(spec(DOUBLE, "0000"));
+        mock.setMock(new DoubleOption(1));
+        assertThat(mock.apply(), is("0001"));
+    }
+
+    /**
+     * decimal placeholder.
+     * @throws Exception if failed
+     */
+    @Test
+    public void placeholder_decimal() throws Exception {
+        Mock mock = new Mock(spec(DECIMAL, "0000"));
+        mock.setMock(new DecimalOption(BigDecimal.valueOf(1)));
+        assertThat(mock.apply(), is("0001"));
     }
 
     /**
@@ -204,8 +289,11 @@ public class StringTemplateTest {
 
     private static class Mock extends StringTemplate {
 
+        private final FormatSpec[] ss;
+
         Mock(FormatSpec... specs) {
             super(specs);
+            this.ss = specs;
         }
 
         void setMock(Object... values) {
@@ -216,7 +304,10 @@ public class StringTemplateTest {
         public void set(Object object) {
             Object[] values = (Object[]) object;
             for (int i = 0; i < values.length; i++) {
-                setProperty(i, values[i]);
+                FormatSpec spec = ss[i];
+                Object value = values[i];
+                spec.getFormat().check(value.getClass(), spec.getString());
+                setProperty(i, value);
             }
         }
     }

--- a/mapreduce/compiler/directio/src/main/java/com/asakusafw/compiler/directio/OutputPattern.java
+++ b/mapreduce/compiler/directio/src/main/java/com/asakusafw/compiler/directio/OutputPattern.java
@@ -19,8 +19,11 @@ import java.lang.reflect.Type;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -28,14 +31,21 @@ import java.util.regex.Pattern;
 import com.asakusafw.compiler.flow.DataClass;
 import com.asakusafw.compiler.flow.DataClass.Property;
 import com.asakusafw.runtime.stage.directio.StringTemplate.Format;
+import com.asakusafw.runtime.value.ByteOption;
 import com.asakusafw.runtime.value.DateOption;
 import com.asakusafw.runtime.value.DateTimeOption;
+import com.asakusafw.runtime.value.DecimalOption;
+import com.asakusafw.runtime.value.DoubleOption;
+import com.asakusafw.runtime.value.FloatOption;
+import com.asakusafw.runtime.value.IntOption;
+import com.asakusafw.runtime.value.LongOption;
+import com.asakusafw.runtime.value.ShortOption;
 import com.asakusafw.vocabulary.directio.DirectFileOutputDescription;
 
 /**
  * Processes patterns in {@link DirectFileOutputDescription}.
  * @since 0.2.5
- * @version 0.2.6
+ * @version 0.9.1
  */
 public final class OutputPattern {
 
@@ -80,6 +90,21 @@ public final class OutputPattern {
     private static final int[] ORDER_GROUP_INDEX = { 2, 4, 6, 8, 10 };
 
     private static final boolean[] ASC_MAP = { true, true, false, true, false };
+
+    private static final Map<Class<?>, Format> FORMATS;
+    static {
+        Map<Class<?>, Format> map = new HashMap<>();
+        map.put(ByteOption.class, Format.BYTE);
+        map.put(ShortOption.class, Format.SHORT);
+        map.put(IntOption.class, Format.INT);
+        map.put(LongOption.class, Format.LONG);
+        map.put(FloatOption.class, Format.FLOAT);
+        map.put(DoubleOption.class, Format.DOUBLE);
+        map.put(DecimalOption.class, Format.DECIMAL);
+        map.put(DateOption.class, Format.DATE);
+        map.put(DateTimeOption.class, Format.DATETIME);
+        FORMATS = Collections.unmodifiableMap(map);
+    }
 
     private OutputPattern() {
         return;
@@ -216,13 +241,7 @@ public final class OutputPattern {
             return Format.NATURAL;
         }
         Type type = property.getType();
-        if (type == DateOption.class) {
-            return Format.DATE;
-        }
-        if (type == DateTimeOption.class) {
-            return Format.DATETIME;
-        }
-        return null;
+        return FORMATS.get(type);
     }
 
     private static final class Cursor {

--- a/mapreduce/compiler/directio/src/test/java/com/asakusafw/compiler/directio/OutputPatternTest.java
+++ b/mapreduce/compiler/directio/src/test/java/com/asakusafw/compiler/directio/OutputPatternTest.java
@@ -61,6 +61,19 @@ public class OutputPatternTest {
     }
 
     /**
+     * resource pattern with int placeholder.
+     */
+    @Test
+    public void resource_placeholder_numeric() {
+        List<CompiledResourcePattern> pattern = OutputPattern.compileResourcePattern(
+                "{intValue:#,###}", dataClass);
+        assertThat(pattern.size(), is(1));
+        assertThat(pattern.get(0).getTarget().getName(), is("intValue"));
+        assertThat(pattern.get(0).getFormat(), is(Format.INT));
+        assertThat(pattern.get(0).getArgument(), is("#,###"));
+    }
+
+    /**
      * resource pattern with date placeholder.
      */
     @Test


### PR DESCRIPTION
## Summary

Resource pattern of Direct I/O file output now can accept decimal format (`DecimalFormat`).

## Background, Problem or Goal of the patch

`DirectFileOutputDescription.getResourcePattern()` can contain `{placeholder:format}` but `format` is only available for `DATE` and `DATETIME` properties.

Here, the PR introduces the *format* for numeric properties, `BYTE`, `SHORT`, `INT`, `LONG`, `FLOAT`, `DOUBLE`, and `DECIMAL`. The format pattern must be `DecimalFormat`. 

## Design of the fix, or a new feature

This commit only activates the feature for Asakusa on MapReduce.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 