### PR TITLE
Fix test case for Windows.

### DIFF
--- a/workflow/hadoop/src/test/java/com/asakusafw/workflow/cli/hadoop/BridgeDeleteTaskExecutorTest.java
+++ b/workflow/hadoop/src/test/java/com/asakusafw/workflow/cli/hadoop/BridgeDeleteTaskExecutorTest.java
@@ -15,6 +15,7 @@
  */
 package com.asakusafw.workflow.cli.hadoop;
 
+import static com.asakusafw.workflow.cli.hadoop.BridgeHadoopTaskExecutorTest.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -68,7 +69,7 @@ public class BridgeDeleteTaskExecutorTest {
         TaskInfo task = new BasicDeleteTaskInfo(PathKind.HADOOP_FILE_SYSTEM, "testing");
         TaskExecutor executor = new BridgeDeleteTaskExecutor(ctxt -> (command, arguments) -> {
             assertThat(command.toRealPath(), is(HOME_DIR.resolve(Constants.PATH_BRIDGE_SCRIPT).toRealPath()));
-            assertThat(arguments.get(0), endsWith(Constants.PATH_BRIDGE_LIBRARY));
+            assertThat(Paths.get(arguments.get(0)), pathEndsWith(Constants.PATH_BRIDGE_LIBRARY));
             assertThat(arguments.get(1), is(BridgeDeleteTaskExecutor.DELEGATE_CLASS));
             assertThat(arguments.get(2), is("testing"));
             return 0;
@@ -86,7 +87,7 @@ public class BridgeDeleteTaskExecutorTest {
         TaskInfo task = new BasicDeleteTaskInfo(PathKind.HADOOP_FILE_SYSTEM, "${execution_id}");
         TaskExecutor executor = new BridgeDeleteTaskExecutor(ctxt -> (command, arguments) -> {
             assertThat(command.toRealPath(), is(HOME_DIR.resolve(Constants.PATH_BRIDGE_SCRIPT).toRealPath()));
-            assertThat(arguments.get(0), endsWith(Constants.PATH_BRIDGE_LIBRARY));
+            assertThat(Paths.get(arguments.get(0)), pathEndsWith(Constants.PATH_BRIDGE_LIBRARY));
             assertThat(arguments.get(1), is(BridgeDeleteTaskExecutor.DELEGATE_CLASS));
             assertThat(arguments.get(2), is(context.getExecutionId()));
             return 0;

--- a/workflow/hadoop/src/test/java/com/asakusafw/workflow/cli/hadoop/BridgeHadoopTaskExecutorTest.java
+++ b/workflow/hadoop/src/test/java/com/asakusafw/workflow/cli/hadoop/BridgeHadoopTaskExecutorTest.java
@@ -22,6 +22,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -67,12 +70,25 @@ public class BridgeHadoopTaskExecutorTest {
         TaskInfo task = new BasicHadoopTaskInfo("testing", "TEST_CLASS");
         TaskExecutor executor = new BridgeHadoopTaskExecutor(ctxt -> (command, arguments) -> {
             assertThat(command.toRealPath(), is(HOME_DIR.resolve(Constants.PATH_BRIDGE_SCRIPT).toRealPath()));
-            assertThat(arguments.get(0), endsWith(Constants.PATH_LAUNCHER_LIBRARY));
-            assertThat(arguments.get(1), endsWith(BridgeHadoopTaskExecutor.LAUNCHER_CLASS));
+            assertThat(Paths.get(arguments.get(0)), pathEndsWith(Constants.PATH_LAUNCHER_LIBRARY));
+            assertThat(arguments.get(1), is(BridgeHadoopTaskExecutor.LAUNCHER_CLASS));
             assertThat(arguments.get(2), is("TEST_CLASS"));
             return 0;
         });
         assertThat(executor.isSupported(context, task), is(true));
         executor.execute(context, task);
+    }
+
+    static Matcher<Path> pathEndsWith(String suffix) {
+        return new BaseMatcher<Path>() {
+            @Override
+            public boolean matches(Object item) {
+                return ((Path) item).endsWith(suffix);
+            }
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("ends with ").appendValue(suffix);
+            }
+        };
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes test cases for Windows.

## Background, Problem or Goal of the patch

#746 and #747 includes several test cases which do not work correct on Windows related to difference of path name separator character (`/` or `\`).

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #746 
* #747 
