### PR TITLE
Bump Gradle version for application projects to 4.1.

### DIFF
--- a/gradle/src/main/resources/META-INF/asakusa-gradle/defaults.properties
+++ b/gradle/src/main/resources/META-INF/asakusa-gradle/defaults.properties
@@ -1,4 +1,4 @@
 ## project configurations
 java-version=1.8
-gradle-version=3.4.1
+gradle-version=4.1
 embedded-libs-directory=src/main/libs

--- a/gradle/src/test/groovy/com/asakusafw/gradle/plugins/AsakusaUpgradeTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/gradle/plugins/AsakusaUpgradeTest.groovy
@@ -47,6 +47,14 @@ class AsakusaUpgradeTest {
     }
 
     /**
+     * Test for {@code 4.1} (Asakusa {@code 0.10.0}).
+     */
+    @Test
+    void 'v4.1'() {
+        doUpgradeFromTestName()
+    }
+
+    /**
      * Test for {@code 3.4.1} (Asakusa {@code 0.9.1}).
      */
     @Test


### PR DESCRIPTION
## Summary

This PR bumps up Gradle version for application projects to `4.1`.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.
