### PR TITLE
Enable new operator DSL compiler implementation in default.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
@@ -68,11 +68,7 @@ class EclipsePluginEnhancement {
             AsakusafwPluginConvention sdk =  project.asakusafw
             if (sdk.sdk.operator) {
                 project.dependencies {
-                    if (sdk.sdk.incubating) {
-                        eclipseAnnotationProcessor "com.asakusafw.operator:asakusa-operator-all:${base.frameworkVersion}:lib@jar"
-                    } else {
-                        eclipseAnnotationProcessor "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-operator:${base.frameworkVersion}:lib@jar"
-                    }
+                    eclipseAnnotationProcessor "com.asakusafw.operator:asakusa-operator-all:${base.frameworkVersion}:lib@jar"
                 }
             }
         }

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
@@ -214,11 +214,7 @@ class AsakusaSdkPlugin implements Plugin<Project> {
                     }
 
                     if (features.operator) {
-                        if (features.incubating) {
-                            compile "com.asakusafw.operator:asakusa-operator-all:${base.frameworkVersion}"
-                        } else {
-                            compile "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-operator:${base.frameworkVersion}"
-                        }
+                        compile "com.asakusafw.operator:asakusa-operator-all:${base.frameworkVersion}"
                     }
                     if (features.directio) {
                         compile "com.asakusafw:asakusa-directio-vocabulary:${base.frameworkVersion}"


### PR DESCRIPTION
## Summary

This PR promotes the new operator DSL compiler implementation.

## Background, Problem or Goal of the patch

The new operator DSL compiler has been introduced since `0.9.0`, and it requires `asakusafw.sdk.incubating true`. This PR enables the feature even if `incubating false`.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #663
