### PR TITLE
Fix error messages of views with invalid types on tests.

### DIFF
--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/BasicGroupLoader.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/BasicGroupLoader.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import com.asakusafw.runtime.core.GroupView;
@@ -206,7 +207,9 @@ public class BasicGroupLoader<T> implements GroupLoader<T> {
                                 "invalid key element type at {0}: required={1}, specified={2}",
                                 i,
                                 types[i].name(),
-                                actual.getSimpleName()));
+                                Optional.ofNullable(elements[i])
+                                    .map(it -> it.getClass().getSimpleName())
+                                    .orElseGet(() -> actual.getSimpleName())));
                     }
                 }
                 key.add(value);

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/BasicGroupLoader.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/BasicGroupLoader.java
@@ -210,18 +210,18 @@ public class BasicGroupLoader<T> implements GroupLoader<T> {
                                 .map(it -> it.getClass().getSimpleName())
                                 .orElse("null")), e); //$NON-NLS-1$
                 }
-                Class<?> expect = types[i].getRepresentation();
-                Class<?> actual = Optional.ofNullable(value)
-                        .map(Object::getClass)
-                        .orElse(null);
-                if (actual == null || expect.isAssignableFrom(actual) == false) {
-                    throw new IllegalArgumentException(MessageFormat.format(
-                            "invalid key element type at {0}: required={1}, specified={2}",
-                            i,
-                            types[i].name(),
-                            Optional.ofNullable(elements[i])
-                                .map(it -> it.getClass().getSimpleName())
-                                .orElse("null")));
+                if (value != null) {
+                    Class<?> expect = types[i].getRepresentation();
+                    Class<?> actual = value.getClass();
+                    if (expect.isAssignableFrom(actual) == false) {
+                        throw new IllegalArgumentException(MessageFormat.format(
+                                "invalid key element type at {0}: required={1}, specified={2}",
+                                i,
+                                types[i].name(),
+                                Optional.ofNullable(elements[i])
+                                    .map(it -> it.getClass().getSimpleName())
+                                    .orElse("null")));
+                    }
                 }
                 key.add(value);
             }

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/BasicGroupLoader.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/BasicGroupLoader.java
@@ -206,7 +206,7 @@ public class BasicGroupLoader<T> implements GroupLoader<T> {
                                 "invalid key element type at {0}: required={1}, specified={2}",
                                 i,
                                 types[i].name(),
-                                expect.getSimpleName()));
+                                actual.getSimpleName()));
                     }
                 }
                 key.add(value);


### PR DESCRIPTION
## Summary

This PR fixes error messages of `GroupView.find()` with inconsistent argument types on tests.

## Background, Problem or Goal of the patch

`OperatorTestEnvironment.loader()` can provide `GroupLoader`s but it `.find()` methods will raise error with confusing messages when argument types are wrong.

## Design of the fix, or a new feature

N/A.
