### PR TITLE
Fix code style for Eclipse 4.7.

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/hadoop/HadoopDataSourceUtil.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/hadoop/HadoopDataSourceUtil.java
@@ -1022,7 +1022,7 @@ public final class HadoopDataSourceUtil {
             ExecutorService executor,
             Collection<? extends Callable<?>> tasks) throws IOException, InterruptedException {
         List<Future<?>> futures = tasks.stream()
-                .map(task -> executor.submit(task))
+                .map((Callable<?> task) -> executor.submit(task))
                 .collect(Collectors.toList());
         for (Future<?> future : futures) {
             try {

--- a/testing-project/asakusa-test-data-provider/src/test/java/com/asakusafw/testdriver/excel/ExcelSheetSinkTest.java
+++ b/testing-project/asakusa-test-data-provider/src/test/java/com/asakusafw/testdriver/excel/ExcelSheetSinkTest.java
@@ -307,7 +307,7 @@ public class ExcelSheetSinkTest {
                 if (next == null) {
                     break;
                 }
-                assertThat(next.toString(), results.contains(source), is(false));
+                assertThat(next.toString(), results, not(contains(next)));
                 results.add(next);
             }
         } finally {


### PR DESCRIPTION
## Summary

This PR fixes code style for Eclipse 4.7.

## Background, Problem or Goal of the patch

Java compiler in Eclipse 4.7 has been changed from 4.6. It becomes to raise some new warnings/errors.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.