### PR TITLE
Fix Direct I/O Hive for recent distributions.

### DIFF
--- a/hive-project/asakusa-hive-core/src/main/java/com/asakusafw/directio/hive/parquet/DecimalValueDriver.java
+++ b/hive-project/asakusa-hive-core/src/main/java/com/asakusafw/directio/hive/parquet/DecimalValueDriver.java
@@ -15,11 +15,16 @@
  */
 package com.asakusafw.directio.hive.parquet;
 
+import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.text.MessageFormat;
 import java.util.Arrays;
+import java.util.Optional;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import com.asakusafw.runtime.value.DecimalOption;
 import com.asakusafw.runtime.value.ValueOption;
@@ -36,9 +41,43 @@ import parquet.schema.Types.PrimitiveBuilder;
 
 /**
  * {@link ParquetValueDriver} for decimals.
- * @since 0.7.2
+ * @since 0.10.0
  */
 public class DecimalValueDriver implements ParquetValueDriver {
+
+    static final Log LOG = LogFactory.getLog(DataModelMaterializer.class);
+
+    static final String KEY_PREFIX = "com.asakusafw.hive.parquet.decimal.";
+
+    static final String KEY_USE_BINARY = KEY_PREFIX + "binary";
+
+    static final boolean USE_BINARY = Optional.ofNullable(System.getProperty(KEY_USE_BINARY))
+            .map(String::trim)
+            .map(it -> it.isEmpty() || Boolean.parseBoolean(it))
+            .orElse(false);
+
+    private static final Method BUILDER_LENGTH_METHOD;
+
+    private static final Method BUILDER_PRECISION_METHOD;
+
+    private static final Method BUILDER_SCALE_METHOD;
+
+    static {
+        BUILDER_LENGTH_METHOD = findBuilderMethod("length");
+        BUILDER_PRECISION_METHOD = findBuilderMethod("precision");
+        BUILDER_SCALE_METHOD = findBuilderMethod("scale");
+    }
+
+    private static Method findBuilderMethod(String name) {
+        try {
+            return PrimitiveBuilder.class.getMethod(name, int.class);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(MessageFormat.format(
+                    "Parquet library does not support: {0}#{1}(int)",
+                    PrimitiveBuilder.class.getSimpleName(),
+                    name), e);
+        }
+    }
 
     static final int PRECISION_INT_MAX = 9;
 
@@ -48,63 +87,30 @@ public class DecimalValueDriver implements ParquetValueDriver {
 
     private final int scale;
 
-    private final boolean forceBinary;
-
     /**
      * Creates a new instance.
      * @param precision the precision
      * @param scale the scale
      */
     public DecimalValueDriver(int precision, int scale) {
-        this(precision, scale, true);
-    }
-
-    /**
-     * Creates a new instance.
-     * @param precision the precision
-     * @param scale the scale
-     * @param forceBinary forcibly use {@code PrimitiveType.BINARY} even if precision is so small
-     */
-    public DecimalValueDriver(int precision, int scale, boolean forceBinary) {
         this.precision = precision;
         this.scale = scale;
-        this.forceBinary = forceBinary;
     }
 
     @Override
     public Type getType(String name) {
         int byteLength = getByteLength(precision);
-        PrimitiveTypeName typeName = getTypeNameFor(byteLength);
-        PrimitiveBuilder<PrimitiveType> builder = Types.optional(typeName)
-                .as(OriginalType.DECIMAL)
-                .precision(precision)
-                .scale(scale);
-        if (typeName == PrimitiveTypeName.BINARY) {
-            builder.length(byteLength);
+        PrimitiveTypeName typeName = USE_BINARY ? PrimitiveTypeName.BINARY : PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+        PrimitiveBuilder<PrimitiveType> builder = Types.optional(typeName).as(OriginalType.DECIMAL);
+        // NOTE: return types of PrimitiveBuilder.{length,precision,scale} are unstable
+        try {
+            BUILDER_LENGTH_METHOD.invoke(builder, byteLength);
+            BUILDER_PRECISION_METHOD.invoke(builder, precision);
+            BUILDER_SCALE_METHOD.invoke(builder, scale);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalArgumentException("error occurred while resolving decimal type", e);
         }
         return builder.named(name);
-    }
-
-    private PrimitiveTypeName getTypeNameFor(int byteLength) {
-        if (forceBinary) {
-            return PrimitiveTypeName.BINARY;
-        } else if (byteLength <= 4) {
-            return PrimitiveTypeName.INT32;
-        } else if (byteLength <= 8) {
-            return PrimitiveTypeName.INT64;
-        } else {
-            return PrimitiveTypeName.BINARY;
-        }
-    }
-
-    @Override
-    public ValueConverter getConverter() {
-        return new DecimalConverter(getByteLength(precision), scale, forceBinary);
-    }
-
-    @Override
-    public ValueWriter getWriter() {
-        return new DecimalWriter(getByteLength(precision), precision, scale, forceBinary);
     }
 
     static int getByteLength(int precision) {
@@ -115,22 +121,26 @@ public class DecimalValueDriver implements ParquetValueDriver {
         return (bits + Byte.SIZE - 1) / Byte.SIZE;
     }
 
+    @Override
+    public ValueConverter getConverter() {
+        return new DecimalConverter(scale);
+    }
+
+    @Override
+    public ValueWriter getWriter() {
+        return new DecimalWriter(getByteLength(precision), precision, scale);
+    }
+
     private static class DecimalConverter extends ValueConverter {
 
-        private final int byteLength;
-
         private final int scale;
-
-        private final boolean forceBinary;
 
         private DecimalOption target;
 
         private BigDecimal[] dict;
 
-        DecimalConverter(int byteLength, int scale, boolean forceBinary) {
-            this.byteLength = byteLength;
+        DecimalConverter(int scale) {
             this.scale = scale;
-            this.forceBinary = forceBinary;
         }
 
         @Override
@@ -146,19 +156,7 @@ public class DecimalValueDriver implements ParquetValueDriver {
         @Override
         public void setDictionary(Dictionary dictionary) {
             BigDecimal[] buf = prepareDictionaryBuffer(dictionary);
-            if (forceBinary) {
-                setDictionaryAsBinary(dictionary, buf);
-            } else if (byteLength <= 4) {
-                for (int id = 0, max = dictionary.getMaxId(); id <= max; id++) {
-                    buf[id] = convert(dictionary.decodeToInt(id));
-                }
-            } else if (byteLength <= 8) {
-                for (int id = 0, max = dictionary.getMaxId(); id <= max; id++) {
-                    buf[id] = convert(dictionary.decodeToLong(id));
-                }
-            } else {
-                setDictionaryAsBinary(dictionary, buf);
-            }
+            setDictionaryAsBinary(dictionary, buf);
         }
 
         private void setDictionaryAsBinary(Dictionary dictionary, BigDecimal[] buf) {
@@ -224,12 +222,9 @@ public class DecimalValueDriver implements ParquetValueDriver {
 
         private final int precision;
 
-        private final boolean forceBinary;
-
-        DecimalWriter(int byteLength, int precision, int scale, boolean forceBinary) {
+        DecimalWriter(int byteLength, int precision, int scale) {
             this.byteLength = byteLength;
             this.scale = scale;
-            this.forceBinary = forceBinary;
             this.precision = precision;
         }
 
@@ -239,15 +234,7 @@ public class DecimalValueDriver implements ParquetValueDriver {
             BigInteger unscaled = decimal
                     .setScale(scale, RoundingMode.FLOOR)
                     .unscaledValue();
-            if (forceBinary) {
-                writeAsBinary(consumer, decimal, unscaled);
-            } else if (byteLength <= 4) {
-                 consumer.addInteger(unscaled.intValue());
-            } else if (byteLength <= 8) {
-                consumer.addLong(unscaled.intValue());
-            } else {
-                writeAsBinary(consumer, decimal, unscaled);
-            }
+            writeAsBinary(consumer, decimal, unscaled);
         }
 
         private void writeAsBinary(RecordConsumer consumer, BigDecimal original, BigInteger unscaled) {


### PR DESCRIPTION
## Summary

This PR fixes Direct I/O Hive for recent distributions like CDH 5.x.

## Background, Problem or Goal of the patch

Recent parquet libraries include some binary incompatible changes since Hive `1.2.1`. 

## Design of the fix, or a new feature

This includes the following fixes:
* replace `PrimitiveBuilder.{precision,scale,length}` invocation with reflective operation, because they have been lost their binary compatibility
* replace `ParquetFileReader.new` invocation with reflective operation, because it raises warning logs

## Related Issue, Pull Request or Code

N/A.