### PR TITLE
Inject tool launcher classpath.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
@@ -493,9 +493,11 @@ class AsakusaSdkPlugin implements Plugin<Project> {
     private void configureTestToolTasks() {
         project.tasks.withType(RunBatchappTask) { AbstractTestToolTask task ->
             task.toolClasspath = project.files({ project.sourceSets.test.runtimeClasspath })
+            task.launcherClasspath << project.configurations.asakusaToolLauncher
         }
         project.tasks.withType(TestToolTask) { AbstractTestToolTask task ->
             task.toolClasspath = project.files({ project.sourceSets.test.runtimeClasspath })
+            task.launcherClasspath << project.configurations.asakusaToolLauncher
         }
     }
 


### PR DESCRIPTION
## Summary

This PR is fix of #756, it must inject tool launcher classpath into each Gradle task.

## Background, Problem or Goal of the patch

#756 enables `TestToolTask` to use tool launcher, but tool launcher classpath was not given.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #756 