### PR TITLE
Fix regression (Direct I/O Hive).

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusafwOrganizer.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusafwOrganizer.groovy
@@ -205,8 +205,7 @@ class AsakusafwOrganizer extends AbstractOrganizer {
                 ],
                 DirectIoHiveDist : [],
                 DirectIoHiveLib : [
-                    "com.asakusafw:asakusa-hive-info:${base.frameworkVersion}@jar",
-                    "com.asakusafw:asakusa-hive-core:${base.frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-hive-core:${base.frameworkVersion}:lib@jar",
                 ] + profile.hive.libraries,
                 ExtensionLib : profile.extension.libraries,
             ])

--- a/hive-project/asakusa-hive-core/pom.xml
+++ b/hive-project/asakusa-hive-core/pom.xml
@@ -10,6 +10,36 @@
   </parent>
 
   <packaging>jar</packaging>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>com.asakusafw.info:*</include>
+                </includes>
+              </artifactSet>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+              </transformers>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>lib</shadedClassifierName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
## Summary

This PR fixes Direct I/O Hive since #744.

## Background, Problem or Goal of the patch

In #744, we replaced `asakusa-hive-info` with `com.asakusafw.info:asakusa-info-hive`, but the Framework Organizer still refer the old library.

## Design of the fix, or a new feature

This PR introduces a composite bundle to `com.asakusafw:asakusa-hive-info` as `lib` classifier. It also includes the required dependencies of Direct I/O Hive feature except the Hive core library.

## Related Issue, Pull Request or Code

* #744
