### PR TITLE
Fix integration test for Windows.

### DIFF
--- a/integration/src/integration-test/java/com/asakusafw/integration/core/DirectIoToolsTest.java
+++ b/integration/src/integration-test/java/com/asakusafw/integration/core/DirectIoToolsTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.*;
 
 import java.util.Optional;
 
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,6 +31,7 @@ import org.junit.runners.Parameterized.Parameters;
 import com.asakusafw.integration.AsakusaConfigurator;
 import com.asakusafw.integration.AsakusaProject;
 import com.asakusafw.integration.AsakusaProjectProvider;
+import com.asakusafw.integration.PlatformUtil;
 import com.asakusafw.utils.gradle.Bundle;
 import com.asakusafw.utils.gradle.ContentsConfigurator;
 
@@ -50,6 +52,14 @@ public class DirectIoToolsTest {
             { false },
             { true },
         };
+    }
+
+    /**
+     * Skip this test class for Windows platform.
+     */
+    @BeforeClass
+    public static void checkCkass() {
+        PlatformUtil.skipIfWindows();
     }
 
     /**

--- a/integration/src/integration-test/java/com/asakusafw/integration/core/OperationToolsTest.java
+++ b/integration/src/integration-test/java/com/asakusafw/integration/core/OperationToolsTest.java
@@ -31,6 +31,7 @@ import com.asakusafw.integration.AsakusaConfigurator;
 import com.asakusafw.integration.AsakusaConstants;
 import com.asakusafw.integration.AsakusaProject;
 import com.asakusafw.integration.AsakusaProjectProvider;
+import com.asakusafw.integration.PlatformUtil;
 import com.asakusafw.utils.gradle.Bundle;
 import com.asakusafw.utils.gradle.ContentsConfigurator;
 
@@ -136,6 +137,7 @@ public class OperationToolsTest {
      */
     @Test
     public void hadoop_fs_clean_help() {
+        PlatformUtil.skipIfWindows();
         AsakusaProject project = provider.newInstance("tls");
         project.gradle("installAsakusafw");
 
@@ -151,6 +153,7 @@ public class OperationToolsTest {
      */
     @Test
     public void hadoop_fs_clean_delete() {
+        PlatformUtil.skipIfWindows();
         AsakusaProject project = provider.newInstance("tls");
         project.gradle("installAsakusafw");
 
@@ -172,6 +175,7 @@ public class OperationToolsTest {
      */
     @Test
     public void hadoop_fs_clean_dryrun() {
+        PlatformUtil.skipIfWindows();
         AsakusaProject project = provider.newInstance("tls");
         project.gradle("installAsakusafw");
 
@@ -194,6 +198,7 @@ public class OperationToolsTest {
      */
     @Test
     public void hadoop_fs_clean_skip_dir() {
+        PlatformUtil.skipIfWindows();
         AsakusaProject project = provider.newInstance("tls");
         project.gradle("installAsakusafw");
 
@@ -215,6 +220,7 @@ public class OperationToolsTest {
      */
     @Test
     public void hadoop_fs_clean_recursive() {
+        PlatformUtil.skipIfWindows();
         AsakusaProject project = provider.newInstance("tls");
         project.gradle("installAsakusafw");
 

--- a/integration/src/integration-test/java/com/asakusafw/integration/core/WindGateTest.java
+++ b/integration/src/integration-test/java/com/asakusafw/integration/core/WindGateTest.java
@@ -100,11 +100,11 @@ public class WindGateTest {
                         PROCESS_CMD,
                         "copy",
                         "oneshot",
-                        framework.get("windgate/script/copy.properties").toAbsolutePath().toString(),
+                        framework.get("windgate/script/copy.properties").toUri().toString(),
                         "app",
                         "flow",
                         "testing",
-                        ""),
+                        ","),
                 is(0));
         assertThat(
                 framework.launch(
@@ -134,11 +134,11 @@ public class WindGateTest {
                         PROCESS_CMD,
                         "copy",
                         "begin",
-                        framework.get("windgate/script/copy.properties").toAbsolutePath().toString(),
+                        framework.get("windgate/script/copy.properties").toUri().toString(),
                         "app",
                         "flow",
                         "testing",
-                        ""),
+                        ","),
                 is(0));
         assertThat(contents.find("output.csv"), is(not(Optional.empty())));
         contents.get("output.csv", Files::delete);
@@ -148,11 +148,11 @@ public class WindGateTest {
                         PROCESS_CMD,
                         "copy",
                         "end",
-                        framework.get("windgate/script/copy.properties").toAbsolutePath().toString(),
+                        framework.get("windgate/script/copy.properties").toUri().toString(),
                         "app",
                         "flow",
                         "testing",
-                        ""),
+                        ","),
                 is(0));
         assertThat(contents.find("output.csv"), is(not(Optional.empty())));
         contents.get("output.csv", Files::delete);
@@ -182,11 +182,11 @@ public class WindGateTest {
                         PROCESS_CMD,
                         "copy",
                         "begin",
-                        framework.get("windgate/script/copy.properties").toAbsolutePath().toString(),
+                        framework.get("windgate/script/copy.properties").toUri().toString(),
                         "app",
                         "flow",
                         "testing",
-                        ""),
+                        ","),
                 is(0));
         assertThat(contents.find("output.csv"), is(not(Optional.empty())));
         contents.get("output.csv", Files::delete);
@@ -205,11 +205,11 @@ public class WindGateTest {
                         PROCESS_CMD,
                         "copy",
                         "end",
-                        framework.get("windgate/script/copy.properties").toAbsolutePath().toString(),
+                        framework.get("windgate/script/copy.properties").toUri().toString(),
                         "app",
                         "flow",
                         "testing",
-                        ""),
+                        ","),
                 is(not(0)));
         assertThat(contents.find("output.csv"), is(Optional.empty()));
 
@@ -237,11 +237,11 @@ public class WindGateTest {
                         PROCESS_CMD,
                         "copy",
                         "begin",
-                        framework.get("windgate/script/copy.properties").toAbsolutePath().toString(),
+                        framework.get("windgate/script/copy.properties").toUri().toString(),
                         "app",
                         "flow",
                         "testing",
-                        ""),
+                        ","),
                 is(0));
 
         assertThat(
@@ -249,11 +249,11 @@ public class WindGateTest {
                         PROCESS_CMD,
                         "copy",
                         "begin",
-                        framework.get("windgate/script/copy.properties").toAbsolutePath().toString(),
+                        framework.get("windgate/script/copy.properties").toUri().toString(),
                         "app",
                         "flow",
                         "testing",
-                        ""),
+                        ","),
                 is(not(0)));
 
         assertThat(
@@ -281,11 +281,11 @@ public class WindGateTest {
                         PROCESS_CMD,
                         "copy",
                         "begin",
-                        framework.get("windgate/script/copy.properties").toAbsolutePath().toString(),
+                        framework.get("windgate/script/copy.properties").toUri().toString(),
                         "app",
                         "flow",
                         "testing-1",
-                        ""),
+                        ","),
                 is(0));
         assertThat(contents.find("output.csv"), is(not(Optional.empty())));
         contents.get("output.csv", Files::delete);
@@ -295,11 +295,11 @@ public class WindGateTest {
                         PROCESS_CMD,
                         "copy",
                         "begin",
-                        framework.get("windgate/script/copy.properties").toAbsolutePath().toString(),
+                        framework.get("windgate/script/copy.properties").toUri().toString(),
                         "app",
                         "flow",
                         "testing-2",
-                        ""),
+                        ","),
                 is(0));
         assertThat(contents.find("output.csv"), is(not(Optional.empty())));
         contents.get("output.csv", Files::delete);
@@ -332,11 +332,11 @@ public class WindGateTest {
                         PROCESS_CMD,
                         "copy-remote",
                         "begin",
-                        framework.get("windgate/script/remote-put.properties").toAbsolutePath().toString(),
+                        framework.get("windgate/script/remote-put.properties").toUri().toString(),
                         "app",
                         "flow",
                         "testing",
-                        ""),
+                        ","),
                 is(0));
         assertThat(contents.find("tmp.bin"), is(not(Optional.empty())));
         assertThat(
@@ -344,11 +344,11 @@ public class WindGateTest {
                         PROCESS_CMD,
                         "copy-remote",
                         "end",
-                        framework.get("windgate/script/remote-get.properties").toAbsolutePath().toString(),
+                        framework.get("windgate/script/remote-get.properties").toUri().toString(),
                         "app",
                         "flow",
                         "testing",
-                        ""),
+                        ","),
                 is(0));
         assertThat(
                 framework.launch(

--- a/integration/src/integration-test/java/com/asakusafw/integration/core/YaessTest.java
+++ b/integration/src/integration-test/java/com/asakusafw/integration/core/YaessTest.java
@@ -21,12 +21,14 @@ import static org.junit.Assert.*;
 
 import java.util.Optional;
 
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
 import com.asakusafw.integration.AsakusaConfigurator;
 import com.asakusafw.integration.AsakusaProject;
 import com.asakusafw.integration.AsakusaProjectProvider;
+import com.asakusafw.integration.PlatformUtil;
 import com.asakusafw.utils.gradle.Bundle;
 import com.asakusafw.utils.gradle.ContentsConfigurator;
 
@@ -35,6 +37,14 @@ import com.asakusafw.utils.gradle.ContentsConfigurator;
  * Please see {@code src/integration-test/data/yaess/README.md} on this project.
  */
 public class YaessTest {
+
+    /**
+     * Skip this test class for Windows platform.
+     */
+    @BeforeClass
+    public static void checkCkass() {
+        PlatformUtil.skipIfWindows();
+    }
 
     /**
      * project provider.

--- a/integration/src/main/java/com/asakusafw/integration/PlatformUtil.java
+++ b/integration/src/main/java/com/asakusafw/integration/PlatformUtil.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.integration;
+
+import java.util.Locale;
+
+import org.junit.AssumptionViolatedException;
+
+/**
+ * Utilities about running platform.
+ * @since 0.10.0
+ */
+public final class PlatformUtil {
+
+    static final boolean WINDOWS = System.getProperty("os.name", "")
+            .toLowerCase(Locale.ENGLISH)
+            .startsWith("windows");
+
+    private PlatformUtil() {
+        return;
+    }
+
+    /**
+     * Skips test if it is on Windows platform.
+     */
+    public static void skipIfWindows() {
+        if (WINDOWS) {
+            throw new AssumptionViolatedException("skip test on Windows platform");
+        }
+    }
+}

--- a/windgate-project/bootstrap/src/main/java/com/asakusafw/windgate/bootstrap/FinalizeBootstrap.java
+++ b/windgate-project/bootstrap/src/main/java/com/asakusafw/windgate/bootstrap/FinalizeBootstrap.java
@@ -20,6 +20,7 @@ import static com.asakusafw.windgate.bootstrap.WindGateConstants.*;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -82,7 +83,7 @@ public class FinalizeBootstrap {
         Path home = getHome(environment);
         return new String[] {
                 "-profile", getProfileUri(home, context.getProfileName()).toString(),
-                "-session", context.getExecutionId(),
+                "-session", Optional.ofNullable(context.getExecutionId()).orElse(""),
                 "-plugin", getPluginPath(home).stream()
                         .map(Path::toString)
                         .collect(Collectors.joining(File.pathSeparator)),


### PR DESCRIPTION
## Summary

This PR fixes integration test for Windows platform.

## Background, Problem or Goal of the patch

See #752.

## Design of the fix, or a new feature

This also fixed WindGate finalizer for Windows. It had been crashed if session ID (a.k.a. execution ID) was not specified.

## Related Issue, Pull Request or Code

* #752