### PR TITLE
Revise error messages in `asakusa run`.

### DIFF
--- a/workflow/cli/src/main/java/com/asakusafw/workflow/cli/run/RunCommand.java
+++ b/workflow/cli/src/main/java/com/asakusafw/workflow/cli/run/RunCommand.java
@@ -76,7 +76,7 @@ public class RunCommand implements Runnable, CommandProvider {
             throw new CommandConfigurationException(MessageFormat.format(
                     "cannot execute batch \"{0}\" ({1})",
                     workflow.getId(),
-                    e.getMessage()));
+                    e.getMessage()), e);
         } catch (IOException | InterruptedException e) {
             throw new CommandExecutionException(MessageFormat.format(
                     "executing batch \"{0}\" was failed",


### PR DESCRIPTION
## Summary

This PR revises error messages in `asakusa run`.

## Background, Problem or Goal of the patch

In the latest implementation, `asakusa run` drops root causal information of errors.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #757 