### PR TITLE
Add `asakusa hive` command group.

### DIFF
--- a/info/cli/src/main/java/com/asakusafw/info/cli/hive/HiveDdlCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/hive/HiveDdlCommand.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.info.cli.hive;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.info.hive.LocationInfo;
+import com.asakusafw.info.hive.TableInfo;
+import com.asakusafw.info.hive.syntax.HiveCreateTable;
+import com.asakusafw.info.hive.syntax.HiveQlEmitter;
+import com.asakusafw.info.hive.syntax.SimpleCreateTable;
+import com.asakusafw.utils.jcommander.CommandConfigurationException;
+import com.asakusafw.utils.jcommander.CommandException;
+import com.asakusafw.utils.jcommander.common.HelpParameter;
+import com.asakusafw.utils.jcommander.common.OutputParameter;
+import com.asakusafw.utils.jcommander.common.VerboseParameter;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.beust.jcommander.ParametersDelegate;
+
+/**
+ * A command for printing Hive DDL.
+ * @since 0.10.0
+ */
+@Parameters(
+        commandNames = "ddl",
+        commandDescription = "Generates Hive DDL."
+)
+public class HiveDdlCommand implements Runnable {
+
+    static final Logger LOG = LoggerFactory.getLogger(HiveDdlCommand.class);
+
+    static final String STATEMENT_SEPARATOR = ";"; //$NON-NLS-1$
+
+    @ParametersDelegate
+    final HelpParameter helpParameter = new HelpParameter();
+
+    @ParametersDelegate
+    final VerboseParameter verboseParameter = new VerboseParameter();
+
+    @ParametersDelegate
+    final OutputParameter outputParameter = new OutputParameter();
+
+    @ParametersDelegate
+    final HiveTableParameter hiveTableParameter = new HiveTableParameter();
+
+    @ParametersDelegate
+    final LocationParameter locationParameter = new LocationParameter();
+
+    @Parameter(
+            names = { "--database" },
+            description = "Database name.",
+            required = false)
+    String databaseParameter = null;
+
+    @Parameter(
+            names = { "--external" },
+            description = "Add \"EXTERNAL\" for tables.",
+            required = false)
+    boolean externalParameter = false;
+
+    @Parameter(
+            names = { "--if-not-exists" },
+            description = "Add \"IF NOT EXISTS\" for tables.",
+            required = false)
+    boolean ifNotExistsParameter = false;
+
+    @Parameter(
+            names = { "--on-error" },
+            description = "Action for errors.",
+            required = false)
+    ErrorAction errorAction = ErrorAction.FAIL;
+
+    @Override
+    public void run() {
+        LOG.debug("starting {}", getClass().getSimpleName());
+        List<HiveCreateTable> statements = getStatements();
+        if (statements.isEmpty()) {
+            throw new CommandConfigurationException("there are no available tables to generate DDL");
+        }
+        try (PrintWriter writer = outputParameter.open()) {
+            for (HiveCreateTable statement : statements) {
+                HiveQlEmitter.emit(statement, writer);
+                writer.printf("%s%n%n", STATEMENT_SEPARATOR);
+            }
+        } catch (IOException e) {
+            throw new CommandException("error occurred while generating Hive DDL", e);
+        }
+    }
+
+    private List<HiveCreateTable> getStatements() {
+        List<HiveCreateTable> candidates = hiveTableParameter.collect().entrySet().stream()
+                .map(e -> toStatement(e.getKey(), e.getValue()))
+                .flatMap(it -> it.map(Stream::of).orElse(Stream.empty()))
+                .collect(Collectors.toList());
+
+        List<HiveCreateTable> results = validate(candidates);
+        return results;
+    }
+
+    private Optional<HiveCreateTable> toStatement(TableInfo table, Set<LocationInfo> locations) {
+        String location;
+        try {
+            location = locationParameter.resolve(locations).orElse(null);
+        } catch (CommandConfigurationException ex) {
+            switch (errorAction) {
+            case SKIP:
+                LOG.warn("cannot resolve location of table {} (skip generate DDL)",
+                        table.getName(), ex);
+                return Optional.empty();
+            case FORCE:
+                LOG.warn("cannot resolve location of table {} (disable table location)",
+                        table.getName(), ex);
+                location = null;
+                break;
+            case FAIL:
+                throw ex;
+            default:
+                throw new AssertionError(ex);
+            }
+        }
+        return Optional.of(new SimpleCreateTable(table)
+                .withDatabaseName(databaseParameter)
+                .withExternal(externalParameter)
+                .withSkipPresentTable(ifNotExistsParameter)
+                .withLocation(location));
+    }
+
+    private List<HiveCreateTable> validate(List<HiveCreateTable> candidates) {
+        Map<String, Long> occurrences = candidates.stream().collect(Collectors.groupingBy(
+                it -> it.getTableInfo().getName(),
+                Collectors.counting()));
+
+        List<HiveCreateTable> results = new ArrayList<>();
+        Set<String> saw = new HashSet<>();
+        for (HiveCreateTable candidate : candidates) {
+            String name = candidate.getTableInfo().getName();
+            long occurrence = occurrences.getOrDefault(name, 0L);
+            assert occurrence > 0;
+            if (occurrence == 1) {
+                results.add(candidate);
+            } else {
+                switch (errorAction) {
+                case SKIP:
+                    LOG.warn("table \"{}\" is ambiguous (skip this table)", name);
+                    break;
+                case FORCE:
+                    if (saw.contains(name) == false) {
+                        saw.add(name);
+                        LOG.warn("table \"{}\" is ambiguous (force generate statemets)", name);
+                    }
+                    results.add(candidate);
+                    break;
+                case FAIL:
+                    throw new CommandConfigurationException(MessageFormat.format(
+                            "table \"{0}\" is ambiguous: {1}",
+                            candidates.stream()
+                                    .filter(it -> it.getTableInfo().getName().equals(name))
+                                    .collect(Collectors.toList())));
+                default:
+                    throw new AssertionError(errorAction);
+                }
+            }
+        }
+        return results;
+    }
+
+    enum ErrorAction {
+
+        SKIP,
+
+        FORCE,
+
+        FAIL,
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/info/cli/hive/HiveGroup.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/hive/HiveGroup.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.info.cli.hive;
+
+import com.asakusafw.info.cli.list.ListHiveInputCommand;
+import com.asakusafw.info.cli.list.ListHiveOutputCommand;
+import com.asakusafw.utils.jcommander.CommandBuilder;
+import com.asakusafw.utils.jcommander.common.CommandProvider;
+import com.asakusafw.utils.jcommander.common.GroupUsageCommand;
+import com.beust.jcommander.Parameters;
+
+/**
+ * A group command for Direct I/O Hive tools.
+ * @since 0.10.0
+ */
+@Parameters(
+        commandNames = "hive",
+        commandDescription = "Direct I/O Hive toolbox."
+)
+public class HiveGroup extends GroupUsageCommand implements CommandProvider {
+
+    @Override
+    public void accept(CommandBuilder<Runnable> builder) {
+        builder.addGroup(new HiveGroup(), group -> group
+                .addCommand(new HiveDdlCommand())
+                .addCommand(new ListHiveInputCommand())
+                .addCommand(new ListHiveOutputCommand()));
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/info/cli/hive/HiveIoParameter.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/hive/HiveIoParameter.java
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.info.cli.hive;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.info.cli.common.BatchInfoParameter;
+import com.asakusafw.info.hive.HiveIoAttribute;
+import com.asakusafw.info.hive.HivePortInfo;
+import com.asakusafw.info.hive.LocationInfo;
+import com.asakusafw.info.hive.TableInfo;
+import com.beust.jcommander.ParametersDelegate;
+
+/**
+ * Provides Direct I/O Hive inputs/outputs information.
+ * @since 0.10.0
+ */
+public class HiveIoParameter {
+
+    static final Logger LOG = LoggerFactory.getLogger(HiveIoParameter.class);
+
+    /**
+     * The batch information.
+     */
+    @ParametersDelegate
+    public final BatchInfoParameter batchInfoParameter = new BatchInfoParameter();
+
+    private List<TableLocationInfo> inputs;
+
+    private List<TableLocationInfo> outputs;
+
+    /**
+     * Returns the available Direct I/O Hive tables.
+     * @return the table information
+     */
+    public List<TableLocationInfo> getInputs() {
+        if (inputs == null) {
+            inputs = collect(HiveIoAttribute::getInputs);
+        }
+        return inputs;
+    }
+
+    /**
+     * Returns the available Direct I/O Hive tables.
+     * @return the table information
+     */
+    public List<TableLocationInfo> getOutputs() {
+        if (outputs == null) {
+            outputs = collect(HiveIoAttribute::getOutputs);
+        }
+        return outputs;
+    }
+
+    private List<TableLocationInfo> collect(Function<HiveIoAttribute, List<? extends HivePortInfo>> f) {
+        return batchInfoParameter.load().getJobflows().stream()
+                .flatMap(jobflow -> jobflow.getAttributes().stream())
+                .filter(it -> it instanceof HiveIoAttribute)
+                .map(it -> (HiveIoAttribute) it)
+                .map(f)
+                .flatMap(List::stream)
+                .map(it -> new TableLocationInfo(it.getSchema(), it.getLocation()))
+                .sorted(Comparator.comparing((TableLocationInfo it) -> it.getTable().getName())
+                        .thenComparing(it -> it.getLocation().getBasePath())
+                        .thenComparing(it -> it.getLocation().getResourcePattern()))
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Represents table schema and location.
+     * @since 0.10.0
+     */
+    public static class TableLocationInfo {
+
+        private final TableInfo table;
+
+        private final LocationInfo location;
+
+        /**
+         * Creates a new instance.
+         * @param table table information
+         * @param location location information
+         */
+        public TableLocationInfo(TableInfo table, LocationInfo location) {
+            this.table = table;
+            this.location = location;
+        }
+
+        /**
+         * Returns the table.
+         * @return the table
+         */
+        public TableInfo getTable() {
+            return table;
+        }
+
+        /**
+         * Returns the location.
+         * @return the location
+         */
+        public LocationInfo getLocation() {
+            return location;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Objects.hashCode(table);
+            result = prime * result + Objects.hashCode(location);
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            TableLocationInfo other = (TableLocationInfo) obj;
+            return Objects.equals(table, other.table) && Objects.equals(location, other.location);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s(%s)", table.getName(), location);
+        }
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/info/cli/hive/HiveTableParameter.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/hive/HiveTableParameter.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.info.cli.hive;
+
+import java.text.MessageFormat;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.info.cli.hive.HiveIoParameter.TableLocationInfo;
+import com.asakusafw.info.hive.LocationInfo;
+import com.asakusafw.info.hive.TableInfo;
+import com.asakusafw.utils.jcommander.CommandConfigurationException;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParametersDelegate;
+
+/**
+ * Provides Direct I/O Hive table information.
+ * @since 0.10.0
+ */
+public class HiveTableParameter {
+
+    static final Logger LOG = LoggerFactory.getLogger(HiveTableParameter.class);
+
+    /**
+     * The batch information.
+     */
+    @ParametersDelegate
+    public final HiveIoParameter hiveIoParameter = new HiveIoParameter();
+
+    @Parameter(
+            names = { "--table" },
+            description = "Target table name pattern ('*' as wildcard character).",
+            required = false)
+    String tableNamePatternString = "*";
+
+    private Pattern tableNamePattern;
+
+    @Parameter(
+            names = { "--direction" },
+            description = "Target port direction.",
+            required = false)
+    Direction direction = Direction.AUTO;
+
+    /**
+     * Returns the table name pattern string.
+     * @return the table name pattern string
+     */
+    public String getTableNamePatternString() {
+        return tableNamePatternString;
+    }
+
+    /**
+     * Returns the target table name pattern.
+     * @return the target table name pattern
+     */
+    public Pattern getTableNamePattern() {
+        if (tableNamePattern == null) {
+            LOG.debug("resolving table name pattern: {}", tableNamePatternString);
+            this.tableNamePattern = parseSegment(tableNamePatternString);
+        }
+        return tableNamePattern;
+    }
+
+    private static Pattern parseSegment(String pattern) {
+        StringBuilder buf = new StringBuilder();
+        int start = 0;
+        while (true) {
+            int next = pattern.indexOf('*', start);
+            if (next < 0) {
+                break;
+            }
+            if (start < next) {
+                buf.append(Pattern.quote(pattern.substring(start, next)));
+            }
+            buf.append(".*"); //$NON-NLS-1$
+            start = next + 1;
+        }
+        if (start < pattern.length()) {
+            buf.append(Pattern.quote(pattern.substring(start)));
+        }
+        try {
+            return Pattern.compile(buf.toString());
+        } catch (PatternSyntaxException e) {
+            throw new CommandConfigurationException(MessageFormat.format(
+                    "cannot recognize pattern: {0}",
+                    pattern), e);
+        }
+    }
+
+    /**
+     * Returns the target tables and their locations.
+     * @return target tables and locations
+     */
+    public Map<TableInfo, Set<LocationInfo>> collect() {
+        Map<TableInfo, Set<LocationInfo>> candidates = collect0(direction)
+                .filter(it -> getTableNamePattern().matcher(it.getTable().getName()).matches())
+                .collect(Collectors.groupingBy(
+                        TableLocationInfo::getTable,
+                        Collectors.mapping(TableLocationInfo::getLocation, Collectors.toSet())));
+        if (candidates.isEmpty()) {
+            if (collect0(direction).findAny().isPresent() == false) {
+                throw new CommandConfigurationException("there are no available tables for pattern");
+            } else {
+                throw new CommandConfigurationException(MessageFormat.format(
+                        "there are no available tables for pattern: {0}",
+                        tableNamePatternString));
+            }
+        }
+        return candidates;
+    }
+
+    Stream<TableLocationInfo> collect0(Direction d) {
+        switch (d) {
+        case INPUT:
+            return hiveIoParameter.getInputs().stream();
+        case OUTPUT:
+            return hiveIoParameter.getOutputs().stream();
+        case AUTO:
+            return Stream.concat(
+                    hiveIoParameter.getInputs().stream(),
+                    hiveIoParameter.getOutputs().stream());
+        default:
+            throw new AssertionError(direction);
+        }
+    }
+
+    /**
+     * Represents I/O port direction.
+     * @since 0.10.0
+     */
+    public enum Direction {
+
+        /**
+         * Select from input ports.
+         */
+        INPUT,
+
+        /**
+         * Select from output ports.
+         */
+        OUTPUT,
+
+        /**
+         * Select from input and output ports.
+         */
+        AUTO,
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/info/cli/hive/LocationMapper.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/hive/LocationMapper.java
@@ -1,0 +1,148 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.info.cli.hive;
+
+import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.info.hive.LocationInfo;
+
+/**
+ * Maps {@link LocationInfo} to Hadoop file location.
+ * @since 0.10.0
+ */
+public class LocationMapper implements Function<LocationInfo, Optional<String>> {
+
+    static final Logger LOG = LoggerFactory.getLogger(LocationMapper.class);
+
+    static final Pattern PATTERN_META_CHARACTER = Pattern.compile("[\\*\\?\\[\\]\\{\\}\\\\\\$]");
+
+    private static final char SEGMENT_SEPARATOR = '/';
+
+    private static final Comparator<Element> GREEDY = Comparator
+            .comparingInt((Element e) -> e.prefix.size())
+            .reversed();
+
+    private final Element[] elements;
+
+    /**
+     * Creates a new instance.
+     * @param prefixMap the base path prefix into Hadoop file location
+     */
+    public LocationMapper(Map<String, String> prefixMap) {
+        prefixMap.forEach((k, v) -> {
+            findInvalidSequence(v).ifPresent(it -> {
+                throw new IllegalArgumentException(MessageFormat.format(
+                        "substitution must not contain meta-character \"{2}\": \"{0}\" -> \"{1}\"",
+                        k, v, it));
+            });
+        });
+        elements = prefixMap.entrySet().stream()
+                .map(entry -> new Element(entry.getKey(), entry.getValue()))
+                .sorted(GREEDY)
+                .toArray(Element[]::new);
+    }
+
+    @Override
+    public Optional<String> apply(LocationInfo location) {
+        LOG.debug("finding location mapping: {}", location);
+        for (Element element : elements) {
+            LOG.debug("test location mapping: {}", element);
+            Optional<String> result = element.apply(location);
+            if (result.isPresent()) {
+                return result;
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Returns invalid sequence in the location.
+     * @param location the location
+     * @return invalid sequence in the location, or {@code empty} if it is valid
+     */
+    public Optional<String> findInvalidSequence(String location) {
+        Matcher matcher = PATTERN_META_CHARACTER.matcher(location);
+        if (matcher.find()) {
+            return Optional.of(matcher.group());
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    private static final class Element implements Function<LocationInfo, Optional<String>> {
+
+        final List<String> prefix;
+
+        final String target;
+
+        Element(String prefix, String target) {
+            this.prefix = split(prefix);
+            this.target = trimTrailingSegmentSeparators(target);
+        }
+
+        static String trimTrailingSegmentSeparators(String path) {
+            int end = path.length();
+            while (end > 0) {
+                if (path.charAt(end - 1) != SEGMENT_SEPARATOR) {
+                    break;
+                }
+                end--;
+            }
+            if (end == path.length()) {
+                return path;
+            }
+            return path.substring(0, end);
+        }
+
+        private static List<String> split(String s) {
+            return Arrays.stream(s.split(String.valueOf(SEGMENT_SEPARATOR)))
+                    .map(String::trim)
+                    .filter(it -> it.isEmpty() == false)
+                    .collect(Collectors.toList());
+        }
+
+        @Override
+        public Optional<String> apply(LocationInfo info) {
+            List<String> path = split(info.getBasePath());
+            if (path.size() < prefix.size() || prefix.equals(path.subList(0, prefix.size())) == false) {
+                return Optional.empty();
+            } else {
+                return Optional.of(Stream.concat(
+                        Stream.of(target),
+                        path.subList(prefix.size(), path.size()).stream())
+                        .collect(Collectors.joining(String.valueOf(SEGMENT_SEPARATOR))));
+            }
+        }
+
+        @Override
+        public String toString() {
+            return String.format("\"%s\" -> \"%s\"", prefix, target);
+        }
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/info/cli/hive/LocationParameter.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/hive/LocationParameter.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.info.cli.hive;
+
+import java.text.MessageFormat;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.info.hive.LocationInfo;
+import com.asakusafw.utils.jcommander.CommandConfigurationException;
+import com.beust.jcommander.DynamicParameter;
+
+/**
+ * Handles parameters about table locations.
+ * @since 0.10.0
+ */
+public class LocationParameter {
+
+    static final Logger LOG = LoggerFactory.getLogger(LocationParameter.class);
+
+    @DynamicParameter(
+            names = { "-L", "--location" },
+            description = "Table location mapping (base/path/prefix=hdfs://path/to/prefix)")
+    Map<String, String> locations = new LinkedHashMap<>();
+
+    private LocationMapper mapper;
+
+    /**
+     * Resolves the logical location information into physical one.
+     * @param source the logical location information
+     * @return related physical location, or {@code empty} if no mapping rules are registered
+     */
+    public Optional<String> resolve(LocationInfo source) {
+        LOG.debug("resolve {}: {}", source, locations);
+        if (mapper == null) {
+            if (locations.isEmpty()) {
+                return Optional.empty();
+            }
+            mapper = new LocationMapper(locations);
+        }
+        String result = mapper.apply(source)
+                .orElseThrow(() -> new CommandConfigurationException(MessageFormat.format(
+                        "there are no suitable location mapping patterns for {0}: {1}",
+                        source,
+                        locations)));
+        mapper.findInvalidSequence(result).ifPresent(it -> {
+            throw new CommandConfigurationException(MessageFormat.format(
+                    "mapping result contains invalid sequence \"{2}\": {0} -> {1}",
+                    source,
+                    result,
+                    it));
+        });
+        return Optional.of(result);
+    }
+
+    /**
+     * Resolves the candidates of logical locations into physical one.
+     * @param sources candidates of logical locations
+     * @return resolved physical location
+     */
+    public Optional<String> resolve(Collection<? extends LocationInfo> sources) {
+        List<Optional<String>> candidates = sources.stream()
+                .map(this::resolve)
+                .distinct()
+                .collect(Collectors.toList());
+        if (candidates.isEmpty()) {
+            return Optional.empty();
+        } else if (candidates.size() == 1) {
+            return candidates.get(0);
+        } else {
+            throw new CommandConfigurationException(MessageFormat.format(
+                    "ambiguous location of table: {0}",
+                    candidates.stream()
+                        .map(it -> it.orElse("(N/A)"))
+                        .collect(Collectors.joining(", "))));
+        }
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/info/cli/hive/package-info.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/hive/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Direct I/O Hive tools.
+ */
+package com.asakusafw.info.cli.hive;

--- a/info/cli/src/main/resources/META-INF/services/com.asakusafw.utils.jcommander.common.CommandProvider
+++ b/info/cli/src/main/resources/META-INF/services/com.asakusafw.utils.jcommander.common.CommandProvider
@@ -1,2 +1,3 @@
 com.asakusafw.info.cli.list.ListGroup
 com.asakusafw.info.cli.draw.DrawGroup
+com.asakusafw.info.cli.hive.HiveGroup

--- a/integration/src/integration-test/java/com/asakusafw/integration/core/OperationToolsTest.java
+++ b/integration/src/integration-test/java/com/asakusafw/integration/core/OperationToolsTest.java
@@ -121,6 +121,18 @@ public class OperationToolsTest {
     }
 
     /**
+     * portal {@code hive}.
+     */
+    @Test
+    public void portal_hive() {
+        AsakusaProject project = provider.newInstance("ptl");
+        project.gradle("installAsakusafw");
+
+        Bundle framework = project.getFramework();
+        framework.withLaunch(AsakusaConstants.CMD_PORTAL, "hive");
+    }
+
+    /**
      * portal {@code list batch}.
      */
     @Test


### PR DESCRIPTION
## Summary

This PR introduces `asakusa hive` command group.

## Background, Problem or Goal of the patch

The introduces command group includes `ddl` sub-command that generates Hive DDL script from `batch-info.json` files.

## Design of the fix, or a new feature

Note that, this command is currently experimental. The command name will be changed in future.

## Related Issue, Pull Request or Code

N/A.