### PR TITLE
Remove reviewer section from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,3 @@ triggers. Also it must include expected results and actual results,
 making the difference clear.
 
 ## Related Issue, Pull Request or Code
-
-## Wanted reviewer


### PR DESCRIPTION
## Summary

This PR removes Reviewer section from PR template.
The Reviewer can be specified from the side menu of creating PR page.