### PR TITLE
Remove use of deprecated methods in Direct I/O hive.

### DIFF
--- a/hive-project/asakusa-hive-core/src/main/java/com/asakusafw/directio/hive/parquet/AbstractParquetFileFormat.java
+++ b/hive-project/asakusa-hive-core/src/main/java/com/asakusafw/directio/hive/parquet/AbstractParquetFileFormat.java
@@ -110,7 +110,8 @@ public abstract class AbstractParquetFileFormat<T> extends HadoopFileFormat<T>
                     context.getDataType().getSimpleName(),
                     files.size()));
         }
-        List<Footer> footers = ParquetFileReader.readAllFootersInParallel(getConf(), files);
+        // NOTE: BlockMetaData requires skipRowGroup=false
+        List<Footer> footers = ParquetFileReader.readAllFootersInParallel(getConf(), files, false);
         for (Footer footer : footers) {
             Path path = footer.getFile();
             FileStatus status = pathMap.get(path);

--- a/hive-project/asakusa-hive-core/src/main/java/com/asakusafw/directio/hive/parquet/ParquetFileInput.java
+++ b/hive-project/asakusa-hive-core/src/main/java/com/asakusafw/directio/hive/parquet/ParquetFileInput.java
@@ -34,6 +34,7 @@ import com.asakusafw.runtime.directio.Counter;
 import com.asakusafw.runtime.io.ModelInput;
 
 import parquet.column.page.PageReadStore;
+import parquet.format.converter.ParquetMetadataConverter;
 import parquet.hadoop.ParquetFileReader;
 import parquet.hadoop.metadata.BlockMetaData;
 import parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -166,7 +167,8 @@ public class ParquetFileInput<T> implements ModelInput<T> {
                         descriptor.getDataModelClass().getSimpleName(),
                         path));
             }
-            ParquetMetadata footer = ParquetFileReader.readFooter(hadoopConfiguration, path);
+            ParquetMetadata footer = ParquetFileReader.readFooter(
+                    hadoopConfiguration, path, ParquetMetadataConverter.NO_FILTER);
             List<BlockMetaData> blocks = filterBlocks(footer.getBlocks());
             if (blocks.isEmpty()) {
                 return null;


### PR DESCRIPTION
## Summary

This PR removes use of deprecated method in Direct I/O HIve.

## Background, Problem or Goal of the patch

The following methods have been introduced since Hive `1.1.0`:

* `ParquetFileReader.readAllFootersInParallel` with `skipRowGroups`
* `ParquetFileReader.readFooter` with `ParquetMetadataConverter`

The above methods improves performance by filtering some metadata, and the existing methods have become deprecated. We now use the introduced methods instead of deprecated (require Hive `>= 1.1.0`).

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.