### PR TITLE
Bump Gradle required Java version to 1.8.

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -71,8 +71,7 @@ dependencies {
     deployerJars 'org.springframework.build:aws-maven:5.0.0.RELEASE'
 }
 
-project.sourceCompatibility = JavaVersion.toVersion('1.7')
-project.targetCompatibility = JavaVersion.toVersion('1.7')
+project.sourceCompatibility = JavaVersion.toVersion('1.8')
 
 tasks.withType(AbstractCompile) { task ->
     task.options.encoding = 'UTF-8'


### PR DESCRIPTION
## Summary

This PR bumps up Gradle required JDK version to 1.8.

## Background, Problem or Goal of the patch

Asakusa Framework has been required Java `>= 1.8` in recent versions, but application Gradle does not require `1.8` for backward compatibility.

## Design of the fix, or a new feature

Note that, we remove `project.targetCompatibility` in `build.gradle` because it inherits `project.sourceCompatibility` in default.

## Related Issue, Pull Request or Code

N/A.