### PR TITLE
Bump Gradle tooling API version to 4.1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <gson.version>2.7</gson.version>
     <jackson.version>2.8.3</jackson.version>
     <jcommander.version>1.72</jcommander.version>
-    <gradle.version>4.0.1</gradle.version>
+    <gradle.version>4.1</gradle.version>
     <javacc.version>7.0.2</javacc.version>
     <checkstyle.version>6.17</checkstyle.version>
 


### PR DESCRIPTION
## Summary

This PR bumps the Gradle tooling API version to 4.1, used in each integration test.

## Background, Problem or Goal of the patch

#753 did not change the Gradle tooling API version.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #753