### PR TITLE
Suppress class resolution on searching for batch classes.

### DIFF
--- a/mapreduce/compiler/cli/src/main/java/com/asakusafw/compiler/bootstrap/AllBatchCompilerDriver.java
+++ b/mapreduce/compiler/cli/src/main/java/com/asakusafw/compiler/bootstrap/AllBatchCompilerDriver.java
@@ -308,7 +308,7 @@ public final class AllBatchCompilerDriver {
 
     private static Class<? extends BatchDescription> loadIfBatchClass(String className) {
         try {
-            Class<?> aClass = Class.forName(className);
+            Class<?> aClass = Class.forName(className, false, AllBatchCompilerDriver.class.getClassLoader());
             if (BatchDescription.class.isAssignableFrom(aClass) == false) {
                 return null;
             }


### PR DESCRIPTION
## Summary

This PR suppresses class resolutions when MapReduce compiler searches for source classes.

## Background, Problem or Goal of the patch

In the latest implementation, MapReduce compiler always resolves the compilation target classes.

## Design of the fix, or a new feature

We use `Class.forName(name, false, classLoader)` instead of `Class.forName(name)`.

## Related Issue, Pull Request or Code

N/A.