### PR TITLE
Fix base dir of `--output` in `asakusa` command.

### DIFF
--- a/info/cli/src/main/java/com/asakusafw/info/cli/common/ApplicationBaseDirectoryParameter.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/common/ApplicationBaseDirectoryParameter.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.asakusafw.utils.jcommander.CommandConfigurationException;
+import com.asakusafw.utils.jcommander.common.LocalPath;
 import com.beust.jcommander.Parameter;
 
 /**
@@ -86,7 +87,7 @@ public class ApplicationBaseDirectoryParameter {
             return Optional.empty();
         }
         return Optional.of(path)
-                .map(Paths::get)
+                .map(LocalPath::of)
                 .filter(Files::isDirectory);
     }
 
@@ -102,7 +103,7 @@ public class ApplicationBaseDirectoryParameter {
                     ENV_ASAKUSA_HOME,
                     OPT_BATCHAPPS));
         }
-        Path result = Paths.get(path);
+        Path result = LocalPath.of(path);
         if (Files.isDirectory(result) == false) {
             throw new CommandConfigurationException(MessageFormat.format(
                     "batch applications directory is not found: {0}",

--- a/info/cli/src/main/java/com/asakusafw/info/cli/common/BatchInfoParameter.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/common/BatchInfoParameter.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 
 import com.asakusafw.info.BatchInfo;
 import com.asakusafw.utils.jcommander.CommandConfigurationException;
+import com.asakusafw.utils.jcommander.common.LocalPath;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -86,7 +87,7 @@ public class BatchInfoParameter {
      * @return the information file path, or {@code empty} if it is not found
      */
     public static Optional<Path> findInfo(Path applicationBaseDir, String location) {
-        Path path = Paths.get(location);
+        Path path = LocalPath.of(location);
         // just batch-info.json
         if (Files.isRegularFile(path)) {
             return Optional.of(path);
@@ -99,8 +100,9 @@ public class BatchInfoParameter {
             }
         }
         // may be a batch ID
-        if (path.isAbsolute() == false && path.getNameCount() == 1 && applicationBaseDir != null) {
-            Path applicationDir = applicationBaseDir.resolve(path.toString());
+        Path purePath = Paths.get(location);
+        if (purePath.isAbsolute() == false && purePath.getNameCount() == 1 && applicationBaseDir != null) {
+            Path applicationDir = applicationBaseDir.resolve(purePath.toString());
             Optional<Path> info = ApplicationBaseDirectoryParameter.findInfo(applicationDir);
             if (info.isPresent()) {
                 return info;

--- a/operation-project/command-portal/src/main/dist/bin/asakusa
+++ b/operation-project/command-portal/src/main/dist/bin/asakusa
@@ -16,6 +16,7 @@
 #
 
 _ROOT="${ASAKUSA_HOME:?ASAKUSA_HOME is not defined}/tools"
+export CALLER_CWD="$(pwd)"
 
 cd
 

--- a/operation-project/command-portal/src/main/dist/bin/asakusa.cmd
+++ b/operation-project/command-portal/src/main/dist/bin/asakusa.cmd
@@ -22,6 +22,7 @@ if not defined ASAKUSA_HOME (
     exit /b 1
 )
 
+set CALLER_CWD=%cd%
 cd /d %USERPROFILE%
 
 set libdir=%ASAKUSA_HOME%\tools\lib

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/common/ConfigurationParameter.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/common/ConfigurationParameter.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.asakusafw.utils.jcommander.common.LocalPath;
 import com.beust.jcommander.Parameter;
 
 /**
@@ -57,7 +58,7 @@ public class ConfigurationParameter {
      * @return the configuration path
      */
     public Optional<Path> getPath() {
-        return Optional.ofNullable(path).map(Paths::get);
+        return Optional.ofNullable(path).map(LocalPath::of);
     }
 
     /**
@@ -70,7 +71,7 @@ public class ConfigurationParameter {
             if (path == null) {
                 LOG.warn("environment variable {} is not defined", ENV_ASAKUSA_HOME);
             } else {
-                Path p = Paths.get(path);
+                Path p = LocalPath.of(path);
                 LOG.debug("loading configuration: {}", p);
                 if (Files.isRegularFile(p)) {
                     try {

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/LocalPathParameter.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/LocalPathParameter.java
@@ -16,14 +16,11 @@
 package com.asakusafw.operation.tools.directio.file;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.text.MessageFormat;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.asakusafw.utils.jcommander.CommandConfigurationException;
+import com.asakusafw.utils.jcommander.common.LocalPath;
 import com.beust.jcommander.Parameter;
 
 /**
@@ -34,20 +31,12 @@ public class LocalPathParameter {
 
     static final Logger LOG = LoggerFactory.getLogger(LocalPathParameter.class);
 
-    static final String KEY_WORKING_DIRECTORY = "cli.cwd";
-
-    static final String ENV_WORKING_DIRECTORY = "CALLER_CWD";
-
     @Parameter(
             names = { "--working-directory" },
-            description = "",
+            description = "base path of local files (only for testing).",
             required = false,
             hidden = true)
-    Path workingDirectory = Optional.ofNullable(
-            System.getProperty(KEY_WORKING_DIRECTORY, System.getenv(ENV_WORKING_DIRECTORY)))
-            .filter(it -> it.isEmpty() == false)
-            .map(Paths::get)
-            .orElse(null);
+    Path workingDirectory;
 
     /**
      * Resolves the given path.
@@ -55,22 +44,6 @@ public class LocalPathParameter {
      * @return the corresponded local file path
      */
     public Path resolve(String path) {
-        Path candidate = Paths.get(path);
-        if (candidate.isAbsolute()) {
-            return candidate;
-        } else if (workingDirectory != null) {
-            if (workingDirectory.isAbsolute() == false) {
-                throw new CommandConfigurationException(MessageFormat.format(
-                        "custom working dierctory path must be absolute: {0}",
-                        workingDirectory));
-            }
-            Path result = workingDirectory.resolve(path);
-            LOG.debug("resolve local path: {} -> {}", path, result);
-            return result;
-        } else {
-            throw new CommandConfigurationException(MessageFormat.format(
-                    "local file path must be absolute: {0}",
-                    path));
-        }
+        return LocalPath.of(path, workingDirectory);
     }
 }

--- a/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/common/LocalPath.java
+++ b/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/common/LocalPath.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.utils.jcommander.common;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.MessageFormat;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.utils.jcommander.CommandConfigurationException;
+
+/**
+ * Utilities about local path.
+ * @since 0.10.0
+ */
+public final class LocalPath {
+
+    static final Logger LOG = LoggerFactory.getLogger(LocalPath.class);
+
+    static final String KEY_WORKING_DIRECTORY = "cli.cwd";
+
+    static final String ENV_WORKING_DIRECTORY = "CALLER_CWD";
+
+    private static final Path WORKING_DIRECTORY;
+
+    static {
+        WORKING_DIRECTORY = Optional.ofNullable(
+                System.getProperty(KEY_WORKING_DIRECTORY, System.getenv(ENV_WORKING_DIRECTORY)))
+                .filter(it -> it.isEmpty() == false)
+                .map(Paths::get)
+                .orElse(null);
+    }
+
+    private LocalPath() {
+        return;
+    }
+
+    /**
+     * Returns the custom working directory.
+     * @return the custom working directory, or {@code empty} if it is not defined
+     */
+    public static Optional<Path> findWorkingDirectory() {
+        return Optional.ofNullable(WORKING_DIRECTORY);
+    }
+
+    /**
+     * Returns a local path.
+     * This is an alias of {@code #of(String, Path) of(path, Paths.get("."))}.
+     * @param path the path string
+     * @return the local path
+     * @throws CommandConfigurationException if the path cannot be resolved
+     */
+    public static Path of(String path) {
+        return of(path, Paths.get("."));
+    }
+
+    /**
+     * Returns a local path.
+     * @param path the path string
+     * @param defaultWorkingDirectory the default working directory (nullable)
+     * @return the local path
+     * @throws CommandConfigurationException if the path cannot be resolved
+     */
+    public static Path of(String path, Path defaultWorkingDirectory) {
+        Path candidate = Paths.get(path);
+        if (candidate.isAbsolute()) {
+            return candidate;
+        } else if (WORKING_DIRECTORY != null) {
+            if (WORKING_DIRECTORY.isAbsolute() == false) {
+                throw new CommandConfigurationException(MessageFormat.format(
+                        "custom working dierctory path must be absolute: {0}",
+                        WORKING_DIRECTORY));
+            }
+            Path result = WORKING_DIRECTORY.resolve(path);
+            LOG.debug("resolve local path: {} -> {}", path, result);
+            return result;
+        } else if (defaultWorkingDirectory != null) {
+            return defaultWorkingDirectory.resolve(path).toAbsolutePath();
+        } else {
+            throw new CommandConfigurationException(MessageFormat.format(
+                    "local file path must be absolute: {0}",
+                    path));
+        }
+    }
+}

--- a/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/common/OutputParameter.java
+++ b/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/common/OutputParameter.java
@@ -21,7 +21,6 @@ import java.io.PrintWriter;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.text.MessageFormat;
 import java.util.Objects;
 
@@ -76,7 +75,7 @@ public class OutputParameter {
                     }
                 };
             } else {
-                Path file = Paths.get(output).toAbsolutePath();
+                Path file = LocalPath.of(output);
                 Path parent = file.getParent();
                 if (parent != null) {
                     Files.createDirectories(parent);


### PR DESCRIPTION
## Summary

This PR fixes `--output` option of `asakusa` command. Its relative path will be resolved as wrong path.

## Background, Problem or Goal of the patch

`asakusa` command always works on the `$HOME` (or `%USERPROFILE%`) directory because `asakusa run` requires such the working directory, but it also makes relative paths wrong.

## Design of the fix, or a new feature

We keeps the original working directory into the environment variable `CALLER_CWD`, and resolves each relative path with the original one.

This PR will fix the following local paths:
* `--output` parameter of `asakusa` and `directio` command
* `--batchapps` parameter of `asakusa` command
* `--configuration` parameter of `directio` command
* Batch application directories in `asakusa` command parameter

## Related Issue, Pull Request or Code

* #750 
* #765 