### PR TITLE
Add `bin/asakusa.cmd` for Windows.

### DIFF
--- a/operation-project/command-portal/src/main/dist/bin/asakusa
+++ b/operation-project/command-portal/src/main/dist/bin/asakusa
@@ -25,7 +25,7 @@ _CLASSPATH+=("$_ROOT/lib/slf4j-simple.jar")
 
 exec "$_JAVA_CMD" $JAVA_OPTS \
     -classpath "$(IFS=:; echo "${_CLASSPATH[*]}")" \
-    -Dcli.name="asakusafw.sh" \
+    -Dcli.name="asakusa" \
     -Dorg.slf4j.simpleLogger.showThreadName=false \
     -Dorg.slf4j.simpleLogger.showLogName=false \
     -Dorg.slf4j.simpleLogger.levelInBrackets=true \

--- a/operation-project/command-portal/src/main/dist/bin/asakusa.cmd
+++ b/operation-project/command-portal/src/main/dist/bin/asakusa.cmd
@@ -1,0 +1,34 @@
+@REM
+@REM Copyright 2011-2017 Asakusa Framework Team.
+@REM
+@REM Licensed under the Apache License, Version 2.0 (the "License");
+@REM you may not use this file except in compliance with the License.
+@REM You may obtain a copy of the License at
+@REM
+@REM     http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing, software
+@REM distributed under the License is distributed on an "AS IS" BASIS,
+@REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@REM See the License for the specific language governing permissions and
+@REM limitations under the License.
+@REM
+
+@echo off
+setlocal
+
+if not defined ASAKUSA_HOME (
+    echo environment variable %%ASAKUSA_HOME%% must be defined
+    exit /b 1
+)
+
+set libdir=%ASAKUSA_HOME%\tools\lib
+set java_classpath=%libdir%\asakusa-command-portal.jar;%libdir%\slf4j-simple.jar
+set main_class=com.asakusafw.operation.tools.portal.AsakusaPortal
+
+set java_props=-Dcli.name=asakusa
+set java_props=%java_props% -Dorg.slf4j.simpleLogger.showThreadName=false
+set java_props=%java_props% -Dorg.slf4j.simpleLogger.showLogName=false
+set java_props=%java_props% -Dorg.slf4j.simpleLogger.levelInBrackets=true
+
+java %JAVA_OPTS% -classpath %java_classpath% %java_props% %main_class% %*

--- a/pom.xml
+++ b/pom.xml
@@ -460,6 +460,7 @@ encoding/<project>=UTF-8
               <include>src/**/*.flex</include>
               <include>src/**/*.jj</include>
               <include>src/**/*.sh</include>
+              <include>src/**/*.cmd</include>
             </includes>
             <encoding>UTF-8</encoding>
             <mapping>


### PR DESCRIPTION
## Summary

This PR introduces `bin/asakusa.cmd` which is portal command entry for Windows platform.

## Background, Problem or Goal of the patch

The portal command introduced in #747 and #750 is only for Unix like environment because its entry is a bash script. We now introduce `asakusa.cmd` which is written as Windows batch file. Note that, `asakusa run` does not work correct, but other commands like `list` will be work.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #747 
* #750 