### PR TITLE
CoGroup with no input (but views) should be compile error.

### DIFF
--- a/operator/builtin/src/test/java/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.java
+++ b/operator/builtin/src/test/java/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.java
@@ -520,4 +520,12 @@ public class CoGroupOperatorDriverTest extends OperatorDriverTestRoot {
     public void violate_group_view_with_key() {
         violate("com.example.ViolateGroupViewWithKey");
     }
+
+    /**
+     * violates input exists.
+     */
+    @Test
+    public void violate_with_input_view() {
+        violate("com.example.ViolateWithInputView");
+    }
 }

--- a/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.files/com/example/ViolateWithInputView.java.txt
+++ b/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/CoGroupOperatorDriverTest.files/com/example/ViolateWithInputView.java.txt
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.util.List;
+import com.asakusafw.runtime.core.*;
+import com.asakusafw.vocabulary.model.Key;
+import com.asakusafw.vocabulary.operator.*;
+
+public abstract class $s {
+
+    @CoGroup
+    public void method(@Key(group = "content") GroupView<Model> in, Result<Proceeded> out) {
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes operator compiler to raise errors for `@CoGroup` operator without standard inputs.

## Background, Problem or Goal of the patch

The latest implementation does not raise errors for the following method:

```java
@CoGroup
public void method(@Key(group = "content") GroupView<Model> in, Result<Proceeded> out) {
...
}
```

It must have one or more input parameters other than views.

## Design of the fix, or a new feature

The compiler has also assumed views as standard inputs. It slips through operator input validation - each operator must have one or more inputs.

## Related Issue, Pull Request or Code

N/A.