### PR TITLE
Introduce `tools/bin/setup.jar`.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusafwOrganizer.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusafwOrganizer.groovy
@@ -85,6 +85,7 @@ class AsakusafwOrganizer extends AbstractOrganizer {
                       TestingDist : "Contents of Asakusa Framework testing tools (${profile.name}).",
                     OperationDist : "Contents of Asakusa Framework operation tools (${profile.name}).",
                      OperationLib : "Libraries of Asakusa Framework operation tools (${profile.name}).",
+                    OperationExec : "Executables of Asakusa Framework operation tools (${profile.name}).",
                      ExtensionLib : "Asakusa Framework extension libraries (${profile.name}).",
         ])
         configuration('asakusafwExtensionLib').transitive = false
@@ -196,6 +197,9 @@ class AsakusafwOrganizer extends AbstractOrganizer {
                     "com.asakusafw:asakusa-command-portal:${base.frameworkVersion}:exec@jar",
                     "com.asakusafw.workflow:asakusa-workflow-hadoop:${base.frameworkVersion}:lib@jar",
                     "org.slf4j:slf4j-simple:${base.slf4jVersion}@jar",
+                ],
+                OperationExec : [
+                    "com.asakusafw:asakusa-setup-tools:${base.frameworkVersion}:exec@jar",
                 ],
                 DirectIoHiveDist : [],
                 DirectIoHiveLib : [
@@ -324,6 +328,12 @@ class AsakusafwOrganizer extends AbstractOrganizer {
                         rename(/slf4j-simple-.*\.jar/, 'slf4j-simple.jar')
                     }
                }
+                into('tools/bin') {
+                    put configuration('asakusafwOperationExec')
+                    process {
+                        rename(/asakusa-setup-tools-.*-exec.jar/, 'setup.jar')
+                    }
+                }
             },
             Extension : {
                 into('ext/lib') {

--- a/integration/src/integration-test/java/com/asakusafw/integration/core/SetupToolsTest.java
+++ b/integration/src/integration-test/java/com/asakusafw/integration/core/SetupToolsTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.integration.core;
+
+import static com.asakusafw.integration.core.Util.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.nio.file.Path;
+
+import org.junit.AssumptionViolatedException;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.asakusafw.integration.AsakusaProject;
+import com.asakusafw.integration.AsakusaProjectProvider;
+import com.asakusafw.utils.gradle.Bundle;
+import com.asakusafw.utils.gradle.CommandPath;
+import com.asakusafw.utils.gradle.ContentsConfigurator;
+
+/**
+ * Test for setup tools.
+ */
+public class SetupToolsTest {
+
+    private static final String SETUP_JAR = "tools/bin/setup.jar";
+
+    /**
+     * project provider.
+     */
+    @Rule
+    public final AsakusaProjectProvider provider = new AsakusaProjectProvider()
+            .withProject(ContentsConfigurator.copy(data("organizer-simple")));
+
+    private static Path java() {
+        return CommandPath.system().find("java")
+                .orElseThrow(() -> new AssumptionViolatedException("missing java command"));
+    }
+
+    /**
+     * {@code setup}.
+     */
+    @Test
+    public void setup() {
+        Path java = java();
+
+        AsakusaProject project = provider.newInstance("tls");
+        project.gradle("installAsakusafw");
+
+        int exit = project.getCommandLauncher().launch(
+                java,
+                "-jar",
+                project.getFramework().get(SETUP_JAR).toAbsolutePath().toString());
+
+        assertThat(exit, is(0));
+    }
+
+    /**
+     * {@code setup --help}.
+     */
+    @Test
+    public void setup_help() {
+        Path java = java();
+
+        AsakusaProject project = provider.newInstance("tls");
+        project.gradle("installAsakusafw");
+
+        int exit = project.getCommandLauncher().launch(
+                java,
+                "-jar",
+                project.getFramework().get(SETUP_JAR).toAbsolutePath().toString(),
+                "--help");
+
+        assertThat(exit, is(0));
+    }
+
+    /**
+     * {@code setup} with non-default home.
+     */
+    @Test
+    public void setup_copy() {
+        Path java = java();
+
+        AsakusaProject project = provider.newInstance("tls");
+        project.gradle("installAsakusafw");
+
+        Bundle copy = project.addBundle("copy").copy(project.getFramework().getDirectory());
+        int exit = project.getCommandLauncher().launch(
+                java,
+                "-jar",
+                project.getFramework().get(SETUP_JAR).toAbsolutePath().toString(),
+                copy.getDirectory().toAbsolutePath().toString());
+
+        assertThat(exit, is(0));
+    }
+
+    /**
+     * {@code setup} with invalid home.
+     */
+    @Test
+    public void setup_not_home() {
+        Path java = java();
+
+        AsakusaProject project = provider.newInstance("tls");
+        project.gradle("installAsakusafw");
+
+        Bundle invalid = project.addBundle("invalid");
+        int exit = project.getCommandLauncher().launch(
+                java,
+                "-jar",
+                project.getFramework().get(SETUP_JAR).toAbsolutePath().toString(),
+                invalid.getDirectory().toAbsolutePath().toString());
+
+        assertThat(exit, is(not(0)));
+    }
+}

--- a/operation-project/pom.xml
+++ b/operation-project/pom.xml
@@ -13,6 +13,7 @@
   <modules>
     <module>asakusa-operation-tools</module>
     <module>command-portal</module>
+    <module>setup-tools</module>
   </modules>
 
 </project>

--- a/operation-project/setup-tools/.gitignore
+++ b/operation-project/setup-tools/.gitignore
@@ -1,0 +1,8 @@
+/.gradle
+/build
+/target
+/.project
+/.classpath
+/.settings
+/bin
+

--- a/operation-project/setup-tools/pom.xml
+++ b/operation-project/setup-tools/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <name>Asakusa Framework Setup Tools</name>
+  <artifactId>asakusa-setup-tools</artifactId>
+  <parent>
+    <artifactId>asakusa-operation-project</artifactId>
+    <groupId>com.asakusafw</groupId>
+    <version>0.10.0-SNAPSHOT</version>
+  </parent>
+
+  <packaging>jar</packaging>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>com.asakusafw.operation.tools.setup.Setup</mainClass>
+                </transformer>
+              </transformers>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>exec</shadedClassifierName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/operation-project/setup-tools/src/main/java/com/asakusafw/operation/tools/setup/MakeExecutable.java
+++ b/operation-project/setup-tools/src/main/java/com/asakusafw/operation/tools/setup/MakeExecutable.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.operation.tools.setup;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+final class MakeExecutable {
+
+    private static final Set<String> TRIGGER_NAME = Stream.of(
+            "bin",
+            "libexec").collect(Collectors.toSet());
+
+    private static final Set<PosixFilePermission> EXECUTABLES = EnumSet.of(
+            PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE,
+            PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
+            PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE);
+
+    private static final Set<String> EXTENSION_ALWAYS = Stream.of(
+            ".sh").collect(Collectors.toSet());
+
+    private static final Set<String> EXTENSION_NEVER = Stream.of(
+            ".cmd",
+            ".exe").collect(Collectors.toSet());
+
+    private MakeExecutable() {
+        return;
+    }
+
+    static void setExecutable(Path root) throws IOException {
+        if (root.getFileSystem().supportedFileAttributeViews().contains("posix") == false) {
+            System.out.printf("installation path is not a POSIX file system: %s%n", root);
+            return;
+        }
+        walk(root, false);
+    }
+
+    private static void walk(Path current, boolean inExecDir) throws IOException {
+        if (Files.isDirectory(current)) {
+            List<Path> list = Files.list(current).collect(Collectors.toList());
+            for (Path child : list) {
+                boolean next = inExecDir || Optional.ofNullable(child.getFileName())
+                        .map(Path::toString)
+                        .filter(TRIGGER_NAME::contains)
+                        .isPresent();
+                walk(child, next);
+            }
+        } else if (isExecutableTarget(current, inExecDir)) {
+            PosixFileAttributeView attr = Files.getFileAttributeView(current, PosixFileAttributeView.class);
+            Set<PosixFilePermission> perms = attr.readAttributes().permissions();
+            if (perms.containsAll(EXECUTABLES) == false) {
+                System.out.printf("set executable: %s (%s)%n", current, PosixFilePermissions.toString(perms));
+                perms.addAll(EXECUTABLES);
+                attr.setPermissions(perms);
+            }
+        }
+    }
+
+    private static boolean isExecutableTarget(Path file, boolean execDir) {
+        String name = Optional.ofNullable(file.getFileName())
+                .map(Path::toString)
+                .orElse(null);
+        if (name == null) {
+            return false;
+        }
+        if (EXTENSION_ALWAYS.stream().anyMatch(name::endsWith)) {
+            return true;
+        }
+        if (EXTENSION_NEVER.stream().anyMatch(name::endsWith)) {
+            return false;
+        }
+        return execDir;
+    }
+}

--- a/operation-project/setup-tools/src/main/java/com/asakusafw/operation/tools/setup/MakeExecutable.java
+++ b/operation-project/setup-tools/src/main/java/com/asakusafw/operation/tools/setup/MakeExecutable.java
@@ -43,6 +43,7 @@ final class MakeExecutable {
             ".sh").collect(Collectors.toSet());
 
     private static final Set<String> EXTENSION_NEVER = Stream.of(
+            ".jar",
             ".cmd",
             ".exe").collect(Collectors.toSet());
 

--- a/operation-project/setup-tools/src/main/java/com/asakusafw/operation/tools/setup/Setup.java
+++ b/operation-project/setup-tools/src/main/java/com/asakusafw/operation/tools/setup/Setup.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.operation.tools.setup;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.Properties;
+
+/**
+ * Validates Asakusa framework installation.
+ * @since 0.10.0
+ */
+public final class Setup {
+
+    static final String NAME = System.getProperty("cli.name", "<self.jar>");
+
+    static final String ENV_INSTALLATION = "ASAKUSA_HOME";
+
+    static final String PATH_VERSION = "VERSION";
+
+    private Setup() {
+        return;
+    }
+
+    /**
+     * Program entry.
+     * @param args installation paths
+     */
+    public static void main(String... args) {
+        int exitValue = exec(args);
+        if (exitValue != 0) {
+            System.exit(exitValue);
+        }
+    }
+
+    static int exec(String... args) {
+        if (args.length >= 2) {
+            usage();
+            return 1;
+        } else if (args.length == 1) {
+            switch (args[0]) {
+            case "-h":
+            case "--help":
+                usage();
+                return 0;
+            default:
+                break;
+            }
+            return exec(Paths.get(args[0]));
+        } else {
+            String path = System.getenv(ENV_INSTALLATION);
+            if (path == null || path.isEmpty()) {
+                System.out.printf("environment variable %s must be defined.%n", ENV_INSTALLATION);
+                return 2;
+            }
+            return exec(Paths.get(path));
+        }
+    }
+
+    static int exec(Path path) {
+        System.out.printf("setup: %s%n", path);
+        if (Files.exists(path) == false) {
+            System.out.printf("installation not found: %s%n", path);
+            usage();
+            return 2;
+        }
+        if (check(path) == false) {
+            System.out.printf("installation is not valid: %s%n", path);
+            usage();
+            return 2;
+        }
+        try {
+            MakeExecutable.setExecutable(path);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return 2;
+        }
+        return 0;
+    }
+
+    private static boolean check(Path path) {
+        Path versionFile = path.resolve(PATH_VERSION);
+        if (Files.isRegularFile(versionFile) == false) {
+            return false;
+        }
+        String version;
+        try (InputStream input = Files.newInputStream(versionFile)) {
+            Properties props = new Properties();
+            props.load(input);
+            version = props.getProperty("asakusafw.version");
+            if (version == null) {
+                return false;
+            } else {
+                System.out.printf("framework version: %s%n", version);
+                return true;
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    private static void usage() {
+        System.out.printf("Usage:%n");
+        System.out.printf("    java -jar %s%n", NAME);
+        System.out.printf("        Processes the default installation (%s=%s).%n",
+                ENV_INSTALLATION,
+                Optional.ofNullable(System.getenv(ENV_INSTALLATION))
+                        .filter(it -> it.isEmpty() == false)
+                        .orElse("(not defined)"));
+        System.out.printf("    java -jar %s /path/to/installation%n", NAME);
+        System.out.printf("        Processes the specified installation.%n");
+        System.out.printf("    java -jar %s --help%n", NAME);
+        System.out.printf("        Prints this message.%n");
+    }
+}

--- a/operation-project/setup-tools/src/main/java/com/asakusafw/operation/tools/setup/package-info.java
+++ b/operation-project/setup-tools/src/main/java/com/asakusafw/operation/tools/setup/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Asakusa Framework Setup Tools.
+ */
+package com.asakusafw.operation.tools.setup;


### PR DESCRIPTION
## Summary

This PR introduces post installation script onto `tools/bin/setup.jar`.

## Background, Problem or Goal of the patch

The introduced script makes Asakusa Framework installation (which typically it is on `$ASAKUSA_HOME`) available. Archivers sometimes removes file permissions from Asakusa deployment archives, and then the script restores executable permissions of commands in the installation. Since the latest version, each command name must ends with `.sh`, and users simply restore executable permission by `find . -name '*.sh' | xargs ...`. However, recent commits like #752 removes the common file extension of these commands. This introduced script will replace that operation.

## Design of the fix, or a new feature

```
Usage:
    java -jar $ASAKUSA_HOME/tools/bin/setup.jar
        Processes the default installation (ASAKUSA_HOME=/Users/arakawa/target/asakusa/home).
    java -jar $ASAKUSA_HOME/tools/bin/setup.jar /path/to/installation
        Processes the specified installation.
    java -jar $ASAKUSA_HOME/tools/bin/setup.jar --help
        Prints this message.
```

## Related Issue, Pull Request or Code

* #752