### PR TITLE
Fix hive-exec reference in Gradle plug-ins.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
@@ -224,7 +224,12 @@ class AsakusaSdkPlugin implements Plugin<Project> {
                         compile "com.asakusafw:asakusa-windgate-vocabulary:${base.frameworkVersion}"
                     }
                     if (features.hive) {
-                        compile "com.asakusafw:asakusa-hive-core:${base.frameworkVersion}"
+                        compile("com.asakusafw:asakusa-hive-core:${base.frameworkVersion}") {
+                            exclude group: 'org.apache.hive', module: 'hive-exec'
+                        }
+                        compile("org.apache.hive:hive-exec:${base.hiveVersion}@jar") {
+                            transitive false
+                        }
                     }
                 }
                 if (features.testing) {

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusafwOrganizer.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusafwOrganizer.groovy
@@ -88,6 +88,7 @@ class AsakusafwOrganizer extends AbstractOrganizer {
                     OperationExec : "Executables of Asakusa Framework operation tools (${profile.name}).",
                      ExtensionLib : "Asakusa Framework extension libraries (${profile.name}).",
         ])
+        configuration('asakusafwDirectIoHiveLib').transitive = false
         configuration('asakusafwExtensionLib').transitive = false
         configuration('asakusafwHadoopLib').with { Configuration conf ->
             conf.transitive = true


### PR DESCRIPTION
## Summary

This PR fixes regressions about hive-exec library references in Gradle plug-ins.

## Background, Problem or Goal of the patch

(1) `sdk.hive true` brings incorrect `hive-exec` library (it must be `1.1.1`, but uses `1.2.1` from `asakusa-hive-core`).

(2) `asakusafwOrganizer.hive.libraries` introduces transitive dependencies.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.