### PR TITLE
Make testing `asakusa-test-driver` more stable.

### DIFF
--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/DirectIoUtilTest.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/DirectIoUtilTest.java
@@ -62,6 +62,12 @@ public class DirectIoUtilTest {
     public static final WindowsSupport WINDOWS_SUPPORT = new WindowsSupport();
 
     /**
+     * Resets all Hadoop file systems.
+     */
+    @Rule
+    public final FileSystemCleaner fsCleaner = new FileSystemCleaner();
+
+    /**
      * temporary folder.
      */
     @Rule

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/FileSystemCleaner.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/FileSystemCleaner.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.testdriver;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.junit.rules.ExternalResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Closes all Hadoop file systems and resets their cache.
+ */
+public class FileSystemCleaner extends ExternalResource {
+
+    static final Logger LOG = LoggerFactory.getLogger(FileSystemCleaner.class);
+
+    @Override
+    protected void before() {
+        clean();
+    }
+
+    @Override
+    protected void after() {
+        clean();
+    }
+
+    private static void clean() {
+        try {
+            FileSystem.closeAll();
+        } catch (IOException e) {
+            LOG.warn("error occurred while cleaning up Hadoop file systems", e);
+        }
+    }
+}

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/FlowDriverInputTest.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/FlowDriverInputTest.java
@@ -23,6 +23,7 @@ import java.net.URI;
 
 import org.apache.hadoop.io.Text;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.asakusafw.runtime.windows.WindowsSupport;
@@ -41,6 +42,12 @@ public class FlowDriverInputTest {
      */
     @ClassRule
     public static final WindowsSupport WINDOWS_SUPPORT = new WindowsSupport();
+
+    /**
+     * Resets all Hadoop file systems.
+     */
+    @Rule
+    public final FileSystemCleaner fsCleaner = new FileSystemCleaner();
 
     /**
      * simple test for {@link FlowDriverInput#prepare(java.lang.String)}.

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/FlowDriverOutputTest.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/FlowDriverOutputTest.java
@@ -75,6 +75,12 @@ public class FlowDriverOutputTest {
     public static final WindowsSupport WINDOWS_SUPPORT = new WindowsSupport();
 
     /**
+     * Resets all Hadoop file systems.
+     */
+    @Rule
+    public final FileSystemCleaner fsCleaner = new FileSystemCleaner();
+
+    /**
      * A temporary folder.
      */
     @Rule

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/OperatorTestEnvironmentTest.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/OperatorTestEnvironmentTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.Assume;
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.asakusafw.runtime.core.BatchContext;
@@ -40,6 +41,12 @@ import com.asakusafw.testdriver.testing.model.Simple;
  * Test for {@link OperatorTestEnvironment}.
  */
 public class OperatorTestEnvironmentTest {
+
+    /**
+     * Resets all Hadoop file systems.
+     */
+    @Rule
+    public final FileSystemCleaner fsCleaner = new FileSystemCleaner();
 
     /**
      * test for loading configuration file.

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/TesterTestRoot.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/TesterTestRoot.java
@@ -56,6 +56,12 @@ public abstract class TesterTestRoot {
     protected final MockCompilerToolkit compiler = new MockCompilerToolkit();
 
     /**
+     * Resets all Hadoop file systems.
+     */
+    @Rule
+    public final FileSystemCleaner fsCleaner = new FileSystemCleaner();
+
+    /**
      * Temporary framework installation target.
      */
     @Rule

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/loader/BasicDataLoaderTest.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/loader/BasicDataLoaderTest.java
@@ -22,6 +22,7 @@ import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.List;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 import com.asakusafw.runtime.core.GroupView;
@@ -29,6 +30,7 @@ import com.asakusafw.runtime.core.View;
 import com.asakusafw.runtime.value.DecimalOption;
 import com.asakusafw.runtime.value.IntOption;
 import com.asakusafw.runtime.value.StringOption;
+import com.asakusafw.testdriver.FileSystemCleaner;
 import com.asakusafw.testdriver.core.DataModelDefinition;
 import com.asakusafw.testdriver.core.DataModelReflection;
 import com.asakusafw.testdriver.core.DataModelSource;
@@ -42,6 +44,12 @@ import com.asakusafw.testdriver.model.DefaultDataModelDefinition;
 public class BasicDataLoaderTest {
 
     static final DataModelDefinition<MockDataModel> DEF = new DefaultDataModelDefinition<>(MockDataModel.class);
+
+    /**
+     * Resets all Hadoop file systems.
+     */
+    @Rule
+    public final FileSystemCleaner fsCleaner = new FileSystemCleaner();
 
     /**
      * simple case.

--- a/testing-project/asakusa-test-moderator/src/main/java/com/asakusafw/testdriver/hadoop/ConfigurationFactory.java
+++ b/testing-project/asakusa-test-moderator/src/main/java/com/asakusafw/testdriver/hadoop/ConfigurationFactory.java
@@ -121,7 +121,7 @@ public class ConfigurationFactory extends ConfigurationProvider {
     protected void configure(Configuration configuration) {
         if (preferences.getLocalFileSystemClassName() != null) {
             configuration.set("fs.file.impl", preferences.getLocalFileSystemClassName()); //$NON-NLS-1$
-            configuration.setBoolean("fs.fs.impl.disable.cache", true); //$NON-NLS-1$
+            configuration.setBoolean("fs.file.impl.disable.cache", true); //$NON-NLS-1$
         }
     }
 


### PR DESCRIPTION
## Summary

This PR makes testing `asakusa-test-driver` project more stable.

## Background, Problem or Goal of the patch

`asakusa-test-driver` project replaces the Hadoop local file system implementation with `AsakusaTestLocalFileSystem` instead of `LocalFileSystem` in almost of its test cases, but several test cases introduced in `0.9.1` still use `LocalFileSystem`. If test cases with using `LocalFileSystem` run before other tests, Hadoop keeps a `LocalFileSystem` object as cache for the default local file system. And it may leak into other test cases which requires `AsakusaTestLocalFileSystem`. 

## Design of the fix, or a new feature

We introduced `FileSystemCleaner` class that removes all Hadoop file system caches, and apply it before/after running each test case.

## Related Issue, Pull Request or Code

N/A.