### PR TITLE
Revise `tools/bin/directio` command.

### DIFF
--- a/operation-project/command-portal/src/main/dist/bin/asakusa
+++ b/operation-project/command-portal/src/main/dist/bin/asakusa
@@ -15,9 +15,11 @@
 # limitations under the License.
 #
 
-_ROOT="$(cd "$(dirname "$0")/../tools" ; pwd)"
+_ROOT="${ASAKUSA_HOME:?ASAKUSA_HOME is not defined}/tools"
 
-. "${ASAKUSA_HOME:?ASAKUSA_HOME is not defined}/core/libexec/configure-java.sh"
+cd
+
+. "$ASAKUSA_HOME/core/libexec/configure-java.sh"
 
 _CLASSPATH=()
 _CLASSPATH+=("$_ROOT/lib/asakusa-command-portal.jar")

--- a/operation-project/command-portal/src/main/dist/bin/asakusa.cmd
+++ b/operation-project/command-portal/src/main/dist/bin/asakusa.cmd
@@ -22,6 +22,8 @@ if not defined ASAKUSA_HOME (
     exit /b 1
 )
 
+cd /d %USERPROFILE%
+
 set libdir=%ASAKUSA_HOME%\tools\lib
 set java_classpath=%libdir%\asakusa-command-portal.jar;%libdir%\slf4j-simple.jar
 set main_class=com.asakusafw.operation.tools.portal.AsakusaPortal

--- a/operation-project/directio/src/main/dist/tools/bin/directio
+++ b/operation-project/directio/src/main/dist/tools/bin/directio
@@ -31,8 +31,8 @@ export CALLER_CWD="$(pwd)"
 
 cd
 
-import "$ASAKUSA_HOME/hadoop/libexec/configure-hadoop.sh"
 import "$_ROOT/conf/env.sh"
+import "$ASAKUSA_HOME/hadoop/libexec/configure-hadoop.sh"
 
 _MAIN_CLASS=com.asakusafw.operation.tools.directio.DirectIo
 _CLI_NAME=directio

--- a/operation-project/directio/src/main/dist/tools/bin/directio.cmd
+++ b/operation-project/directio/src/main/dist/tools/bin/directio.cmd
@@ -30,7 +30,6 @@ set java_classpath=%libdir%\asakusa-directio-tools.jar
 set main_class=com.asakusafw.operation.tools.directio.bootstrap.Bootstrap
 
 set java_props=-Dcli.name=directio
-set java_props=%java_props% -Dcli.name=directio
 set java_props=%java_props% -Dhadoop.home.dir=%ASAKUSA_HOME%\hadoop
 
 java %ASAKUSA_CLIENT_OPTS% -classpath %java_classpath% %java_props% %main_class% %*

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FileGetCommand.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FileGetCommand.java
@@ -125,7 +125,7 @@ public class FileGetCommand implements Runnable {
                 .isPresent()) {
             if (files.size() != 1) {
                 throw new CommandConfigurationException(MessageFormat.format(
-                        "copy souce is ambiguous: {0}",
+                        "copy source is ambiguous: {0}",
                         files.stream()
                                 .map(ResourceInfo::getPath)
                                 .collect(Collectors.joining(", "))));

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FilePutCommand.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FilePutCommand.java
@@ -240,7 +240,7 @@ public class FilePutCommand implements Runnable {
                         }
                         dstFs.mkdirs(destination);
                         verboseParameter.printf(writer, "copy directory: %s -> %s%n", source, destination);
-                        Arrays.stream(dstFs.listStatus(source))
+                        Arrays.stream(srcFs.listStatus(source))
                                 .map(s -> {
                                     org.apache.hadoop.fs.Path src = s.getPath();
                                     org.apache.hadoop.fs.Path dst = resolve(destination, src.getName());

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FilePutCommand.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FilePutCommand.java
@@ -118,7 +118,7 @@ public class FilePutCommand implements Runnable {
             if (stat(parent).filter(it -> it.isDirectory()).isPresent()) {
                 if (sources.size() >= 2) {
                     throw new CommandConfigurationException(MessageFormat.format(
-                            "copy souce is ambiguous: {0}",
+                            "copy source is ambiguous: {0}",
                             sources.stream()
                                     .map(String::valueOf)
                                     .collect(Collectors.joining(", "))));

--- a/utils-project/jcommander-wrapper/src/test/java/com/asakusafw/utils/jcommander/JCommanderWrapperTest.java
+++ b/utils-project/jcommander-wrapper/src/test/java/com/asakusafw/utils/jcommander/JCommanderWrapperTest.java
@@ -191,7 +191,7 @@ public class JCommanderWrapperTest {
     @Test
     public void expand_dynamic() {
         JCommanderWrapper<Supplier<String>> commander = new JCommanderWrapper<>("PG", new Exp());
-        Optional<String> result = commander.parse("-ac", "-De").map(Supplier::get);
+        Optional<String> result = commander.parse("-ac", "-De=f").map(Supplier::get);
         assertThat(result, is(Optional.of("ace=f")));
     }
 
@@ -203,6 +203,16 @@ public class JCommanderWrapperTest {
         JCommanderWrapper<Supplier<String>> commander = new JCommanderWrapper<>("PG", new Exp());
         Optional<String> result = commander.parse("-abc", "MAIN").map(Supplier::get);
         assertThat(result, is(Optional.of("abcMAIN")));
+    }
+
+    /**
+     * w/ expand + escape.
+     */
+    @Test
+    public void expand_escape() {
+        JCommanderWrapper<Supplier<String>> commander = new JCommanderWrapper<>("PG", new Exp());
+        Optional<String> result = commander.parse("-a", "--", "-bc").map(Supplier::get);
+        assertThat(result, is(Optional.of("a-bc")));
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR improves usage of `tools/bin/directio` command introduced since #765.

## Background, Problem or Goal of the patch

See #765.

## Design of the fix, or a new feature

This PR includes the following revisions:

* `tools/bin/directio` script is now relocatable (only depends on `ASAKUSA_HOME`)
* better parsing command line options
  * accepts combined short-name options like `-vrw` => `-v -r -w`
  * rejects unknown options instead of recognize as main parameters
* fix `put` command
* fix typo

## Related Issue, Pull Request or Code

* #765 