### PR TITLE
Fix WindGate inprocess testing to pass a valid Hadoop conf.

### DIFF
--- a/windgate-project/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/ProfileContext.java
+++ b/windgate-project/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/ProfileContext.java
@@ -15,15 +15,23 @@
  */
 package com.asakusafw.windgate.core;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
 /**
  * The profile context.
  * @since 0.2.4
+ * @version 0.9.1
  */
 public class ProfileContext {
 
     private final ClassLoader classLoader;
 
     private final ParameterList contextParameters;
+
+    private final Map<Class<?>, Object> resources;
 
     /**
      * Creates a new instance.
@@ -40,6 +48,13 @@ public class ProfileContext {
         }
         this.classLoader = classLoader;
         this.contextParameters = contextParameters;
+        this.resources = Collections.emptyMap();
+    }
+
+    private ProfileContext(ClassLoader classLoader, ParameterList contextParameters, Map<Class<?>, Object> resources) {
+        this.classLoader = classLoader;
+        this.contextParameters = contextParameters;
+        this.resources = resources;
     }
 
     /**
@@ -50,6 +65,20 @@ public class ProfileContext {
      */
     public static ProfileContext system(ClassLoader classLoader) {
         return new ProfileContext(classLoader, new ParameterList(System.getenv()));
+    }
+
+    /**
+     * Creates a new context with the additional resource.
+     * @param <T> the resource type
+     * @param type the resource type
+     * @param object the resource
+     * @return the created context
+     * @since 0.9.1
+     */
+    public <T> ProfileContext withResource(Class<T> type, T object) {
+        Map<Class<?>, Object> copy = new LinkedHashMap<>(resources);
+        copy.put(type, object);
+        return new ProfileContext(classLoader, contextParameters, copy);
     }
 
     /**
@@ -66,5 +95,16 @@ public class ProfileContext {
      */
     public ParameterList getContextParameters() {
         return contextParameters;
+    }
+
+    /**
+     * Returns an optional resource.
+     * @param <T> the resource type
+     * @param type the resource type
+     * @return the related resource
+     * @since 0.9.1
+     */
+    public <T> Optional<T> findResource(Class<T> type) {
+        return Optional.ofNullable(type.cast(resources.get(type)));
     }
 }

--- a/windgate-project/asakusa-windgate-hadoopfs/src/main/java/com/asakusafw/windgate/hadoopfs/HadoopFsProvider.java
+++ b/windgate-project/asakusa-windgate-hadoopfs/src/main/java/com/asakusafw/windgate/hadoopfs/HadoopFsProvider.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.asakusafw.windgate.core.ParameterList;
+import com.asakusafw.windgate.core.ProfileContext;
 import com.asakusafw.windgate.core.resource.ResourceMirror;
 import com.asakusafw.windgate.core.resource.ResourceProfile;
 import com.asakusafw.windgate.core.resource.ResourceProvider;
@@ -30,6 +31,7 @@ import com.asakusafw.windgate.core.resource.ResourceProvider;
 /**
  * Provides {@link HadoopFsMirror}.
  * @since 0.2.2
+ * @version 0.9.1
  */
 public class HadoopFsProvider extends ResourceProvider {
 
@@ -43,7 +45,7 @@ public class HadoopFsProvider extends ResourceProvider {
     protected void configure(ResourceProfile profile) throws IOException {
         LOG.debug("Configuring Hadoop FS resource \"{}\"",
                 profile.getName());
-        this.configuration = new Configuration();
+        this.configuration = getConfiguration(profile.getContext());
         try {
             this.hfsProfile = HadoopFsProfile.convert(configuration, profile);
         } catch (IllegalArgumentException e) {
@@ -65,5 +67,16 @@ public class HadoopFsProvider extends ResourceProvider {
                 hfsProfile.getResourceName(),
                 sessionId);
         return new HadoopFsMirror(configuration, hfsProfile, arguments);
+    }
+
+    /**
+     * Returns the Hadoop configuration for the current context.
+     * @param context the current context
+     * @return the Hadoop configuration
+     * @since 0.9.1
+     */
+    public static Configuration getConfiguration(ProfileContext context) {
+        return context.findResource(Configuration.class)
+                .orElseGet(Configuration::new);
     }
 }

--- a/windgate-project/asakusa-windgate-hadoopfs/src/main/java/com/asakusafw/windgate/hadoopfs/jsch/JschHadoopFsProvider.java
+++ b/windgate-project/asakusa-windgate-hadoopfs/src/main/java/com/asakusafw/windgate/hadoopfs/jsch/JschHadoopFsProvider.java
@@ -26,6 +26,7 @@ import com.asakusafw.windgate.core.ParameterList;
 import com.asakusafw.windgate.core.resource.ResourceMirror;
 import com.asakusafw.windgate.core.resource.ResourceProfile;
 import com.asakusafw.windgate.core.resource.ResourceProvider;
+import com.asakusafw.windgate.hadoopfs.HadoopFsProvider;
 import com.asakusafw.windgate.hadoopfs.ssh.SshProfile;
 
 /**
@@ -44,7 +45,7 @@ public class JschHadoopFsProvider extends ResourceProvider {
     protected void configure(ResourceProfile profile) throws IOException {
         LOG.debug("Configuring Hadoop FS via JSch resource \"{}\"",
                 profile.getName());
-        this.configuration = new Configuration();
+        this.configuration = HadoopFsProvider.getConfiguration(profile.getContext());
         try {
             this.sshProfile = SshProfile.convert(configuration, profile);
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
## Summary

This PR fixes WindGate in-process testing to pass a valid Hadoop configuration object.

## Background, Problem or Goal of the patch

Disabling the Hadoop local file system cache in #725 makes in-process test execution more strict, and WindGate `hadoop.*` resources had used an incorrect configuration object.

## Design of the fix, or a new feature

We enhanced WindGate in-process boot strap (`AbstractWindGateCommandEmulator`) to pass a well configured Hadoop configuration object into `hadoop.*` resources.

## Related Issue, Pull Request or Code

* #725 