### PR TITLE
Rename `asakusa` command groups.

### DIFF
--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/GenerateGroup.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/GenerateGroup.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.info.cli.hive;
+package com.asakusafw.info.cli.generate;
 
-import com.asakusafw.info.cli.list.ListHiveInputCommand;
-import com.asakusafw.info.cli.list.ListHiveOutputCommand;
+import com.asakusafw.info.cli.generate.ddl.DdlGroup;
+import com.asakusafw.info.cli.generate.dot.DotGroup;
 import com.asakusafw.utils.jcommander.CommandBuilder;
 import com.asakusafw.utils.jcommander.common.CommandProvider;
 import com.asakusafw.utils.jcommander.common.GroupUsageCommand;
@@ -27,16 +27,15 @@ import com.beust.jcommander.Parameters;
  * @since 0.10.0
  */
 @Parameters(
-        commandNames = "hive",
-        commandDescription = "Direct I/O Hive toolbox."
+        commandNames = "generate",
+        commandDescription = "Generates resources from DSL information."
 )
-public class HiveGroup extends GroupUsageCommand implements CommandProvider {
+public class GenerateGroup extends GroupUsageCommand implements CommandProvider {
 
     @Override
     public void accept(CommandBuilder<Runnable> builder) {
-        builder.addGroup(new HiveGroup(), group -> group
-                .addCommand(new HiveDdlCommand())
-                .addCommand(new ListHiveInputCommand())
-                .addCommand(new ListHiveOutputCommand()));
+        builder.addGroup(new GenerateGroup(), group -> group
+                .configure(new DotGroup())
+                .configure(new DdlGroup()));
     }
 }

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/DdlGroup.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/DdlGroup.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.info.cli.generate.ddl;
+
+import com.asakusafw.utils.jcommander.CommandBuilder;
+import com.asakusafw.utils.jcommander.common.CommandProvider;
+import com.asakusafw.utils.jcommander.common.GroupUsageCommand;
+import com.beust.jcommander.Parameters;
+
+/**
+ * A group command for Direct I/O Hive tools.
+ * @since 0.10.0
+ */
+@Parameters(
+        commandNames = "ddl",
+        commandDescription = "Generates DDL scripts."
+)
+public class DdlGroup extends GroupUsageCommand implements CommandProvider {
+
+    @Override
+    public void accept(CommandBuilder<Runnable> builder) {
+        builder.addGroup(new DdlGroup(), group -> group
+                .addCommand(new DdlHiveCommand()));
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/DdlHiveCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/DdlHiveCommand.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.info.cli.hive;
+package com.asakusafw.info.cli.generate.ddl;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -49,12 +49,12 @@ import com.beust.jcommander.ParametersDelegate;
  * @since 0.10.0
  */
 @Parameters(
-        commandNames = "ddl",
+        commandNames = "hive",
         commandDescription = "Generates Hive DDL."
 )
-public class HiveDdlCommand implements Runnable {
+public class DdlHiveCommand implements Runnable {
 
-    static final Logger LOG = LoggerFactory.getLogger(HiveDdlCommand.class);
+    static final Logger LOG = LoggerFactory.getLogger(DdlHiveCommand.class);
 
     static final String STATEMENT_SEPARATOR = ";"; //$NON-NLS-1$
 

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/HiveIoParameter.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/HiveIoParameter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.info.cli.hive;
+package com.asakusafw.info.cli.generate.ddl;
 
 import java.util.Comparator;
 import java.util.List;

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/HiveTableParameter.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/HiveTableParameter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.info.cli.hive;
+package com.asakusafw.info.cli.generate.ddl;
 
 import java.text.MessageFormat;
 import java.util.Map;
@@ -26,7 +26,7 @@ import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.asakusafw.info.cli.hive.HiveIoParameter.TableLocationInfo;
+import com.asakusafw.info.cli.generate.ddl.HiveIoParameter.TableLocationInfo;
 import com.asakusafw.info.hive.LocationInfo;
 import com.asakusafw.info.hive.TableInfo;
 import com.asakusafw.utils.jcommander.CommandConfigurationException;

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/LocationMapper.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/LocationMapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2011-2016 Asakusa Framework Team.
+ * Copyright 2011-2017 Asakusa Framework Team.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/LocationMapper.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/LocationMapper.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.info.cli.hive;
+package com.asakusafw.info.cli.generate.ddl;
 
 import java.text.MessageFormat;
 import java.util.Arrays;

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/LocationParameter.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/LocationParameter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.info.cli.hive;
+package com.asakusafw.info.cli.generate.ddl;
 
 import java.text.MessageFormat;
 import java.util.Collection;

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/package-info.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/ddl/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Implementations of {@code generate ddl} group.
+ */
+package com.asakusafw.info.cli.generate.ddl;

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/DotGroup.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/DotGroup.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.info.cli.draw;
+package com.asakusafw.info.cli.generate.dot;
 
 import com.asakusafw.utils.jcommander.CommandBuilder;
 import com.asakusafw.utils.jcommander.common.CommandProvider;
@@ -21,18 +21,18 @@ import com.asakusafw.utils.jcommander.common.GroupUsageCommand;
 import com.beust.jcommander.Parameters;
 
 /**
- * A group command for draw.
+ * A group command for Graphviz DOT.
  * @since 0.10.0
  */
 @Parameters(
-        commandNames = "draw",
+        commandNames = "dot",
         commandDescription = "Generates information graph as Graphviz DOT scripts."
 )
-public class DrawGroup extends GroupUsageCommand implements CommandProvider {
+public class DotGroup extends GroupUsageCommand implements CommandProvider {
 
     @Override
     public void accept(CommandBuilder<Runnable> builder) {
-        builder.addGroup(new DrawGroup(), group -> group
+        builder.addGroup(new DotGroup(), group -> group
                 .addCommand(new DrawJobflowCommand())
                 .addCommand(new DrawOperatorCommand())
                 .addCommand(new DrawPlanCommand()));

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/DotParameter.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/DotParameter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.info.cli.draw;
+package com.asakusafw.info.cli.generate.dot;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -21,10 +21,10 @@ import java.util.Map;
 import com.beust.jcommander.DynamicParameter;
 
 /**
- * Provides graphviz options.
+ * Provides graphviz DOT options.
  * @since 0.10.0
  */
-public class GraphvizParameter {
+public class DotParameter {
 
     @DynamicParameter(
             names = { "-G", "--graph-option" },

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/DrawEngine.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/DrawEngine.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.info.cli.draw;
+package com.asakusafw.info.cli.generate.dot;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import com.asakusafw.info.cli.draw.Drawer.Shape;
+import com.asakusafw.info.cli.generate.dot.Drawer.Shape;
 import com.asakusafw.info.operator.CoreOperatorSpec;
 import com.asakusafw.info.operator.CustomOperatorSpec;
 import com.asakusafw.info.operator.FlowOperatorSpec;

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/DrawJobflowCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/DrawJobflowCommand.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.info.cli.draw;
+package com.asakusafw.info.cli.generate.dot;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 import com.asakusafw.info.BatchInfo;
 import com.asakusafw.info.JobflowInfo;
 import com.asakusafw.info.cli.common.BatchInfoParameter;
-import com.asakusafw.info.cli.draw.Drawer.Shape;
+import com.asakusafw.info.cli.generate.dot.Drawer.Shape;
 import com.asakusafw.info.graph.Node;
 import com.asakusafw.info.task.TaskInfo;
 import com.asakusafw.info.task.TaskListAttribute;
@@ -63,7 +63,7 @@ public class DrawJobflowCommand implements Runnable {
     final ShowAllParameter verboseParameter = new ShowAllParameter();
 
     @ParametersDelegate
-    final GraphvizParameter graphvizParameter = new GraphvizParameter();
+    final DotParameter graphvizParameter = new DotParameter();
 
     @ParametersDelegate
     final OutputParameter outputParameter = new OutputParameter();

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/DrawOperatorCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/DrawOperatorCommand.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.info.cli.draw;
+package com.asakusafw.info.cli.generate.dot;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 import com.asakusafw.info.JobflowInfo;
 import com.asakusafw.info.cli.common.FlowPartSelectorParameter;
 import com.asakusafw.info.cli.common.JobflowInfoParameter;
-import com.asakusafw.info.cli.draw.DrawEngine.Feature;
+import com.asakusafw.info.cli.generate.dot.DrawEngine.Feature;
 import com.asakusafw.info.operator.FlowOperatorSpec;
 import com.asakusafw.info.operator.OperatorGraphAttribute;
 import com.asakusafw.info.operator.view.OperatorGraphView;
@@ -65,7 +65,7 @@ public class DrawOperatorCommand implements Runnable {
     final FlowPartSelectorParameter flowPartSelectorParameter = new FlowPartSelectorParameter();
 
     @ParametersDelegate
-    final GraphvizParameter graphvizParameter = new GraphvizParameter();
+    final DotParameter graphvizParameter = new DotParameter();
 
     @ParametersDelegate
     final OutputParameter outputParameter = new OutputParameter();

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/DrawPlanCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/DrawPlanCommand.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.info.cli.draw;
+package com.asakusafw.info.cli.generate.dot;
 
 import java.io.PrintWriter;
 import java.text.MessageFormat;
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 import com.asakusafw.info.JobflowInfo;
 import com.asakusafw.info.cli.common.JobflowInfoParameter;
 import com.asakusafw.info.cli.common.VertexSelectorParameter;
-import com.asakusafw.info.cli.draw.DrawEngine.Feature;
+import com.asakusafw.info.cli.generate.dot.DrawEngine.Feature;
 import com.asakusafw.info.operator.view.OperatorGraphView;
 import com.asakusafw.info.operator.view.OperatorView;
 import com.asakusafw.info.plan.PlanAttribute;
@@ -67,7 +67,7 @@ public class DrawPlanCommand implements Runnable {
     final VertexSelectorParameter vertexSelectorParameter = new VertexSelectorParameter();
 
     @ParametersDelegate
-    final GraphvizParameter graphvizParameter = new GraphvizParameter();
+    final DotParameter graphvizParameter = new DotParameter();
 
     @ParametersDelegate
     final OutputParameter outputParameter = new OutputParameter();

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/Drawer.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/Drawer.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.info.cli.draw;
+package com.asakusafw.info.cli.generate.dot;
 
 import java.io.PrintWriter;
 import java.util.ArrayList;

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/ShowAllParameter.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/ShowAllParameter.java
@@ -13,7 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package com.asakusafw.info.cli.generate.dot;
+
+import com.beust.jcommander.Parameter;
+
 /**
- * Direct I/O Hive tools.
+ * Provides verbose flag for draw group.
+ * @since 0.10.0
  */
-package com.asakusafw.info.cli.hive;
+public class ShowAllParameter {
+
+    /**
+     * Whether or not the help message is required.
+     */
+    @Parameter(
+            names = { "-v", "--verbose", "--show-all", },
+            description = "Displays all optional information.",
+            required = false
+    )
+    public boolean required = false;
+
+    /**
+     * Returns the required.
+     * @return the required
+     */
+    public boolean isRequired() {
+        return required;
+    }
+}

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/package-info.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/dot/package-info.java
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Implementations of {@code draw} group.
+ * Implementations of {@code generate dot} group.
  */
-package com.asakusafw.info.cli.draw;
+package com.asakusafw.info.cli.generate.dot;

--- a/info/cli/src/main/java/com/asakusafw/info/cli/generate/package-info.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/generate/package-info.java
@@ -13,31 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.asakusafw.info.cli.draw;
-
-import com.beust.jcommander.Parameter;
-
 /**
- * Provides verbose flag for draw group.
- * @since 0.10.0
+ * Implementations of {@code generate} group.
  */
-public class ShowAllParameter {
-
-    /**
-     * Whether or not the help message is required.
-     */
-    @Parameter(
-            names = { "-v", "--verbose", "--show-all", },
-            description = "Displays all optional information.",
-            required = false
-    )
-    public boolean required = false;
-
-    /**
-     * Returns the required.
-     * @return the required
-     */
-    public boolean isRequired() {
-        return required;
-    }
-}
+package com.asakusafw.info.cli.generate;

--- a/info/cli/src/main/resources/META-INF/services/com.asakusafw.utils.jcommander.common.CommandProvider
+++ b/info/cli/src/main/resources/META-INF/services/com.asakusafw.utils.jcommander.common.CommandProvider
@@ -1,3 +1,2 @@
 com.asakusafw.info.cli.list.ListGroup
-com.asakusafw.info.cli.draw.DrawGroup
-com.asakusafw.info.cli.hive.HiveGroup
+com.asakusafw.info.cli.generate.GenerateGroup

--- a/integration/src/integration-test/java/com/asakusafw/integration/core/OperationToolsTest.java
+++ b/integration/src/integration-test/java/com/asakusafw/integration/core/OperationToolsTest.java
@@ -97,7 +97,7 @@ public class OperationToolsTest {
     }
 
     /**
-     * portal {@code draw}.
+     * portal {@code generate}.
      */
     @Test
     public void portal_draw() {
@@ -105,7 +105,7 @@ public class OperationToolsTest {
         project.gradle("installAsakusafw");
 
         Bundle framework = project.getFramework();
-        framework.withLaunch(AsakusaConstants.CMD_PORTAL, "draw");
+        framework.withLaunch(AsakusaConstants.CMD_PORTAL, "generate");
     }
 
     /**
@@ -118,18 +118,6 @@ public class OperationToolsTest {
 
         Bundle framework = project.getFramework();
         framework.withLaunch(AsakusaConstants.CMD_PORTAL, "run", "--help");
-    }
-
-    /**
-     * portal {@code hive}.
-     */
-    @Test
-    public void portal_hive() {
-        AsakusaProject project = provider.newInstance("ptl");
-        project.gradle("installAsakusafw");
-
-        Bundle framework = project.getFramework();
-        framework.withLaunch(AsakusaConstants.CMD_PORTAL, "hive");
     }
 
     /**

--- a/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/CommandBuilder.java
+++ b/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/CommandBuilder.java
@@ -25,6 +25,16 @@ import java.util.function.Consumer;
 public interface CommandBuilder<T> {
 
     /**
+     * Configures this object.
+     * @param configurator the configurator
+     * @return this
+     */
+    default CommandBuilder<T> configure(Consumer<? super CommandBuilder<T>> configurator) {
+        configurator.accept(this);
+        return this;
+    }
+
+    /**
      * Adds a leaf command.
      * @param command the command object
      * @return this

--- a/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/JCommanderWrapper.java
+++ b/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/JCommanderWrapper.java
@@ -74,8 +74,9 @@ public class JCommanderWrapper<T> implements CommandBuilder<T> {
      * @param configurator the configurator
      * @return this
      */
+    @Override
     public JCommanderWrapper<T> configure(Consumer<? super CommandBuilder<T>> configurator) {
-        configurator.accept(this);
+        root.configure(configurator);
         return this;
     }
 


### PR DESCRIPTION
## Summary

This PR renames `asakusa` command groups.

## Background, Problem or Goal of the patch

`asakusa hive` command introduced #774 is out of alignment from the existing command groups, so that we rearrange some commands.

* `asakusa draw ...` -> `asakusa generate dot ...`
* `asakusa hive ddl` -> `asakusa generate ddl hive`
* `asakusa hive {input,output}` -> N/A
  * they are alias of `asakusa list hive {input,output}`

Finally, `asakusa` has the following command groups:

```
    generate - Generates resources from DSL information.
    list - Displays DSL information as list style.
    run - Runs a batch application.
```

## Design of the fix, or a new feature

Note that, some integration tests in the downstream projects will be broken.

## Related Issue, Pull Request or Code

* #774
