### PR TITLE
Remove deadcode in generated `CsvFormat` (v1).

### DIFF
--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/csv/driver/CsvFormatEmitter.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/csv/driver/CsvFormatEmitter.java
@@ -450,8 +450,7 @@ public class CsvFormatEmitter extends JavaDataModelDriver {
                                 isNotHead)
                         .toLocalVariableDeclaration(context.resolve(InputStream.class), fragmentInput));
             } else {
-                statements.add(new ExpressionBuilder(f, fragmentInput)
-                        .assignFrom(blessInputStream(stream))
+                statements.add(new ExpressionBuilder(f, blessInputStream(stream))
                         .toLocalVariableDeclaration(context.resolve(InputStream.class), fragmentInput));
             }
 

--- a/sandbox-project/asakusa-directio-dmdl-ext/src/main/java/com/asakusafw/dmdl/directio/tsv/driver/TsvFormatEmitter.java
+++ b/sandbox-project/asakusa-directio-dmdl-ext/src/main/java/com/asakusafw/dmdl/directio/tsv/driver/TsvFormatEmitter.java
@@ -337,8 +337,7 @@ public class TsvFormatEmitter extends JavaDataModelDriver {
                                 isNotHead)
                         .toLocalVariableDeclaration(context.resolve(InputStream.class), fragmentInput));
             } else {
-                statements.add(new ExpressionBuilder(f, fragmentInput)
-                        .assignFrom(blessInputStream(stream))
+                statements.add(new ExpressionBuilder(f, blessInputStream(stream))
                         .toLocalVariableDeclaration(context.resolve(InputStream.class), fragmentInput));
             }
 


### PR DESCRIPTION
## Summary

This PR removes dead-code in generated `~CsvFormat` (`@directio.csv`).

## Background, Problem or Goal of the patch

If input splitting is disabled, generated `~CsvFormat` contained
redundant assignment:

```java
InputStream fragmentInput = fragmentInput = ...;
```

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.