### PR TITLE
Rename `directio.text.{delimited=>tabular}`.

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/tabular/CharMap.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/tabular/CharMap.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.runtime.io.text.delimited;
+package com.asakusafw.runtime.io.text.tabular;
 
 import java.util.Arrays;
 import java.util.List;

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/tabular/EscapeSequence.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/tabular/EscapeSequence.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.runtime.io.text.delimited;
+package com.asakusafw.runtime.io.text.tabular;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/tabular/LineCursor.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/tabular/LineCursor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.runtime.io.text.delimited;
+package com.asakusafw.runtime.io.text.tabular;
 
 import java.io.Closeable;
 import java.io.IOException;

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/tabular/TabularFieldReader.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/tabular/TabularFieldReader.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.runtime.io.text.delimited;
+package com.asakusafw.runtime.io.text.tabular;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -23,10 +23,10 @@ import java.util.function.UnaryOperator;
 import com.asakusafw.runtime.io.text.FieldReader;
 
 /**
- * A {@link FieldReader} for delimited text contents.
+ * A {@link FieldReader} for tabular-style text contents.
  * @since 0.9.1
  */
-public class DelimitedFieldReader implements FieldReader {
+public class TabularFieldReader implements FieldReader {
 
     private static final int EOF = -1;
 
@@ -63,7 +63,7 @@ public class DelimitedFieldReader implements FieldReader {
      * @param escapeSequences the escape sequences definition (nullable)
      * @param transformer the line content transformer (nullable)
      */
-    public DelimitedFieldReader(
+    public TabularFieldReader(
             Reader reader,
             char fieldSeparator,
             EscapeSequence escapeSequences,

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/tabular/TabularFieldWriter.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/tabular/TabularFieldWriter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.runtime.io.text.delimited;
+package com.asakusafw.runtime.io.text.tabular;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -29,10 +29,10 @@ import com.asakusafw.runtime.io.text.UnmappableOutputException;
 import com.asakusafw.runtime.io.text.driver.FieldOutput;
 
 /**
- * A {@link FieldWriter} for delimited text contents.
+ * A {@link FieldWriter} for tabular style text contents.
  * @since 0.9.1
  */
-public class DelimitedFieldWriter implements FieldWriter {
+public class TabularFieldWriter implements FieldWriter {
 
     private static final int ABSENT = -2;
 
@@ -72,7 +72,7 @@ public class DelimitedFieldWriter implements FieldWriter {
      * @param escapeSequences the escape sequences definition (nullable)
      * @param transformer the output transformer (nullable)
      */
-    public DelimitedFieldWriter(
+    public TabularFieldWriter(
             Writer writer,
             LineSeparator lineSeparator,
             char fieldSeparator,

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/tabular/TabularTextFormat.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/tabular/TabularTextFormat.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.runtime.io.text.delimited;
+package com.asakusafw.runtime.io.text.tabular;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -32,10 +32,10 @@ import com.asakusafw.runtime.io.text.LineSeparator;
 import com.asakusafw.runtime.io.text.TextFormat;
 
 /**
- * An implementation of {@link TextFormat} for delimited text files.
+ * An implementation of {@link TextFormat} for tabular-style text files.
  * @since 0.9.1
  */
-public class DelimitedTextFormat implements TextFormat {
+public class TabularTextFormat implements TextFormat {
 
     /**
      * The default charset.
@@ -64,7 +64,7 @@ public class DelimitedTextFormat implements TextFormat {
 
     private final Supplier<? extends UnaryOperator<CharSequence>> outputTransformer;
 
-    DelimitedTextFormat(
+    TabularTextFormat(
             Charset charset,
             LineSeparator lineSeparator, char fieldSeparator,
             EscapeSequence escapeSequence,
@@ -87,26 +87,26 @@ public class DelimitedTextFormat implements TextFormat {
     }
 
     @Override
-    public DelimitedFieldReader open(InputStream input) throws IOException {
+    public TabularFieldReader open(InputStream input) throws IOException {
         return open(new InputStreamReader(input, charset));
     }
 
     @Override
-    public DelimitedFieldWriter open(OutputStream output) throws IOException {
+    public TabularFieldWriter open(OutputStream output) throws IOException {
         return open(new OutputStreamWriter(output, charset));
     }
 
     @Override
-    public DelimitedFieldReader open(Reader input) throws IOException {
-        return new DelimitedFieldReader(
+    public TabularFieldReader open(Reader input) throws IOException {
+        return new TabularFieldReader(
                 input,
                 fieldSeparator, escapeSequence,
                 inputTransformer.get());
     }
 
     @Override
-    public DelimitedFieldWriter open(Writer output) throws IOException {
-        return new DelimitedFieldWriter(
+    public TabularFieldWriter open(Writer output) throws IOException {
+        return new TabularFieldWriter(
                 output,
                 lineSeparator, fieldSeparator, escapeSequence,
                 outputTransformer.get());
@@ -121,7 +121,7 @@ public class DelimitedTextFormat implements TextFormat {
     }
 
     /**
-     * A builder of {@link DelimitedTextFormat}.
+     * A builder of {@link TabularTextFormat}.
      * @since 0.9.1
      */
     public static class Builder {
@@ -243,11 +243,11 @@ public class DelimitedTextFormat implements TextFormat {
         }
 
         /**
-         * Builds a {@link DelimitedTextFormat}.
+         * Builds a {@link TabularTextFormat}.
          * @return the built object
          */
-        public DelimitedTextFormat build() {
-            return new DelimitedTextFormat(
+        public TabularTextFormat build() {
+            return new TabularTextFormat(
                     charset,
                     lineSeparator, fieldSeparator,
                     escapeSequence,

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/tabular/package-info.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/tabular/package-info.java
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Extracting and generating delimited field text..
+ * Extracting and generating tabular-style text files.
  */
-package com.asakusafw.runtime.io.text.delimited;
+package com.asakusafw.runtime.io.text.tabular;

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/csv/CsvFieldWriterTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/csv/CsvFieldWriterTest.java
@@ -28,8 +28,8 @@ import org.junit.Test;
 
 import com.asakusafw.runtime.io.text.FieldWriter;
 import com.asakusafw.runtime.io.text.LineSeparator;
-import com.asakusafw.runtime.io.text.UnmappableOutputException;
 import com.asakusafw.runtime.io.text.UnmappableOutput.ErrorCode;
+import com.asakusafw.runtime.io.text.UnmappableOutputException;
 import com.asakusafw.runtime.io.text.driver.BasicFieldOutput;
 import com.asakusafw.runtime.io.text.driver.FieldOutput;
 import com.asakusafw.runtime.io.text.driver.StandardFieldOutputOption;

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/tabular/LineCursorTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/tabular/LineCursorTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.runtime.io.text.delimited;
+package com.asakusafw.runtime.io.text.tabular;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/tabular/TabularFieldReaderTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/tabular/TabularFieldReaderTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.runtime.io.text.delimited;
+package com.asakusafw.runtime.io.text.tabular;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
@@ -27,9 +27,9 @@ import java.util.function.UnaryOperator;
 import org.junit.Test;
 
 /**
- * Test for {@link DelimitedFieldReader}.
+ * Test for {@link TabularFieldReader}.
  */
-public class DelimitedFieldReaderTest {
+public class TabularFieldReaderTest {
 
     private EscapeSequence escape = EscapeSequence.builder('\\')
             .addMapping('\\', '\\')
@@ -288,7 +288,7 @@ public class DelimitedFieldReaderTest {
      */
     @Test
     public void indices() throws Exception {
-        try (DelimitedFieldReader reader = reader(null, "A\tB\tC")) {
+        try (TabularFieldReader reader = reader(null, "A\tB\tC")) {
             assertThat(reader.nextRecord(), is(true));
 
             assertThat(reader.nextField(), is(true));
@@ -318,7 +318,7 @@ public class DelimitedFieldReaderTest {
      */
     @Test
     public void indices_multiline() throws Exception {
-        try (DelimitedFieldReader reader = reader(null, "A", "B", "C")) {
+        try (TabularFieldReader reader = reader(null, "A", "B", "C")) {
             assertThat(reader.nextRecord(), is(true));
 
             assertThat(reader.nextField(), is(true));
@@ -356,7 +356,7 @@ public class DelimitedFieldReaderTest {
      */
     @Test
     public void indices_filter() throws Exception {
-        try (DelimitedFieldReader reader = reader(s -> s.toString().equals("B") ? null : s, "A", "B", "C")) {
+        try (TabularFieldReader reader = reader(s -> s.toString().equals("B") ? null : s, "A", "B", "C")) {
             assertThat(reader.nextRecord(), is(true));
 
             assertThat(reader.nextField(), is(true));
@@ -384,7 +384,7 @@ public class DelimitedFieldReaderTest {
     }
 
     private String[][] read(UnaryOperator<CharSequence> transformer, String... lines) {
-        try (DelimitedFieldReader reader = reader(transformer, lines)) {
+        try (TabularFieldReader reader = reader(transformer, lines)) {
             List<List<String>> results = new ArrayList<>();
             while (reader.nextRecord()) {
                 List<String> row = new ArrayList<>();
@@ -402,8 +402,8 @@ public class DelimitedFieldReaderTest {
         }
     }
 
-    private DelimitedFieldReader reader(UnaryOperator<CharSequence> transformer, String... lines) {
-        return new DelimitedFieldReader(
+    private TabularFieldReader reader(UnaryOperator<CharSequence> transformer, String... lines) {
+        return new TabularFieldReader(
                 new StringReader(String.join("\n", lines)), '\t', escape, transformer);
     }
 }

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/tabular/TabularFieldWriterTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/tabular/TabularFieldWriterTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.runtime.io.text.delimited;
+package com.asakusafw.runtime.io.text.tabular;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
@@ -29,14 +29,14 @@ import org.junit.Test;
 import com.asakusafw.runtime.io.text.FieldWriter;
 import com.asakusafw.runtime.io.text.LineSeparator;
 import com.asakusafw.runtime.io.text.UnmappableOutput.ErrorCode;
+import com.asakusafw.runtime.io.text.UnmappableOutputException;
 import com.asakusafw.runtime.io.text.driver.BasicFieldOutput;
 import com.asakusafw.runtime.io.text.driver.FieldOutput;
-import com.asakusafw.runtime.io.text.UnmappableOutputException;
 
 /**
- * Test for {@link DelimitedFieldWriter}.
+ * Test for {@link TabularFieldWriter}.
  */
-public class DelimitedFieldWriterTest {
+public class TabularFieldWriterTest {
 
     private LineSeparator lineSeparator = LineSeparator.UNIX;
 
@@ -781,7 +781,7 @@ public class DelimitedFieldWriterTest {
 
     private String emit(UnaryOperator<CharSequence> transformer, Action action) {
         StringWriter writer = new StringWriter();
-        try (DelimitedFieldWriter w = new DelimitedFieldWriter(writer, lineSeparator, '\t', escape, transformer)) {
+        try (TabularFieldWriter w = new TabularFieldWriter(writer, lineSeparator, '\t', escape, transformer)) {
             action.perform(w);
         } catch (IOException e) {
             throw new AssertionError(e);

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/tabular/TabularTextFormatTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/tabular/TabularTextFormatTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.runtime.io.text.delimited;
+package com.asakusafw.runtime.io.text.tabular;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
@@ -33,16 +33,16 @@ import com.asakusafw.runtime.io.text.LineSeparator;
 import com.asakusafw.runtime.io.text.driver.BasicFieldOutput;
 
 /**
- * Test for {@link DelimitedTextFormat}.
+ * Test for {@link TabularTextFormat}.
  */
-public class DelimitedTextFormatTest {
+public class TabularTextFormatTest {
 
     /**
      * input.
      */
     @Test
     public void input() {
-        DelimitedTextFormat format = DelimitedTextFormat.builder()
+        TabularTextFormat format = TabularTextFormat.builder()
                 .build();
         String[][] results = read(format, new String[] {
                 "Hello, world!",
@@ -57,7 +57,7 @@ public class DelimitedTextFormatTest {
      */
     @Test
     public void input_delimited() {
-        DelimitedTextFormat format = DelimitedTextFormat.builder()
+        TabularTextFormat format = TabularTextFormat.builder()
                 .build();
         String[][] results = read(format, new String[] {
                 "A\tB",
@@ -74,7 +74,7 @@ public class DelimitedTextFormatTest {
      */
     @Test
     public void input_charset() {
-        DelimitedTextFormat format = DelimitedTextFormat.builder()
+        TabularTextFormat format = TabularTextFormat.builder()
                 .withCharset("US-ASCII")
                 .build();
         String[][] results = read(format, new String[] {
@@ -92,7 +92,7 @@ public class DelimitedTextFormatTest {
      */
     @Test
     public void input_field_separator() {
-        DelimitedTextFormat format = DelimitedTextFormat.builder()
+        TabularTextFormat format = TabularTextFormat.builder()
                 .withFieldSeparator(',')
                 .build();
         String[][] results = read(format, new String[] {
@@ -110,7 +110,7 @@ public class DelimitedTextFormatTest {
      */
     @Test
     public void input_escape_sequence() {
-        DelimitedTextFormat format = DelimitedTextFormat.builder()
+        TabularTextFormat format = TabularTextFormat.builder()
                 .withEscapeSequence(EscapeSequence.builder('\\')
                         .addMapping('t', '\t')
                         .build())
@@ -130,7 +130,7 @@ public class DelimitedTextFormatTest {
      */
     @Test
     public void input_transformer() {
-        DelimitedTextFormat format = DelimitedTextFormat.builder()
+        TabularTextFormat format = TabularTextFormat.builder()
                 .withInputTransformer(LowerCaseTransformer.class)
                 .build();
         String[][] results = read(format, new String[] {
@@ -148,7 +148,7 @@ public class DelimitedTextFormatTest {
      */
     @Test
     public void output() {
-        DelimitedTextFormat format = DelimitedTextFormat.builder()
+        TabularTextFormat format = TabularTextFormat.builder()
                 .build();
         String[] results = write(format, new String[][] {
             { "Hello, world!", },
@@ -163,7 +163,7 @@ public class DelimitedTextFormatTest {
      */
     @Test
     public void output_delimited() {
-        DelimitedTextFormat format = DelimitedTextFormat.builder()
+        TabularTextFormat format = TabularTextFormat.builder()
                 .build();
         String[] results = write(format, new String[][] {
             { "A", "B", },
@@ -180,7 +180,7 @@ public class DelimitedTextFormatTest {
      */
     @Test
     public void output_charset() {
-        DelimitedTextFormat format = DelimitedTextFormat.builder()
+        TabularTextFormat format = TabularTextFormat.builder()
                 .withCharset("US-ASCII")
                 .build();
         String[] results = write(format, new String[][] {
@@ -198,7 +198,7 @@ public class DelimitedTextFormatTest {
      */
     @Test
     public void output_line_separator() {
-        DelimitedTextFormat format = DelimitedTextFormat.builder()
+        TabularTextFormat format = TabularTextFormat.builder()
                 .withLineSeparator(LineSeparator.WINDOWS)
                 .build();
         String[] results = write(format, new String[][] {
@@ -216,7 +216,7 @@ public class DelimitedTextFormatTest {
      */
     @Test
     public void output_field_separator() {
-        DelimitedTextFormat format = DelimitedTextFormat.builder()
+        TabularTextFormat format = TabularTextFormat.builder()
                 .withFieldSeparator(',')
                 .build();
         String[] results = write(format, new String[][] {
@@ -234,7 +234,7 @@ public class DelimitedTextFormatTest {
      */
     @Test
     public void output_escape_sequence() {
-        DelimitedTextFormat format = DelimitedTextFormat.builder()
+        TabularTextFormat format = TabularTextFormat.builder()
                 .withEscapeSequence(EscapeSequence.builder('\\')
                         .addMapping('t', '\t')
                         .build())
@@ -254,7 +254,7 @@ public class DelimitedTextFormatTest {
      */
     @Test
     public void output_transformer() {
-        DelimitedTextFormat format = DelimitedTextFormat.builder()
+        TabularTextFormat format = TabularTextFormat.builder()
                 .withOutputTransformer(LowerCaseTransformer.class)
                 .build();
         String[] results = write(format, new String[][] {
@@ -267,14 +267,14 @@ public class DelimitedTextFormatTest {
         }));
     }
 
-    private String[][] read(DelimitedTextFormat format, String... lines) {
+    private String[][] read(TabularTextFormat format, String... lines) {
         StringBuilder buffer = new StringBuilder();
         for (String line : lines) {
             buffer.append(line);
             buffer.append(format.getLineSeparator().getSequence());
         }
         byte[] bytes = buffer.toString().getBytes(format.getCharset());
-        try (DelimitedFieldReader reader = format.open(new ByteArrayInputStream(bytes))) {
+        try (TabularFieldReader reader = format.open(new ByteArrayInputStream(bytes))) {
             List<List<String>> results = new ArrayList<>();
             while (reader.nextRecord()) {
                 List<String> row = new ArrayList<>();
@@ -292,10 +292,10 @@ public class DelimitedTextFormatTest {
         }
     }
 
-    private String[] write(DelimitedTextFormat format, String[][] fields) {
+    private String[] write(TabularTextFormat format, String[][] fields) {
         BasicFieldOutput fout = new BasicFieldOutput();
         ByteArrayOutputStream output = new ByteArrayOutputStream();
-        try (DelimitedFieldWriter writer = format.open(output)) {
+        try (TabularFieldWriter writer = format.open(output)) {
             for (String[] row : fields) {
                 for (String field : row) {
                     writer.putField(fout.set(field));

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/TextFormatConstants.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/TextFormatConstants.java
@@ -254,7 +254,7 @@ public final class TextFormatConstants {
      */
     public static final String ELEMENT_HEADER_QUOTE_STYLE = "header_" + ELEMENT_QUOTE_STYLE; //$NON-NLS-1$
 
-    // delimited text
+    // tabular
 
     /**
      * The element name of escape character.

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/csv/CsvTextEmitter.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/csv/CsvTextEmitter.java
@@ -68,10 +68,10 @@ public class CsvTextEmitter extends JavaDataModelDriver {
                 model,
                 PACKAGE_SEGMENT,
                 "{0}CsvTextFormat"); //$NON-NLS-1$
-        LOG.debug("Generating delimited text format for {}", //$NON-NLS-1$
+        LOG.debug("Generating CSV format for {}", //$NON-NLS-1$
                 context.getQualifiedTypeName().toNameString());
         FormatGenerator.emit(next, model, trait);
-        LOG.debug("Generated delimited text format for {}: {}", //$NON-NLS-1$
+        LOG.debug("Generated CSV format for {}: {}", //$NON-NLS-1$
                 context.getQualifiedTypeName().toNameString(),
                 next.getQualifiedTypeName().toNameString());
         return next.getQualifiedTypeName();

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/tabular/Messages.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/tabular/Messages.java
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.dmdl.directio.text.delimited;
+package com.asakusafw.dmdl.directio.text.tabular;
 
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
 final class Messages {
-    private static final String BUNDLE_NAME = "com.asakusafw.dmdl.directio.text.delimited.messages"; //$NON-NLS-1$
+    private static final String BUNDLE_NAME = "com.asakusafw.dmdl.directio.text.tabular.messages"; //$NON-NLS-1$
 
     private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
 

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/tabular/TabularTextDriver.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/tabular/TabularTextDriver.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.dmdl.directio.text.delimited;
+package com.asakusafw.dmdl.directio.text.tabular;
 
 import static com.asakusafw.dmdl.directio.text.TextFormatConstants.*;
 
@@ -37,16 +37,16 @@ import com.asakusafw.dmdl.spi.ModelAttributeDriver;
 import com.asakusafw.dmdl.util.AttributeUtil;
 
 /**
- * Processes <code>&#64;directio.text.delimited</code> attributes.
+ * Processes <code>&#64;directio.text.tabular</code> attributes.
  * @since 0.9.1
  * @see TextFormatConstants
  */
-public class DelimitedTextDriver extends ModelAttributeDriver {
+public class TabularTextDriver extends ModelAttributeDriver {
 
     /**
      * The attribute name.
      */
-    public static final String NAME = PREFIX_NAMESPACE + "delimited"; //$NON-NLS-1$
+    public static final String NAME = PREFIX_NAMESPACE + "tabular"; //$NON-NLS-1$
 
     @Override
     public String getTargetName() {
@@ -60,15 +60,15 @@ public class DelimitedTextDriver extends ModelAttributeDriver {
         EscapeSettings escape = EscapeSettings.consume(environment, attribute, elements);
         TextFieldSettings field = TextFieldSettings.consume(environment, attribute, elements);
         environment.reportAll(AttributeUtil.reportInvalidElements(attribute, elements.values()));
-        DelimitedTextTrait trait = new DelimitedTextTrait(attribute, format, escape, field);
+        TabularTextTrait trait = new TabularTextTrait(attribute, format, escape, field);
         if (trait.verify(environment, declaration)) {
-            DelimitedTextTrait.register(environment, declaration, trait);
+            TabularTextTrait.register(environment, declaration, trait);
         }
     }
 
     @Override
     public void verify(DmdlSemantics environment, ModelDeclaration declaration, AstAttribute attribute) {
-        DelimitedTextTrait parent = DelimitedTextTrait.get(declaration);
+        TabularTextTrait parent = TabularTextTrait.get(declaration);
         verifyModel(environment, declaration, parent);
         declaration.getDeclaredProperties().stream()
             .filter(p -> TextFieldTrait.find(p).isPresent())
@@ -81,12 +81,12 @@ public class DelimitedTextDriver extends ModelAttributeDriver {
     }
 
     private static void verifyModel(
-            DmdlSemantics environment, ModelDeclaration declaration, DelimitedTextTrait trait) {
+            DmdlSemantics environment, ModelDeclaration declaration, TabularTextTrait trait) {
         if (declaration.getDeclaredProperties().stream()
                 .noneMatch(p -> TextFieldTrait.getKind(p) == TextFieldTrait.Kind.VALUE)) {
             environment.report(new Diagnostic(
                     Diagnostic.Level.ERROR, trait.getOriginalAst().name,
-                    Messages.getString("DelimitedTextDriver.diagnosticNoAvailableField"), //$NON-NLS-1$
+                    Messages.getString("TabularTextDriver.diagnosticNoAvailableField"), //$NON-NLS-1$
                     declaration.getName(),
                     trait.getOriginalAst().name));
         }
@@ -117,7 +117,7 @@ public class DelimitedTextDriver extends ModelAttributeDriver {
             String a, String b) {
         environment.report(new Diagnostic(
                 Diagnostic.Level.ERROR, property.getName(),
-                Messages.getString("DelimitedTextDriver.diagnosticConflictFormat"), //$NON-NLS-1$
+                Messages.getString("TabularTextDriver.diagnosticConflictFormat"), //$NON-NLS-1$
                 property.getOwner().getName(),
                 property.getName(),
                 a, b));

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/tabular/TabularTextEmitter.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/tabular/TabularTextEmitter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.dmdl.directio.text.delimited;
+package com.asakusafw.dmdl.directio.text.tabular;
 
 import static com.asakusafw.dmdl.directio.text.TextFormatConstants.*;
 
@@ -33,8 +33,8 @@ import com.asakusafw.dmdl.directio.util.MapValue;
 import com.asakusafw.dmdl.java.emitter.EmitContext;
 import com.asakusafw.dmdl.java.spi.JavaDataModelDriver;
 import com.asakusafw.dmdl.semantics.ModelDeclaration;
-import com.asakusafw.runtime.io.text.delimited.DelimitedTextFormat;
-import com.asakusafw.runtime.io.text.delimited.EscapeSequence;
+import com.asakusafw.runtime.io.text.tabular.EscapeSequence;
+import com.asakusafw.runtime.io.text.tabular.TabularTextFormat;
 import com.asakusafw.utils.java.model.syntax.ModelFactory;
 import com.asakusafw.utils.java.model.syntax.Name;
 import com.asakusafw.utils.java.model.syntax.SimpleName;
@@ -43,16 +43,16 @@ import com.asakusafw.utils.java.model.util.ExpressionBuilder;
 import com.asakusafw.utils.java.model.util.TypeBuilder;
 
 /**
- * Emits Direct I/O data format classes about delimited text.
+ * Emits Direct I/O data format classes about tabular text.
  * @since 0.9.1
  */
-public class DelimitedTextEmitter extends JavaDataModelDriver {
+public class TabularTextEmitter extends JavaDataModelDriver {
 
-    static final Logger LOG = LoggerFactory.getLogger(DelimitedTextEmitter.class);
+    static final Logger LOG = LoggerFactory.getLogger(TabularTextEmitter.class);
 
     @Override
     public void generateResources(EmitContext context, ModelDeclaration model) throws IOException {
-        if (DelimitedTextTrait.find(model).isPresent() == false) {
+        if (TabularTextTrait.find(model).isPresent() == false) {
             return;
         }
         Name supportName = generateFormat(context, model);
@@ -63,17 +63,17 @@ public class DelimitedTextEmitter extends JavaDataModelDriver {
     private static Name generateFormat(EmitContext context, ModelDeclaration model) throws IOException {
         assert context != null;
         assert model != null;
-        DelimitedTextTrait trait = DelimitedTextTrait.get(model);
+        TabularTextTrait trait = TabularTextTrait.get(model);
         EmitContext next = new EmitContext(
                 context.getSemantics(),
                 context.getConfiguration(),
                 model,
                 PACKAGE_SEGMENT,
-                "{0}DelimitedTextFormat"); //$NON-NLS-1$
-        LOG.debug("Generating delimited text format for {}", //$NON-NLS-1$
+                "{0}TabularTextFormat"); //$NON-NLS-1$
+        LOG.debug("Generating tabular text format for {}", //$NON-NLS-1$
                 context.getQualifiedTypeName().toNameString());
         FormatGenerator.emit(next, model, trait);
-        LOG.debug("Generated delimited text format for {}: {}", //$NON-NLS-1$
+        LOG.debug("Generated tabular text format for {}: {}", //$NON-NLS-1$
                 context.getQualifiedTypeName().toNameString(),
                 next.getQualifiedTypeName().toNameString());
         return next.getQualifiedTypeName();
@@ -86,9 +86,9 @@ public class DelimitedTextEmitter extends JavaDataModelDriver {
                 context.getConfiguration(),
                 model,
                 PACKAGE_SEGMENT,
-                "Abstract{0}DelimitedTextInputDescription"); //$NON-NLS-1$
+                "Abstract{0}TabularTextInputDescription"); //$NON-NLS-1$
         DirectFileInputDescriptionGenerator.Description desc = new DirectFileInputDescriptionGenerator.Description(
-                "Delimited text file input", context.getQualifiedTypeName()); //$NON-NLS-1$
+                "Tabular text file input", context.getQualifiedTypeName()); //$NON-NLS-1$
         desc.setFormatClassName(formatClassName);
         DirectFileInputDescriptionGenerator.generate(next, desc);
     }
@@ -100,36 +100,36 @@ public class DelimitedTextEmitter extends JavaDataModelDriver {
                 context.getConfiguration(),
                 model,
                 PACKAGE_SEGMENT,
-                "Abstract{0}DelimitedTextOutputDescription"); //$NON-NLS-1$
+                "Abstract{0}TabularTextOutputDescription"); //$NON-NLS-1$
         DirectFileOutputDescriptionGenerator.Description desc = new DirectFileOutputDescriptionGenerator.Description(
-                "Delimited text file output", context.getQualifiedTypeName()); //$NON-NLS-1$
+                "Tabular text file output", context.getQualifiedTypeName()); //$NON-NLS-1$
         desc.setFormatClassName(formatClassName);
         DirectFileOutputDescriptionGenerator.generate(next, desc);
     }
 
     private static final class FormatGenerator extends AbstractTextStreamFormatGenerator {
 
-        private final DelimitedTextTrait root;
+        private final TabularTextTrait root;
 
         private final ModelFactory f;
 
-        private FormatGenerator(EmitContext context, ModelDeclaration model, DelimitedTextTrait root) {
+        private FormatGenerator(EmitContext context, ModelDeclaration model, TabularTextTrait root) {
             super(context, model, root.getFormatSettings(), root.getFieldSettings());
             this.root = root;
             this.f = context.getModelFactory();
         }
 
-        static void emit(EmitContext context, ModelDeclaration model, DelimitedTextTrait trait) throws IOException {
-            new FormatGenerator(context, model, trait).emit(Messages.getString("DelimitedTextEmitter.javadocTitle")); //$NON-NLS-1$
+        static void emit(EmitContext context, ModelDeclaration model, TabularTextTrait trait) throws IOException {
+            new FormatGenerator(context, model, trait).emit(Messages.getString("TabularTextEmitter.javadocTitle")); //$NON-NLS-1$
         }
 
         @Override
         protected List<Statement> createGetTextFormatInternal() {
             SimpleName builder = f.newSimpleName("builder"); //$NON-NLS-1$
             List<Statement> statements = new ArrayList<>();
-            statements.add(new TypeBuilder(f, context.resolve(DelimitedTextFormat.class))
+            statements.add(new TypeBuilder(f, context.resolve(TabularTextFormat.class))
                     .method("builder") //$NON-NLS-1$
-                    .toLocalVariableDeclaration(context.resolve(DelimitedTextFormat.Builder.class), builder));
+                    .toLocalVariableDeclaration(context.resolve(TabularTextFormat.Builder.class), builder));
             buildTextFormat(statements, builder);
             statements.add(new ExpressionBuilder(f, builder)
                     .method("build") //$NON-NLS-1$

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/tabular/TabularTextTrait.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/tabular/TabularTextTrait.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.dmdl.directio.text.delimited;
+package com.asakusafw.dmdl.directio.text.tabular;
 
 import static com.asakusafw.dmdl.directio.text.TextFormatConstants.*;
 
@@ -28,15 +28,15 @@ import com.asakusafw.dmdl.model.AstAttribute;
 import com.asakusafw.dmdl.semantics.DmdlSemantics;
 import com.asakusafw.dmdl.semantics.ModelDeclaration;
 import com.asakusafw.dmdl.semantics.Trait;
-import com.asakusafw.runtime.io.text.delimited.DelimitedTextFormat;
+import com.asakusafw.runtime.io.text.tabular.TabularTextFormat;
 
 /**
- * Attributes of delimited text models.
+ * Attributes of tabular text models.
  * @since 0.9.1
  */
-public class DelimitedTextTrait implements Trait<DelimitedTextTrait> {
+public class TabularTextTrait implements Trait<TabularTextTrait> {
 
-    static final char DEFAULT_FIELD_SEPARATOR = DelimitedTextFormat.DEFAULT_FIELD_SEPARATOR;
+    static final char DEFAULT_FIELD_SEPARATOR = TabularTextFormat.DEFAULT_FIELD_SEPARATOR;
 
     private final AstAttribute attribute;
 
@@ -53,7 +53,7 @@ public class DelimitedTextTrait implements Trait<DelimitedTextTrait> {
      * @param escapeSettings the escape settings
      * @param fieldSettings the field settings
      */
-    public DelimitedTextTrait(
+    public TabularTextTrait(
             AstAttribute attribute,
             TextFormatSettings formatSettings,
             EscapeSettings escapeSettings,
@@ -64,24 +64,24 @@ public class DelimitedTextTrait implements Trait<DelimitedTextTrait> {
         this.fieldSettings = fieldSettings;
     }
 
-    static Optional<DelimitedTextTrait> find(ModelDeclaration declaration) {
-        return Optional.ofNullable(declaration.getTrait(DelimitedTextTrait.class));
+    static Optional<TabularTextTrait> find(ModelDeclaration declaration) {
+        return Optional.ofNullable(declaration.getTrait(TabularTextTrait.class));
     }
 
-    static DelimitedTextTrait get(ModelDeclaration declaration) {
-        return Optional.ofNullable(declaration.getTrait(DelimitedTextTrait.class))
+    static TabularTextTrait get(ModelDeclaration declaration) {
+        return Optional.ofNullable(declaration.getTrait(TabularTextTrait.class))
                 .orElseThrow(IllegalStateException::new);
     }
 
-    static void register(DmdlSemantics environment, ModelDeclaration declaration, DelimitedTextTrait trait) {
+    static void register(DmdlSemantics environment, ModelDeclaration declaration, TabularTextTrait trait) {
         if (find(declaration).isPresent()) {
             environment.report(new Diagnostic(
                     Diagnostic.Level.ERROR, trait.attribute.name,
-                    Messages.getString("DelimitedTextTrait.diagnosticDuplicateAttribute"), //$NON-NLS-1$
+                    Messages.getString("TabularTextTrait.diagnosticDuplicateAttribute"), //$NON-NLS-1$
                     trait.attribute.name,
                     declaration.getName().identifier));
         } else {
-            declaration.putTrait(DelimitedTextTrait.class, trait);
+            declaration.putTrait(TabularTextTrait.class, trait);
         }
     }
 
@@ -129,7 +129,7 @@ public class DelimitedTextTrait implements Trait<DelimitedTextTrait> {
             if (fieldSeparator == escapeCharacter) {
                 analyzer.error(
                         escapeSettings.getCharacter().getDeclaration(),
-                        Messages.getString("DelimitedTextTrait.diagnosticConflictCharacter"), //$NON-NLS-1$
+                        Messages.getString("TabularTextTrait.diagnosticConflictCharacter"), //$NON-NLS-1$
                         ELEMENT_FIELD_SEPARATOR);
             }
         }

--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/tabular/package-info.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/text/tabular/package-info.java
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Delimited text support for Direct I/O.
+ * Tabular-style text support for Direct I/O.
  */
-package com.asakusafw.dmdl.directio.text.delimited;
+package com.asakusafw.dmdl.directio.text.tabular;

--- a/directio-project/asakusa-directio-dmdl/src/main/resources/META-INF/services/com.asakusafw.dmdl.java.spi.JavaDataModelDriver
+++ b/directio-project/asakusa-directio-dmdl/src/main/resources/META-INF/services/com.asakusafw.dmdl.java.spi.JavaDataModelDriver
@@ -1,5 +1,5 @@
 com.asakusafw.dmdl.directio.csv.driver.CsvFormatEmitter
-com.asakusafw.dmdl.directio.text.delimited.DelimitedTextEmitter
+com.asakusafw.dmdl.directio.text.tabular.TabularTextEmitter
 com.asakusafw.dmdl.directio.text.csv.CsvTextEmitter
 com.asakusafw.dmdl.directio.sequencefile.driver.SequenceFileFormatEmitter
 com.asakusafw.dmdl.directio.line.driver.LineFormatEmitter

--- a/directio-project/asakusa-directio-dmdl/src/main/resources/META-INF/services/com.asakusafw.dmdl.spi.AttributeDriver
+++ b/directio-project/asakusa-directio-dmdl/src/main/resources/META-INF/services/com.asakusafw.dmdl.spi.AttributeDriver
@@ -12,11 +12,7 @@ com.asakusafw.dmdl.directio.text.TextFileNameDriver
 com.asakusafw.dmdl.directio.text.TextLineNumberDriver
 com.asakusafw.dmdl.directio.text.TextRecordNumberDriver
 com.asakusafw.dmdl.directio.text.TextIgnoreDriver
-
-# Delimited Text
-com.asakusafw.dmdl.directio.text.delimited.DelimitedTextDriver
-
-# CSV Text
+com.asakusafw.dmdl.directio.text.tabular.TabularTextDriver
 com.asakusafw.dmdl.directio.text.csv.CsvTextDriver
 
 # Sequence File

--- a/directio-project/asakusa-directio-dmdl/src/main/resources/com/asakusafw/dmdl/directio/text/delimited/messages.properties
+++ b/directio-project/asakusa-directio-dmdl/src/main/resources/com/asakusafw/dmdl/directio/text/delimited/messages.properties
@@ -1,5 +1,0 @@
-DelimitedTextDriver.diagnosticConflictFormat="{2}" must not equal to "{3}" (in {0}.{1})
-DelimitedTextDriver.diagnosticNoAvailableField={0} does not have any available fields for @{1}
-DelimitedTextEmitter.javadocTitle=Delimited text
-DelimitedTextTrait.diagnosticConflictCharacter={0} must not equal to "{1}"
-DelimitedTextTrait.diagnosticDuplicateAttribute=@{0} is already declared in {2}

--- a/directio-project/asakusa-directio-dmdl/src/main/resources/com/asakusafw/dmdl/directio/text/tabular/messages.properties
+++ b/directio-project/asakusa-directio-dmdl/src/main/resources/com/asakusafw/dmdl/directio/text/tabular/messages.properties
@@ -1,0 +1,5 @@
+TabularTextDriver.diagnosticConflictFormat="{2}" must not equal to "{3}" (in {0}.{1})
+TabularTextDriver.diagnosticNoAvailableField={0} does not have any available fields for @{1}
+TabularTextEmitter.javadocTitle=Tabular-style text
+TabularTextTrait.diagnosticConflictCharacter={0} must not equal to "{1}"
+TabularTextTrait.diagnosticDuplicateAttribute=@{0} is already declared in {2}

--- a/directio-project/asakusa-directio-dmdl/src/test/java/com/asakusafw/dmdl/directio/text/csv/CsvTextEmitterTest.java
+++ b/directio-project/asakusa-directio-dmdl/src/test/java/com/asakusafw/dmdl/directio/text/csv/CsvTextEmitterTest.java
@@ -30,9 +30,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.asakusafw.dmdl.directio.common.driver.GeneratorTesterRoot;
-import com.asakusafw.dmdl.directio.text.delimited.DelimitedTextEmitterTest;
 import com.asakusafw.dmdl.directio.text.mock.EmptyLineFilter;
 import com.asakusafw.dmdl.directio.text.mock.UpperCaseTransformer;
+import com.asakusafw.dmdl.directio.text.tabular.TabularTextEmitterTest;
 import com.asakusafw.dmdl.java.emitter.driver.ObjectDriver;
 import com.asakusafw.runtime.directio.BinaryStreamFormat;
 import com.asakusafw.runtime.io.ModelInput;
@@ -43,7 +43,7 @@ import com.asakusafw.runtime.value.StringOption;
 
 /**
  * Test for {@link CsvTextEmitter}.
- * @see DelimitedTextEmitterTest
+ * @see TabularTextEmitterTest
  */
 public class CsvTextEmitterTest extends GeneratorTesterRoot {
 
@@ -363,6 +363,30 @@ public class CsvTextEmitterTest extends GeneratorTesterRoot {
                 .setOption("a", new StringOption("A"))
                 .setOption("b", new StringOption("B")));
         assertThat(text(contents), is("\"a\",\"b\"\r\n\"A\",\"B\"\r\n"));
+    }
+
+    /**
+     * w/ {@code header_quote_style}.
+     * @throws Exception if failed
+     */
+    @Test
+    public void header_quote_style_override() throws Exception {
+        ModelLoader loaded = generateJavaFromLines(new String[] {
+                "@directio.text.csv(",
+                "  header = force,",
+                "  quote_style = always,",
+                "  header_quote_style = never,",
+                ")",
+                "simple = {",
+                "  @directio.text.field(quote_style = always)",
+                "  a : TEXT;",
+                "  b : TEXT;",
+                "};",
+        });
+        byte[] contents = restore(loaded, loaded.newModel("Simple")
+                .setOption("a", new StringOption("A"))
+                .setOption("b", new StringOption("B")));
+        assertThat(text(contents), is("a,b\r\n\"A\",\"B\"\r\n"));
     }
 
     /**
@@ -722,7 +746,7 @@ public class CsvTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_field_empty() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.csv",
                 "simple = {",
                 "  @directio.text.ignore",
                 "  a : TEXT;",

--- a/directio-project/asakusa-directio-dmdl/src/test/java/com/asakusafw/dmdl/directio/text/tabular/TabularTextEmitterTest.java
+++ b/directio-project/asakusa-directio-dmdl/src/test/java/com/asakusafw/dmdl/directio/text/tabular/TabularTextEmitterTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.dmdl.directio.text.delimited;
+package com.asakusafw.dmdl.directio.text.tabular;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
@@ -57,9 +57,9 @@ import com.asakusafw.runtime.value.ShortOption;
 import com.asakusafw.runtime.value.StringOption;
 
 /**
- * Test for {@link DelimitedTextEmitter}.
+ * Test for {@link TabularTextEmitter}.
  */
-public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
+public class TabularTextEmitterTest extends GeneratorTesterRoot {
 
     /**
      * Escapes time zone.
@@ -86,7 +86,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
      */
     @Before
     public void setUp() throws Exception {
-        emitDrivers.add(new DelimitedTextEmitter());
+        emitDrivers.add(new TabularTextEmitter());
         emitDrivers.add(new ObjectDriver());
     }
 
@@ -97,13 +97,13 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void simple() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = { value : TEXT; };",
         });
         ModelWrapper model = loaded.newModel("Simple")
                 .setOption("value", new StringOption("Hello, world!"));
 
-        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleDelimitedTextFormat");
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleTabularTextFormat");
         assertThat(support.getSupportedType(), is((Object) model.unwrap().getClass()));
         assertThat(support.getMinimumFragmentSize(), is(not(-1L)));
 
@@ -131,7 +131,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void multiple() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  a : TEXT;",
                 "  b : TEXT;",
@@ -161,7 +161,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void type_boolean() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  a : BOOLEAN;",
                 "};",
@@ -178,7 +178,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void type_byte() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  a : BYTE;",
                 "};",
@@ -195,7 +195,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void type_short() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  a : SHORT;",
                 "};",
@@ -212,7 +212,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void type_int() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  a : INT;",
                 "};",
@@ -229,7 +229,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void type_long() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  a : LONG;",
                 "};",
@@ -246,7 +246,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void type_float() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  a : FLOAT;",
                 "};",
@@ -263,7 +263,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void type_double() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  a : DOUBLE;",
                 "};",
@@ -280,7 +280,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void header() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  header = force,",
                 ")",
                 "simple = {",
@@ -301,7 +301,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void header_name() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  header = force,",
                 ")",
                 "simple = {",
@@ -323,14 +323,14 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void charset() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  charset = 'UTF-16LE',",
                 ")",
                 "simple = {",
                 "  a : TEXT;",
                 "};",
         });
-        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleDelimitedTextFormat");
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleTabularTextFormat");
         assertThat(support.getMinimumFragmentSize(), is(-1L));
 
         ModelWrapper model = loaded.newModel("Simple")
@@ -346,7 +346,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void compression() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  compression = gzip,",
                 ")",
                 "simple = {",
@@ -373,7 +373,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void line_separator() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  line_separator = windows,",
                 ")",
                 "simple = {",
@@ -393,7 +393,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void field_separator() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  field_separator = ':',",
                 ")",
                 "simple = {",
@@ -417,7 +417,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void escape_sequence() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '^',",
                 "  escape_sequence = {",
                 "    't' : '\\t'",
@@ -442,7 +442,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void escape_sequence_empty() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '^',",
                 "  escape_sequence = {},",
                 ")",
@@ -465,7 +465,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void escape_sequence_null() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '^',",
                 "  escape_sequence = {",
                 "    'N' : null",
@@ -488,7 +488,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void escape_line_separator() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '^',",
                 "  escape_line_separator = true,",
                 ")",
@@ -511,7 +511,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void escape_line_separator_false() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '^',",
                 "  escape_line_separator = false,",
                 ")",
@@ -531,7 +531,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void input_transformer() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  input_transformer = '" + EmptyLineFilter.class.getName() + "'",
                 ")",
                 "simple = {",
@@ -550,7 +550,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void output_transformer() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  output_transformer = '" + UpperCaseTransformer.class.getName() + "'",
                 ")",
                 "simple = {",
@@ -570,7 +570,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void on_less_input() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  on_less_input = report,",
                 ")",
                 "simple = {",
@@ -591,7 +591,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void on_more_input() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  on_more_input = report,",
                 ")",
                 "simple = {",
@@ -612,7 +612,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void trim_input() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  trim_input = true,",
                 ")",
                 "simple = {",
@@ -635,7 +635,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void trim_input_field() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  a : TEXT;",
                 "  @directio.text.field(trim_input = true)",
@@ -657,7 +657,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void skip_empty_input() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  skip_empty_input = true,",
                 ")",
                 "simple = {",
@@ -678,7 +678,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void skip_empty_input_field() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field(skip_empty_input = true)",
                 "  a : TEXT;",
@@ -700,7 +700,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void on_malformed_input() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  on_malformed_input = report,",
                 ")",
                 "simple = {",
@@ -723,7 +723,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void on_malformed_input_field() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field(on_malformed_input = report)",
                 "  a : INT;",
@@ -744,7 +744,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void on_unmappable_output() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  on_unmappable_output = report,",
                 ")",
                 "simple = {",
@@ -763,7 +763,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void on_unmappable_output_field() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field(on_unmappable_output = report)",
                 "  a : INT;",
@@ -787,7 +787,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void null_format() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  null_format = 'OK',",
                 ")",
                 "simple = {",
@@ -806,7 +806,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void null_format_field() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  null_format = 'OK',",
                 ")",
                 "simple = {",
@@ -828,7 +828,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void null_format_field_null() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  null_format = 'OK',",
                 ")",
                 "simple = {",
@@ -847,7 +847,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void true_format() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  true_format = 'A',",
                 ")",
                 "simple = {",
@@ -868,7 +868,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void true_format_field() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  true_format = 'A',",
                 ")",
                 "simple = {",
@@ -890,7 +890,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void true_format_inconsistent_type() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field(true_format = '_')",
                 "  a : TEXT;",
@@ -908,7 +908,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void false_format() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  false_format = 'B',",
                 ")",
                 "simple = {",
@@ -929,7 +929,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void false_format_field() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  false_format = 'B',",
                 ")",
                 "simple = {",
@@ -951,7 +951,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void false_format_inconsistent_type() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field(false_format = '_')",
                 "  a : TEXT;",
@@ -969,7 +969,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void number_format() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  number_format = '0.00',",
                 ")",
                 "simple = {",
@@ -990,7 +990,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void number_format_integer() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  number_format = '#,###;(#,###)',",
                 ")",
                 "simple = {",
@@ -1011,7 +1011,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void number_format_field() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  number_format = '0',",
                 ")",
                 "simple = {",
@@ -1033,7 +1033,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void number_format_field_null() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  number_format = '#,###',",
                 ")",
                 "simple = {",
@@ -1055,7 +1055,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void number_format_inconsistent_type() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field(number_format = '#,###')",
                 "  a : TEXT;",
@@ -1073,7 +1073,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void date_format() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  date_format = 'yyyy_MM_dd',",
                 ")",
                 "simple = {",
@@ -1092,7 +1092,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void date_format_field() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field(date_format = 'yyyy_MM_dd')",
                 "  a : DATE;",
@@ -1112,7 +1112,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void datetime_format() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  datetime_format = 'yyyy_MM_dd HH-mm-ss',",
                 ")",
                 "simple = {",
@@ -1131,7 +1131,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void datetime_format_field() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field(datetime_format = 'yyyy_MM_dd HH-mm-ss')",
                 "  a : DATETIME;",
@@ -1151,7 +1151,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void datetime_format_inconsistent_type() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field(datetime_format = '_')",
                 "  a : TEXT;",
@@ -1169,7 +1169,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void timezone() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  timezone = 'UTC',",
                 ")",
                 "simple = {",
@@ -1188,7 +1188,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void timezone_field() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  a : DATETIME;",
                 "  @directio.text.field(timezone = 'UTC')",
@@ -1208,7 +1208,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void timezone_null() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  timezone = 'UTC',",
                 ")",
                 "simple = {",
@@ -1230,7 +1230,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void timezone_inconsistent_type() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field(timezone = 'UTC')",
                 "  a : TEXT;",
@@ -1248,7 +1248,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void decimal_output_style() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  decimal_output_style = plain,",
                 ")",
                 "simple = {",
@@ -1268,7 +1268,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void decimal_output_style_field() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field(decimal_output_style = plain)",
                 "  a : DECIMAL;",
@@ -1289,7 +1289,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void decimal_output_style_inconsistent_type() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field(decimal_output_style = plain)",
                 "  a : TEXT;",
@@ -1307,7 +1307,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void adapter() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  adapter = '" + MockFieldAdapter.class.getName() + "'",
                 ")",
                 "simple = {",
@@ -1327,7 +1327,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void adapter_field() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field(adapter = '" + MockFieldAdapter.class.getName() + "')",
                 "  a : TEXT;",
@@ -1348,7 +1348,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void adapter_override() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  adapter = '" + MockFieldAdapter.class.getName() + "'",
                 ")",
                 "simple = {",
@@ -1371,13 +1371,13 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void field_field() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field",
                 "  a : TEXT;",
                 "};",
         });
-        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleDelimitedTextFormat");
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleTabularTextFormat");
         assertThat(support.getMinimumFragmentSize(), is(not(-1L)));
 
         byte[] contents = write(loaded, loaded.newModel("Simple")
@@ -1394,14 +1394,14 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void field_ignore() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  a : TEXT;",
                 "  @directio.text.ignore",
                 "  b : TEXT;",
                 "};",
         });
-        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleDelimitedTextFormat");
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleTabularTextFormat");
         assertThat(support.getMinimumFragmentSize(), is(not(-1L)));
 
         byte[] contents = write(loaded, loaded.newModel("Simple")
@@ -1420,14 +1420,14 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void field_file_name() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  a : TEXT;",
                 "  @directio.text.file_name",
                 "  b : TEXT;",
                 "};",
         });
-        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleDelimitedTextFormat");
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleTabularTextFormat");
         assertThat(support.getMinimumFragmentSize(), is(not(-1L)));
 
         byte[] contents = write(loaded, loaded.newModel("Simple")
@@ -1446,7 +1446,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void field_line_number() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  input_transformer = '" + EmptyLineFilter.class.getName() + "'",
                 ")",
                 "simple = {",
@@ -1455,7 +1455,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
                 "  b : LONG;",
                 "};",
         });
-        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleDelimitedTextFormat");
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleTabularTextFormat");
         assertThat(support.getMinimumFragmentSize(), is(-1L));
 
         byte[] contents = write(loaded, loaded.newModel("Simple")
@@ -1476,7 +1476,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void field_line_number_int() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  input_transformer = '" + EmptyLineFilter.class.getName() + "'",
                 ")",
                 "simple = {",
@@ -1485,7 +1485,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
                 "  b : INT;",
                 "};",
         });
-        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleDelimitedTextFormat");
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleTabularTextFormat");
         assertThat(support.getMinimumFragmentSize(), is(-1L));
 
         byte[] contents = write(loaded, loaded.newModel("Simple")
@@ -1506,7 +1506,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void field_record_number() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  input_transformer = '" + EmptyLineFilter.class.getName() + "'",
                 ")",
                 "simple = {",
@@ -1515,7 +1515,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
                 "  b : LONG;",
                 "};",
         });
-        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleDelimitedTextFormat");
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleTabularTextFormat");
         assertThat(support.getMinimumFragmentSize(), is(-1L));
 
         byte[] contents = write(loaded, loaded.newModel("Simple")
@@ -1536,7 +1536,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void field_record_number_int() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  input_transformer = '" + EmptyLineFilter.class.getName() + "'",
                 ")",
                 "simple = {",
@@ -1545,7 +1545,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
                 "  b : INT;",
                 "};",
         });
-        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleDelimitedTextFormat");
+        BinaryStreamFormat<?> support = (BinaryStreamFormat<?>) loaded.newObject("text", "SimpleTabularTextFormat");
         assertThat(support.getMinimumFragmentSize(), is(-1L));
 
         byte[] contents = write(loaded, loaded.newModel("Simple")
@@ -1566,7 +1566,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void escape_conflict_key() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '^',",
                 "  escape_sequence = {",
                 "    'a' : 'A',",
@@ -1591,7 +1591,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void escape_conflict_value() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '^',",
                 "  escape_sequence = {",
                 "    'a' : 'A',",
@@ -1616,7 +1616,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void escape_conflict_null() throws Exception {
         ModelLoader loaded = generateJavaFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '^',",
                 "  escape_sequence = {",
                 "    'a' : null,",
@@ -1641,7 +1641,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_unknown_property() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  undef = true,",
                 ")",
                 "simple = {",
@@ -1657,7 +1657,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_charset_unknown() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  charset = '?',",
                 ")",
                 "simple = {",
@@ -1673,7 +1673,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_header_unknown() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  header = '?',",
                 ")",
                 "simple = {",
@@ -1689,7 +1689,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_compression_unknown() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  compression = '?',",
                 ")",
                 "simple = {",
@@ -1705,7 +1705,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_line_separator_unknown() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  line_separator = '\\n',",
                 ")",
                 "simple = {",
@@ -1721,7 +1721,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_field_separator_malformed() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  field_separator = '<>',",
                 ")",
                 "simple = {",
@@ -1737,7 +1737,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_field_separator_conflict() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  field_separator = '\\r',",
                 ")",
                 "simple = {",
@@ -1745,7 +1745,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
                 "};",
         });
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  field_separator = '\\n',",
                 ")",
                 "simple = {",
@@ -1761,7 +1761,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_escape_character_malformed() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '<>',",
                 ")",
                 "simple = {",
@@ -1777,7 +1777,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_escape_line_separator_malformed() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_line_separator = unknown,",
                 ")",
                 "simple = {",
@@ -1793,7 +1793,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_escape_character_conflict_line_separator() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '\\r',",
                 ")",
                 "simple = {",
@@ -1801,7 +1801,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
                 "};",
         });
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '\\n',",
                 ")",
                 "simple = {",
@@ -1817,7 +1817,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_escape_character_conflict_field_separator() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  field_separator = ':',",
                 "  escape_character = ':',",
                 ")",
@@ -1826,7 +1826,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
                 "};",
         });
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '\\t',",
                 ")",
                 "simple = {",
@@ -1842,7 +1842,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_escape_sequence_malformed() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '^',",
                 "  escape_sequence = { 'n', '\\n' },",
                 ")",
@@ -1859,7 +1859,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_escape_sequence_malformed_key() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '^',",
                 "  escape_sequence = {",
                 "    'malformed' : '\\n'",
@@ -1878,7 +1878,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_escape_sequence_malformed_value() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '^',",
                 "  escape_sequence = {",
                 "    'n' : '\\r\\n'",
@@ -1897,7 +1897,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_escape_sequence_conflict_line_separator() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '^',",
                 "  escape_sequence = {",
                 "    '\\n' : '\\n'",
@@ -1908,7 +1908,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
                 "};",
         });
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_character = '^',",
                 "  escape_sequence = {",
                 "    '\\r' : '\\r'",
@@ -1927,7 +1927,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_escape_sequence_without_escape_character() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_sequence = {",
                 "    'N' : null",
                 "  },",
@@ -1945,7 +1945,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_escape_line_separator_without_escape_character() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  escape_line_separator = true,",
                 ")",
                 "simple = {",
@@ -1961,7 +1961,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_null_format_malformed() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  null_format = {},",
                 ")",
                 "simple = {",
@@ -1977,7 +1977,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_true_format_malformed() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  true_format = {},",
                 ")",
                 "simple = {",
@@ -1993,7 +1993,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_true_format_conflict_null_format() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  null_format = 'NULL',",
                 "  true_format = 'NULL',",
                 ")",
@@ -2010,7 +2010,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_true_format_conflict_null_format_inherited() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  null_format = 'a',",
                 ")",
                 "simple = {",
@@ -2027,7 +2027,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_false_format_malformed() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  false_format = {},",
                 ")",
                 "simple = {",
@@ -2043,7 +2043,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_false_format_conflict_null_format() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  null_format = 'NULL',",
                 "  false_format = 'NULL',",
                 ")",
@@ -2060,7 +2060,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_false_format_conflict_true_format() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  true_format = '_',",
                 "  false_format = '_',",
                 ")",
@@ -2077,7 +2077,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_false_format_conflict_null_format_inherited() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  null_format = 'a',",
                 ")",
                 "simple = {",
@@ -2094,7 +2094,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_false_format_conflict_true_format_inherited() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  true_format = 'a',",
                 ")",
                 "simple = {",
@@ -2111,7 +2111,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_number_format_malformed() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  number_format = 'Hello, world!',",
                 ")",
                 "simple = {",
@@ -2127,7 +2127,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_date_format_malformed() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  date_format = 'Hello, world!',",
                 ")",
                 "simple = {",
@@ -2143,7 +2143,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_datetime_format_malformed() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  datetime_format = 'Hello, world!',",
                 ")",
                 "simple = {",
@@ -2159,7 +2159,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_timezone_malformed() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited(",
+                "@directio.text.tabular(",
                 "  timezone = 'Hello, world!',",
                 ")",
                 "simple = {",
@@ -2175,7 +2175,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_field_empty() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.ignore",
                 "  a : TEXT;",
@@ -2190,7 +2190,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_field_conflict() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field",
                 "  @directio.text.ignore",
@@ -2206,7 +2206,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_field_unknown() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.field(undef = '?')",
                 "  a : TEXT;",
@@ -2221,7 +2221,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_field_file_name_inconsistent_type() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.file_name",
                 "  a : INT;",
@@ -2237,7 +2237,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_field_line_number_inconsistent_type() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.line_number",
                 "  a : TEXT;",
@@ -2253,7 +2253,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     @Test
     public void invalid_field_record_number_inconsistent_type() throws Exception {
         shouldSemanticErrorFromLines(new String[] {
-                "@directio.text.delimited",
+                "@directio.text.tabular",
                 "simple = {",
                 "  @directio.text.record_number",
                 "  a : TEXT;",
@@ -2264,7 +2264,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
 
     private byte[] write(ModelLoader loaded, ModelWrapper... objects) {
         String name = objects[0].getModelClass().getSimpleName();
-        BinaryStreamFormat<Object> unsafe = unsafe(loaded.newObject("text", name + "DelimitedTextFormat"));
+        BinaryStreamFormat<Object> unsafe = unsafe(loaded.newObject("text", name + "TabularTextFormat"));
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         try (ModelOutput<Object> writer = unsafe.createOutput(unsafe.getSupportedType(), "testing", output)) {
             for (ModelWrapper object : objects) {
@@ -2278,7 +2278,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
 
     private void writeError(ModelLoader loaded, ModelWrapper object) {
         String name = object.getModelClass().getSimpleName();
-        BinaryStreamFormat<Object> unsafe = unsafe(loaded.newObject("text", name + "DelimitedTextFormat"));
+        BinaryStreamFormat<Object> unsafe = unsafe(loaded.newObject("text", name + "TabularTextFormat"));
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         try (ModelOutput<Object> writer = unsafe.createOutput(unsafe.getSupportedType(), "testing", output)) {
             writer.write(object.unwrap());
@@ -2291,7 +2291,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     }
 
     private void read(ModelLoader loaded, String contents, Consumer<ModelWrapper> tester) {
-        BinaryStreamFormat<Object> unsafe = unsafe(loaded.newObject("text", "SimpleDelimitedTextFormat"));
+        BinaryStreamFormat<Object> unsafe = unsafe(loaded.newObject("text", "SimpleTabularTextFormat"));
         ModelWrapper wrapper = loaded.newModel("Simple");
         Object buffer = wrapper.unwrap();
         try (ModelInput<Object> reader = unsafe.createInput(unsafe.getSupportedType(), "testing", in(contents))) {
@@ -2307,7 +2307,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     private void read(
             byte[] contents, ModelLoader loaded, ModelWrapper... objects) throws IOException, InterruptedException {
         String name = objects[0].getModelClass().getSimpleName();
-        BinaryStreamFormat<Object> unsafe = unsafe(loaded.newObject("text", name + "DelimitedTextFormat"));
+        BinaryStreamFormat<Object> unsafe = unsafe(loaded.newObject("text", name + "TabularTextFormat"));
         Object buffer = loaded.newModel(name).unwrap();
         try (ModelInput<Object> reader = unsafe.createInput(unsafe.getSupportedType(), "testing",
                 new ByteArrayInputStream(contents))) {
@@ -2320,7 +2320,7 @@ public class DelimitedTextEmitterTest extends GeneratorTesterRoot {
     }
 
     private void readError(ModelLoader loaded, String contents) {
-        BinaryStreamFormat<Object> unsafe = unsafe(loaded.newObject("text", "SimpleDelimitedTextFormat"));
+        BinaryStreamFormat<Object> unsafe = unsafe(loaded.newObject("text", "SimpleTabularTextFormat"));
         ModelWrapper wrapper = loaded.newModel("Simple");
         Object buffer = wrapper.unwrap();
         try (ModelInput<Object> reader = unsafe.createInput(unsafe.getSupportedType(), "testing", in(contents))) {


### PR DESCRIPTION
## Summary

This PR renames `@directio.text.{delimited=>tabular}`.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

This also changes generating class names:
* `<name>{Delimited=>Tabular}TextFormat`
* `Abstract<name>{Delimited=>Tabular}TextInputDescription`
* `Abstract<name>{Delimited=>Tabular}TextOutputDescription`

## Related Issue, Pull Request or Code

* #713 

## Wanted reviewer

@akirakw 