### PR TITLE
Revise debug logs of `TemporaryStorage`.

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/stage/temporary/TemporaryStorage.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/stage/temporary/TemporaryStorage.java
@@ -100,9 +100,8 @@ public final class TemporaryStorage {
         FileSystem fs = pathPattern.getFileSystem(conf);
         if (LOG.isDebugEnabled()) {
             LOG.debug(MessageFormat.format(
-                    "Listing temporary input: {0} (fs={1})", //$NON-NLS-1$
-                    pathPattern,
-                    fs.getUri()));
+                    "listing temporary inputs: {0}", //$NON-NLS-1$
+                    fs.makeQualified(pathPattern)));
         }
         FileStatus[] statusList = fs.globStatus(pathPattern);
         if (statusList == null || statusList.length == 0) {
@@ -138,9 +137,8 @@ public final class TemporaryStorage {
         FileSystem fs = path.getFileSystem(conf);
         if (LOG.isDebugEnabled()) {
             LOG.debug(MessageFormat.format(
-                    "Opening temporary input: {0} (fs={1})", //$NON-NLS-1$
-                    path,
-                    fs.getUri()));
+                    "opening temporary input: {0}", //$NON-NLS-1$
+                    fs.makeQualified(path)));
         }
         if (Writable.class.isAssignableFrom(dataType)) {
             return (ModelInput<V>) new TemporaryFileInput<>(fs.open(path), 0);
@@ -212,9 +210,8 @@ public final class TemporaryStorage {
         FileSystem fs = path.getFileSystem(conf);
         if (LOG.isDebugEnabled()) {
             LOG.debug(MessageFormat.format(
-                    "Opening temporary output: {0} (fs={1})", //$NON-NLS-1$
-                    path,
-                    fs.getUri()));
+                    "opening temporary output: {0}", //$NON-NLS-1$
+                    fs.makeQualified(path)));
         }
         if (Writable.class.isAssignableFrom(dataType)) {
             return (ModelOutput<V>) new TemporaryFileOutput<>(
@@ -259,9 +256,8 @@ public final class TemporaryStorage {
         FileSystem fs = path.getFileSystem(conf);
         if (LOG.isDebugEnabled()) {
             LOG.debug(MessageFormat.format(
-                    "Opening temporary output: {0} (fs={1})", //$NON-NLS-1$
-                    path,
-                    fs.getUri()));
+                    "opening temporary output: {0}", //$NON-NLS-1$
+                    fs.makeQualified(path)));
         }
         if (Writable.class.isAssignableFrom(dataType)) {
             return (ModelOutput<V>) new TemporaryFileOutput<>(


### PR DESCRIPTION
## Summary

This PR revises debug log in `TemporaryStorage` class for printing actual data path of their inputs and outputs.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

Here is an example of logback configuration for enabling this logs.
```xml
<configuration>
  ...
  <logger name="com.asakusafw.runtime.stage.temporary.TemporaryStorage" level="DEBUG" />
  ...
</configuration>
```

## Related Issue, Pull Request or Code

* #727 