### PR TITLE
Add `Option.ORACLE_PARTITION` to `JdbcImporterDescription`.

### DIFF
--- a/windgate-project/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/vocabulary/JdbcProcess.java
+++ b/windgate-project/asakusa-windgate-core/src/main/java/com/asakusafw/windgate/core/vocabulary/JdbcProcess.java
@@ -109,6 +109,7 @@ public enum JdbcProcess implements ConfigurationItem {
     /**
      * The source/drain option kinds.
      * @since 0.9.0
+     * @version 0.9.2
      */
     public static final class OptionSymbols {
 
@@ -121,6 +122,12 @@ public enum JdbcProcess implements ConfigurationItem {
          * The JDBC export option symbol of enabling Oracle direct path insert features.
          */
         public static final String ORACLE_DIRPATH = "ORACLE_DIRPATH"; //$NON-NLS-1$
+
+        /**
+         * The JDBC import option symbol of enabling Oracle partitions.
+         * @since 0.9.2
+         */
+        public static final String ORACLE_PARTITION = "ORACLE_PARTITION"; //$NON-NLS-1$
 
         private OptionSymbols() {
             return;

--- a/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/JdbcImporterDescription.java
+++ b/windgate-project/asakusa-windgate-vocabulary/src/main/java/com/asakusafw/vocabulary/windgate/JdbcImporterDescription.java
@@ -113,8 +113,15 @@ public abstract class JdbcImporterDescription extends WindGateImporterDescriptio
      * JDBC import options.
      * @see JdbcImporterDescription#getOptions()
      * @since 0.9.0
+     * @version 0.9.2
      */
     public enum Option implements JdbcAttribute {
+
+        /**
+         * Enable partitioned tables on Oracle.
+         * @since 0.9.2
+         */
+        ORACLE_PARTITION(JdbcProcess.OptionSymbols.ORACLE_PARTITION),
         ;
 
         private final String symbol;


### PR DESCRIPTION
## Summary

This PR introduces a new WindGate JDBC optimization option `Option.ORACLE_PARTITION` to `JdbcImporterDescription`.

## Background, Problem or Goal of the patch

see asakusafw/asakusafw-compiler#128

## Design of the fix, or a new feature

This option is currently available only in WindGate JDBC *direct mode*. 

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-compiler#128