### PR TITLE
Add `directio {copy,move}` commands.

### DIFF
--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/AbstractFileCopyCommand.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/AbstractFileCopyCommand.java
@@ -196,7 +196,7 @@ public abstract class AbstractFileCopyCommand implements Runnable {
                         throw new CommandConfigurationException(MessageFormat.format(
                                 "destination file already exists: {0} ({1})",
                                 dst,
-                                src));
+                                src.getPath()));
                     }
                 });
         try (PrintWriter writer = outputParameter.open()) {

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/AbstractFileCopyCommand.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/AbstractFileCopyCommand.java
@@ -1,0 +1,314 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.operation.tools.directio.file;
+
+import static com.asakusafw.operation.tools.directio.file.Util.*;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.operation.tools.directio.DirectIoPath;
+import com.asakusafw.operation.tools.directio.common.ExecutorParameter;
+import com.asakusafw.operation.tools.directio.common.Task;
+import com.asakusafw.runtime.directio.ResourceInfo;
+import com.asakusafw.runtime.directio.hadoop.HadoopDataSourceCore;
+import com.asakusafw.utils.jcommander.CommandConfigurationException;
+import com.asakusafw.utils.jcommander.CommandExecutionException;
+import com.asakusafw.utils.jcommander.common.HelpParameter;
+import com.asakusafw.utils.jcommander.common.OutputParameter;
+import com.asakusafw.utils.jcommander.common.VerboseParameter;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParametersDelegate;
+
+/**
+ * An abstract implementation of command for copying/moving Direct I/O resources.
+ * @since 0.10.0
+ */
+public abstract class AbstractFileCopyCommand implements Runnable {
+
+    static final Logger LOG = LoggerFactory.getLogger(AbstractFileCopyCommand.class);
+
+    @ParametersDelegate
+    final HelpParameter helpParameter = new HelpParameter();
+
+    @ParametersDelegate
+    final VerboseParameter verboseParameter = new VerboseParameter();
+
+    @ParametersDelegate
+    final OutputParameter outputParameter = new OutputParameter();
+
+    @ParametersDelegate
+    final DataSourceParameter dataSourceParameter = new DataSourceParameter();
+
+    @ParametersDelegate
+    final LocalPathParameter localPathParameter = new LocalPathParameter();
+
+    @ParametersDelegate
+    final ExecutorParameter executorParameter = new ExecutorParameter();
+
+    @Parameter(
+            description = "source-directio-path.. destination-directio-path",
+            required = false)
+    List<String> paths = new ArrayList<>();
+
+    @Parameter(
+            names = { "-w", "--overwrite" },
+            description = "Overwrite destination files.",
+            required = false)
+    boolean overwrite = false;
+
+    abstract Op getOp();
+
+    @Override
+    public void run() {
+        LOG.debug("starting {}", getClass().getSimpleName());
+
+        if (paths.size() < 2) {
+            throw new CommandConfigurationException("source and destination files must be specified");
+        }
+        List<DirectIoPath> sources = getSources();
+        LOG.debug("source: {}", sources);
+
+        Path destination = getDestination();
+        LOG.debug("destination: {}", destination);
+
+        List<ResourceInfo> files = sources.stream()
+                .flatMap(it -> {
+                    List<ResourceInfo> list = FileListCommand.list(it);
+                    if (list.isEmpty()) {
+                        throw new CommandConfigurationException(MessageFormat.format(
+                                "there are no files to copy: {0}",
+                                it));
+                    }
+                    return list.stream();
+                })
+                .collect(Collectors.toList());
+
+        Optional<org.apache.hadoop.fs.FileStatus> stat = stat(destination);
+        if (stat.filter(it -> it.isDirectory()).isPresent()) {
+            copyOnto(files, destination);
+        } else if (stat.filter(it -> it.isDirectory() == false).isPresent() && overwrite == false) {
+            throw new CommandExecutionException(MessageFormat.format(
+                    "destination file already exists: {0}",
+                    destination));
+        } else {
+            Path parent = Optional.ofNullable(destination.getParent())
+                    .orElseThrow(() -> new IllegalStateException(destination.toString()));
+            if (stat(parent).filter(it -> it.isDirectory()).isPresent()) {
+                if (sources.size() >= 2) {
+                    throw new CommandConfigurationException(MessageFormat.format(
+                            "copy source is ambiguous: {0}",
+                            sources.stream()
+                                    .map(String::valueOf)
+                                    .collect(Collectors.joining(", "))));
+                }
+                copyTo(files.get(0), destination);
+            } else {
+                throw new CommandConfigurationException(MessageFormat.format(
+                        "destination directory does not exist: {0}",
+                        parent));
+            }
+        }
+    }
+
+    private Optional<org.apache.hadoop.fs.FileStatus> stat(Path path) {
+        try {
+            return Optional.of(dataSourceParameter.getHadoopFileSystem(path).getFileStatus(path));
+        } catch (FileNotFoundException e) {
+            LOG.trace("not found: {}", path, e);
+            return Optional.empty();
+        } catch (IOException e) {
+            throw new CommandConfigurationException(MessageFormat.format(
+                    "error occurred while resolving Hadoop path: {0}",
+                    path), e);
+        }
+    }
+
+    private void copyOnto(List<ResourceInfo> sources, Path destination) {
+        sources.stream()
+                .filter(it -> isRecursive() || it.isDirectory() == false)
+                .collect(Collectors.groupingBy(it -> asHadoopPath(it.getPath()).getName()))
+                .forEach((k, v) -> {
+                    Path dst = resolve(destination, k);
+                    if (v.size() >= 2) {
+                        throw new CommandExecutionException(MessageFormat.format(
+                                "conflict destination file \"{0}\": {1}",
+                                dst,
+                                v.stream()
+                                        .map(String::valueOf)
+                                        .collect(Collectors.joining(", "))));
+                    }
+                    ResourceInfo src = v.get(0);
+                    if (overwrite == false && stat(dst).isPresent()) {
+                        throw new CommandExecutionException(MessageFormat.format(
+                                "destination file already exists: {0} ({1})",
+                                dst,
+                                src));
+                    }
+                });
+        try (PrintWriter writer = outputParameter.open()) {
+            executorParameter.execute(sources.stream()
+                    .map(source -> {
+                        Path src = asHadoopPath(source.getPath());
+                        Path dst = resolve(destination, src.getName());
+                        return new Copy(
+                                writer,
+                                dataSourceParameter.getHadoopFileSystem(src), src,
+                                dataSourceParameter.getHadoopFileSystem(dst), dst);
+                    })
+                    .collect(Collectors.toList()));
+        }
+    }
+
+    private void copyTo(ResourceInfo source, Path destination) {
+        try (PrintWriter writer = outputParameter.open()) {
+            org.apache.hadoop.fs.Path src = asHadoopPath(source.getPath());
+            Path dst = destination;
+            executorParameter.execute(new Copy(
+                    writer,
+                    dataSourceParameter.getHadoopFileSystem(src), src,
+                    dataSourceParameter.getHadoopFileSystem(dst), dst));
+        }
+    }
+
+    private List<DirectIoPath> getSources() {
+        List<DirectIoPath> dpaths = paths.subList(0, paths.size() - 1).stream()
+                .map(dataSourceParameter::resolve)
+                .peek(it -> {
+                    if (it.isComponentRoot()) {
+                        throw new CommandConfigurationException(MessageFormat.format(
+                                "cannot copy data source root \"{0}\"",
+                                it));
+                    }
+                    if (it.getSource().getEntity().findProperty(HadoopDataSourceCore.class).isPresent() == false) {
+                        throw new CommandConfigurationException(MessageFormat.format(
+                                "unsupported data source \"{0}\" (type: {1}): {2}",
+                                it.getSource().getId(),
+                                it.getSource().getEntity().getClass().getName(),
+                                it));
+                    }
+                })
+                .collect(Collectors.toList());
+        return dpaths;
+    }
+
+    private Path getDestination() {
+        return dataSourceParameter.resolveAsHadoopPath(paths.get(paths.size() - 1));
+    }
+
+    boolean isRecursive() {
+        return getOp() != Op.COPY_THIN;
+    }
+
+    boolean isMove() {
+        return getOp() == Op.MOVE;
+    }
+
+    Configuration getConf() {
+        return dataSourceParameter.getConfiguration();
+    }
+
+    enum Op {
+
+        COPY_THIN,
+
+        COPY_RECURSIVE,
+
+        MOVE,
+    }
+
+    private class Copy implements Task {
+
+        private final PrintWriter writer;
+
+        private final org.apache.hadoop.fs.FileSystem srcFs;
+
+        private final org.apache.hadoop.fs.FileSystem dstFs;
+
+        private final Path source;
+
+        private final Path destination;
+
+        Copy(PrintWriter writer,
+                FileSystem srcFs, Path source,
+                FileSystem dstFs, Path destination) {
+            this.writer = writer;
+            this.srcFs = srcFs;
+            this.dstFs = dstFs;
+            this.source = source;
+            this.destination = destination;
+        }
+
+        @Override
+        public void execute(Context context) {
+            try {
+                FileStatus stat = srcFs.getFileStatus(source);
+                LOG.debug("process: {} (dir={})", stat.getPath(), stat.isDirectory());
+                if (stat.isDirectory()) {
+                    if (isRecursive()) {
+                        if (dstFs.isFile(destination)) {
+                            throw new IOException(MessageFormat.format(
+                                    "cannot overwrite file by directory: {0} -> {1}",
+                                    source, destination));
+                        }
+                        dstFs.mkdirs(destination);
+                        verboseParameter.printf(writer, "copy directory: %s -> %s%n", source, destination);
+                        Arrays.stream(srcFs.listStatus(source))
+                                .map(s -> {
+                                    Path src = s.getPath();
+                                    Path dst = resolve(destination, src.getName());
+                                    return context.submit(new Copy(writer, srcFs, src, dstFs, dst));
+                                })
+                                .collect(Collectors.toList())
+                                .forEach(Task.Wait::forDone);
+                        if (isMove()) {
+                            srcFs.delete(source, true);
+                        }
+                    } else {
+                        LOG.warn("skip directory: {}", source);
+                    }
+                } else {
+                    if (dstFs.isDirectory(destination)) {
+                        throw new IOException(MessageFormat.format(
+                                "cannot overwrite directory by file: {0} -> {1}",
+                                source, destination));
+                    }
+                    FileUtil.copy(srcFs, source, dstFs, destination, isMove(), getConf());
+                    verboseParameter.printf(writer, "copy file: %s -> %s%n", source, destination);
+                }
+            } catch (IOException e) {
+                throw new CommandExecutionException(MessageFormat.format(
+                        "cannot copy resource: {0} -> {1}",
+                        source, destination), e);
+            }
+        }
+    }
+}

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/AbstractFileCopyCommand.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/AbstractFileCopyCommand.java
@@ -188,7 +188,7 @@ public abstract class AbstractFileCopyCommand implements Runnable {
                                 "conflict destination file \"{0}\": {1}",
                                 dst,
                                 v.stream()
-                                        .map(String::valueOf)
+                                        .map(ResourceInfo::getPath)
                                         .collect(Collectors.joining(", "))));
                     }
                     ResourceInfo src = v.get(0);

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/AbstractFileCopyCommand.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/AbstractFileCopyCommand.java
@@ -120,7 +120,7 @@ public abstract class AbstractFileCopyCommand implements Runnable {
         if (stat.filter(it -> it.isDirectory()).isPresent()) {
             copyOnto(files, destination);
         } else if (stat.filter(it -> it.isDirectory() == false).isPresent() && overwrite == false) {
-            throw new CommandExecutionException(MessageFormat.format(
+            throw new CommandConfigurationException(MessageFormat.format(
                     "destination file already exists: {0}",
                     destination));
         } else {
@@ -184,7 +184,7 @@ public abstract class AbstractFileCopyCommand implements Runnable {
                 .forEach((k, v) -> {
                     Path dst = resolve(destination, k);
                     if (v.size() >= 2) {
-                        throw new CommandExecutionException(MessageFormat.format(
+                        throw new CommandConfigurationException(MessageFormat.format(
                                 "conflict destination file \"{0}\": {1}",
                                 dst,
                                 v.stream()
@@ -193,7 +193,7 @@ public abstract class AbstractFileCopyCommand implements Runnable {
                     }
                     ResourceInfo src = v.get(0);
                     if (overwrite == false && stat(dst).isPresent()) {
-                        throw new CommandExecutionException(MessageFormat.format(
+                        throw new CommandConfigurationException(MessageFormat.format(
                                 "destination file already exists: {0} ({1})",
                                 dst,
                                 src));

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FileCopyCommand.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FileCopyCommand.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.operation.tools.directio.file;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+/**
+ * A command for copying Direct I/O resources.
+ * @since 0.10.0
+ */
+@Parameters(
+        commandNames = "copy",
+        commandDescription = "Copies files on Direct I/O data source."
+)
+public class FileCopyCommand extends AbstractFileCopyCommand {
+
+    @Parameter(
+            names = { "-r", "--recursive" },
+            description = "Copy directories recursively.",
+            required = false)
+    boolean recursive = false;
+
+    @Override
+    Op getOp() {
+        return recursive ? Op.COPY_RECURSIVE : Op.COPY_THIN;
+    }
+}

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FileGetCommand.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FileGetCommand.java
@@ -145,7 +145,7 @@ public class FileGetCommand implements Runnable {
                 .forEach((k, v) -> {
                     java.nio.file.Path dst = destination.resolve(k);
                     if (v.size() >= 2) {
-                        throw new CommandExecutionException(MessageFormat.format(
+                        throw new CommandConfigurationException(MessageFormat.format(
                                 "conflict destination file \"{0}\": {1}",
                                 dst,
                                 v.stream()
@@ -154,7 +154,7 @@ public class FileGetCommand implements Runnable {
                     }
                     ResourceInfo src = v.get(0);
                     if (overwrite == false && Files.exists(dst)) {
-                        throw new CommandExecutionException(MessageFormat.format(
+                        throw new CommandConfigurationException(MessageFormat.format(
                                 "destination file already exists: {0} ({1})",
                                 dst,
                                 src.getPath()));
@@ -210,7 +210,7 @@ public class FileGetCommand implements Runnable {
     private java.nio.file.Path getDestination() {
         java.nio.file.Path destination = localPathParameter.resolve(paths.get(paths.size() - 1));
         if (overwrite == false && Files.isRegularFile(destination)) {
-            throw new CommandExecutionException(MessageFormat.format(
+            throw new CommandConfigurationException(MessageFormat.format(
                     "destination file already exists: {0}",
                     destination));
         }

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FileGroup.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FileGroup.java
@@ -44,6 +44,8 @@ public class FileGroup extends GroupUsageCommand implements CommandProvider {
                 .addCommand(new FileListCommand())
                 .addCommand(new FileGetCommand())
                 .addCommand(new FilePutCommand())
+                .addCommand(new FileCopyCommand())
+                .addCommand(new FileMoveCommand())
                 .addCommand(new FileDeleteCommand())
                 .addCommand(new FileMakeDirectoryCommand());
     }

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FileMoveCommand.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FileMoveCommand.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.operation.tools.directio.file;
+
+import com.beust.jcommander.Parameters;
+
+/**
+ * A command for moving Direct I/O resources.
+ * @since 0.10.0
+ */
+@Parameters(
+        commandNames = "move",
+        commandDescription = "Renames files on Direct I/O data source."
+)
+public class FileMoveCommand extends AbstractFileCopyCommand {
+
+    @Override
+    Op getOp() {
+        return Op.MOVE;
+    }
+}

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FilePutCommand.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/file/FilePutCommand.java
@@ -109,7 +109,7 @@ public class FilePutCommand implements Runnable {
         if (stat.filter(it -> it.isDirectory()).isPresent()) {
             copyOnto(sources, destination);
         } else if (stat.filter(it -> it.isDirectory() == false).isPresent() && overwrite == false) {
-            throw new CommandExecutionException(MessageFormat.format(
+            throw new CommandConfigurationException(MessageFormat.format(
                     "destination file already exists: {0}",
                     destination));
         } else {
@@ -154,7 +154,7 @@ public class FilePutCommand implements Runnable {
                 .forEach((k, v) -> {
                     org.apache.hadoop.fs.Path dst = resolve(destination, k);
                     if (v.size() >= 2) {
-                        throw new CommandExecutionException(MessageFormat.format(
+                        throw new CommandConfigurationException(MessageFormat.format(
                                 "conflict destination file \"{0}\": {1}",
                                 dst,
                                 v.stream()
@@ -163,7 +163,7 @@ public class FilePutCommand implements Runnable {
                     }
                     java.nio.file.Path src = v.get(0);
                     if (overwrite == false && stat(dst).isPresent()) {
-                        throw new CommandExecutionException(MessageFormat.format(
+                        throw new CommandConfigurationException(MessageFormat.format(
                                 "destination file already exists: {0} ({1})",
                                 dst,
                                 src));

--- a/operation-project/directio/src/test/java/com/asakusafw/operation/tools/directio/file/FileCopyCommandTest.java
+++ b/operation-project/directio/src/test/java/com/asakusafw/operation/tools/directio/file/FileCopyCommandTest.java
@@ -1,0 +1,261 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.operation.tools.directio.file;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import com.asakusafw.operation.tools.directio.DirectIoToolsTestRoot;
+
+/**
+ * Test for {@link FileCopyCommand}.
+ */
+public class FileCopyCommandTest extends DirectIoToolsTestRoot {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        File root = add("root", "/");
+
+        write(touch(root, "a.txt"), "OK");
+        invoke("copy", "a.txt", "b.txt");
+
+        assertThat(new File(root, "a.txt"), is(file()));
+        assertThat(new File(root, "b.txt"), is(file()));
+        assertThat(read(new File(root, "b.txt")), is("OK"));
+    }
+
+    /**
+     * show help.
+     */
+    @Test
+    public void help() {
+        invoke("copy", "--help");
+    }
+
+    /**
+     * w/ verbose.
+     */
+    @Test
+    public void verbose() {
+        File root = add("root", "/");
+
+        write(touch(root, "a.txt"), "OK");
+        invoke("copy", "a.txt", "b.txt", "-v");
+
+        assertThat(new File(root, "a.txt"), is(file()));
+        assertThat(new File(root, "b.txt"), is(file()));
+        assertThat(read(new File(root, "b.txt")), is("OK"));
+    }
+
+    /**
+     * to directory.
+     */
+    @Test
+    public void to_directory() {
+        File root = add("root", "/");
+
+        write(touch(root, "a.txt"), "OK");
+        File dst = touch(root, "dir/");
+        invoke("copy", "a.txt", "dir");
+
+        assertThat(new File(root, "a.txt"), is(file()));
+        assertThat(new File(dst, "a.txt"), is(file()));
+        assertThat(read(new File(dst, "a.txt")), is("OK"));
+    }
+
+    /**
+     * multiple files.
+     */
+    @Test
+    public void multiple() {
+        File root = add("root", "/");
+
+        write(touch(root, "a.txt"), "A");
+        write(touch(root, "b.txt"), "B");
+        write(touch(root, "d/c.txt"), "C");
+        File dst = touch(root, "dir/");
+        invoke("copy", "a.txt", "b.txt", "d/c.txt", "dir");
+
+        assertThat(new File(root, "a.txt"), is(file()));
+        assertThat(new File(root, "b.txt"), is(file()));
+        assertThat(new File(root, "d/c.txt"), is(file()));
+        assertThat(new File(dst, "a.txt"), is(file()));
+        assertThat(new File(dst, "b.txt"), is(file()));
+        assertThat(new File(dst, "c.txt"), is(file()));
+        assertThat(read(new File(dst, "a.txt")), is("A"));
+        assertThat(read(new File(dst, "b.txt")), is("B"));
+        assertThat(read(new File(dst, "c.txt")), is("C"));
+    }
+
+    /**
+     * skip directory.
+     */
+    @Test
+    public void skip_directory() {
+        File root = add("root", "/");
+
+        write(touch(root, "d/a.txt"), "OK");
+        File dst = touch(root, "dir/");
+
+        invoke("copy", "d", "dir");
+
+        assertThat(new File(root, "d/a.txt"), is(exists()));
+        assertThat(new File(dst, "d/a.txt"), is(not(exists())));
+    }
+
+    /**
+     * copy directory.
+     */
+    @Test
+    public void copy_directory() {
+        File root = add("root", "/");
+
+        write(touch(root, "d/a.txt"), "OK");
+        File dst = touch(root, "dir/");
+
+        invoke("copy", "d", "dir", "--recursive");
+
+        assertThat(new File(root, "d/a.txt"), is(exists()));
+        assertThat(new File(dst, "d/a.txt"), is(file()));
+    }
+
+    /**
+     * w/ overwrite.
+     */
+    @Test
+    public void overwrite() {
+        File root = add("root", "/");
+
+        write(touch(root, "a.txt"), "OK");
+        write(touch(root, "b.txt"), "OLD");
+        invoke("copy", "a.txt", "b.txt", "--overwrite");
+
+        assertThat(new File(root, "a.txt"), is(file()));
+        assertThat(new File(root, "b.txt"), is(file()));
+        assertThat(read(new File(root, "b.txt")), is("OK"));
+    }
+
+    /**
+     * empty source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void empty_source() {
+        add("root", "/");
+        invoke("copy", "*.txt", "b.txt");
+    }
+
+    /**
+     * destination file already exists.
+     */
+    @Test(expected = RuntimeException.class)
+    public void file_exists() {
+        File root = add("root", "/");
+
+        touch(root, "a.txt");
+        touch(root, "b.txt");
+        invoke("copy", "a.txt", "b.txt");
+    }
+
+    /**
+     * multiple files into single target.
+     */
+    @Test(expected = RuntimeException.class)
+    public void ambiguous_source() {
+        File root = add("root", "/");
+
+        touch(root, "a.txt");
+        touch(root, "b.txt");
+        invoke("copy", "a.txt", "b.txt", "c.txt");
+    }
+
+    /**
+     * conflict source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void conflict_source() {
+        File root = add("root", "/");
+
+        touch(root, "d1/a.txt");
+        touch(root, "d2/a.txt");
+        invoke("copy", "d1/*", "d2/*", "/");
+    }
+
+    /**
+     * conflict source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void conflict_destination() {
+        File root = add("root", "/");
+
+        touch(root, "d1/a.txt");
+        touch(root, "d2/a.txt");
+        invoke("copy", "d1/*", "d2");
+    }
+
+    /**
+     * conflict source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void copy_root() {
+        File root = add("root", "/");
+
+        touch(root, "a.txt");
+        touch(root, "dir");
+        invoke("copy", "/", "dir", "--recursive");
+    }
+
+    /**
+     * parent directory of destination does not exist.
+     */
+    @Test(expected = RuntimeException.class)
+    public void missing_destination() {
+        File root = add("root", "/");
+
+        touch(root, "a.txt");
+        invoke("copy", "a.txt", "missing/parent.txt");
+    }
+
+    /**
+     * conflict source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void conflict_file_directory() {
+        File root = add("root", "/");
+
+        touch(root, "a.txt");
+        touch(root, "dir/a.txt/");
+        invoke("copy", "a.txt", "dir", "--overwrite");
+    }
+
+    /**
+     * conflict source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void conflict_directory_file() {
+        File root = add("root", "/");
+
+        touch(root, "d/a.txt");
+        touch(root, "dir/d");
+        invoke("copy", "d", "dir", "--overwrite", "--recursive");
+    }
+}

--- a/operation-project/directio/src/test/java/com/asakusafw/operation/tools/directio/file/FileCopyCommandTest.java
+++ b/operation-project/directio/src/test/java/com/asakusafw/operation/tools/directio/file/FileCopyCommandTest.java
@@ -258,4 +258,27 @@ public class FileCopyCommandTest extends DirectIoToolsTestRoot {
         touch(root, "dir/d");
         invoke("copy", "d", "dir", "--overwrite", "--recursive");
     }
+
+    /**
+     * conflict source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void same_target() {
+        File root = add("root", "/");
+
+        touch(root, "d/a.txt");
+        invoke("copy", "d", "d", "--overwrite");
+    }
+
+    /**
+     * conflict source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void nested_target() {
+        File root = add("root", "/");
+
+        touch(root, "d/a.txt");
+        touch(root, "d/d/");
+        invoke("copy", "d", "d/d", "--overwrite");
+    }
 }

--- a/operation-project/directio/src/test/java/com/asakusafw/operation/tools/directio/file/FileMoveCommandTest.java
+++ b/operation-project/directio/src/test/java/com/asakusafw/operation/tools/directio/file/FileMoveCommandTest.java
@@ -1,0 +1,246 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.operation.tools.directio.file;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import com.asakusafw.operation.tools.directio.DirectIoToolsTestRoot;
+
+/**
+ * Test for {@link FileMoveCommand}.
+ */
+public class FileMoveCommandTest extends DirectIoToolsTestRoot {
+
+    /**
+     * simple case.
+     */
+    @Test
+    public void simple() {
+        File root = add("root", "/");
+
+        write(touch(root, "a.txt"), "OK");
+        invoke("move", "a.txt", "b.txt");
+
+        assertThat(new File(root, "a.txt"), is(not(exists())));
+        assertThat(new File(root, "b.txt"), is(file()));
+        assertThat(read(new File(root, "b.txt")), is("OK"));
+    }
+
+    /**
+     * show help.
+     */
+    @Test
+    public void help() {
+        invoke("move", "--help");
+    }
+
+    /**
+     * w/ verbose.
+     */
+    @Test
+    public void verbose() {
+        File root = add("root", "/");
+
+        write(touch(root, "a.txt"), "OK");
+        invoke("move", "a.txt", "b.txt", "-v");
+
+        assertThat(new File(root, "a.txt"), is(not(exists())));
+        assertThat(new File(root, "b.txt"), is(file()));
+        assertThat(read(new File(root, "b.txt")), is("OK"));
+    }
+
+    /**
+     * to directory.
+     */
+    @Test
+    public void to_directory() {
+        File root = add("root", "/");
+
+        write(touch(root, "a.txt"), "OK");
+        File dst = touch(root, "dir/");
+        invoke("move", "a.txt", "dir");
+
+        assertThat(new File(root, "a.txt"), is(not(exists())));
+        assertThat(new File(dst, "a.txt"), is(file()));
+        assertThat(read(new File(dst, "a.txt")), is("OK"));
+    }
+
+    /**
+     * multiple files.
+     */
+    @Test
+    public void multiple() {
+        File root = add("root", "/");
+
+        write(touch(root, "a.txt"), "A");
+        write(touch(root, "b.txt"), "B");
+        write(touch(root, "d/c.txt"), "C");
+        File dst = touch(root, "dir/");
+        invoke("move", "a.txt", "b.txt", "d/c.txt", "dir");
+
+        assertThat(new File(root, "a.txt"), is(not(exists())));
+        assertThat(new File(root, "b.txt"), is(not(exists())));
+        assertThat(new File(root, "d"), is(exists()));
+        assertThat(new File(root, "d/c.txt"), is(not(exists())));
+        assertThat(new File(dst, "a.txt"), is(file()));
+        assertThat(new File(dst, "b.txt"), is(file()));
+        assertThat(new File(dst, "c.txt"), is(file()));
+        assertThat(read(new File(dst, "a.txt")), is("A"));
+        assertThat(read(new File(dst, "b.txt")), is("B"));
+        assertThat(read(new File(dst, "c.txt")), is("C"));
+    }
+
+    /**
+     * copy directory.
+     */
+    @Test
+    public void copy_directory() {
+        File root = add("root", "/");
+
+        write(touch(root, "d/a.txt"), "OK");
+        File dst = touch(root, "dir/");
+
+        invoke("move", "d", "dir");
+
+        assertThat(new File(root, "d"), is(not(exists())));
+        assertThat(new File(dst, "d/a.txt"), is(file()));
+    }
+
+    /**
+     * w/ overwrite.
+     */
+    @Test
+    public void overwrite() {
+        File root = add("root", "/");
+
+        write(touch(root, "a.txt"), "OK");
+        write(touch(root, "b.txt"), "OLD");
+        invoke("move", "a.txt", "b.txt", "--overwrite");
+
+        assertThat(new File(root, "a.txt"), is(not(exists())));
+        assertThat(new File(root, "b.txt"), is(file()));
+        assertThat(read(new File(root, "b.txt")), is("OK"));
+    }
+
+    /**
+     * empty source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void empty_source() {
+        add("root", "/");
+        invoke("move", "*.txt", "b.txt");
+    }
+
+    /**
+     * destination file already exists.
+     */
+    @Test(expected = RuntimeException.class)
+    public void file_exists() {
+        File root = add("root", "/");
+
+        touch(root, "a.txt");
+        touch(root, "b.txt");
+        invoke("move", "a.txt", "b.txt");
+    }
+
+    /**
+     * multiple files into single target.
+     */
+    @Test(expected = RuntimeException.class)
+    public void ambiguous_source() {
+        File root = add("root", "/");
+
+        touch(root, "a.txt");
+        touch(root, "b.txt");
+        invoke("move", "a.txt", "b.txt", "c.txt");
+    }
+
+    /**
+     * conflict source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void conflict_source() {
+        File root = add("root", "/");
+
+        touch(root, "d1/a.txt");
+        touch(root, "d2/a.txt");
+        invoke("move", "d1/*", "d2/*", "/");
+    }
+
+    /**
+     * conflict source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void conflict_destination() {
+        File root = add("root", "/");
+
+        touch(root, "d1/a.txt");
+        touch(root, "d2/a.txt");
+        invoke("move", "d1/*", "d2");
+    }
+
+    /**
+     * conflict source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void copy_root() {
+        File root = add("root", "/");
+
+        touch(root, "a.txt");
+        touch(root, "dir");
+        invoke("move", "/", "dir");
+    }
+
+    /**
+     * parent directory of destination does not exist.
+     */
+    @Test(expected = RuntimeException.class)
+    public void missing_destination() {
+        File root = add("root", "/");
+
+        touch(root, "a.txt");
+        invoke("move", "a.txt", "missing/parent.txt");
+    }
+
+    /**
+     * conflict source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void conflict_file_directory() {
+        File root = add("root", "/");
+
+        touch(root, "a.txt");
+        touch(root, "dir/a.txt/");
+        invoke("move", "a.txt", "dir", "--overwrite");
+    }
+
+    /**
+     * conflict source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void conflict_directory_file() {
+        File root = add("root", "/");
+
+        touch(root, "d/a.txt");
+        touch(root, "dir/d");
+        invoke("move", "d", "dir", "--overwrite");
+    }
+}

--- a/operation-project/directio/src/test/java/com/asakusafw/operation/tools/directio/file/FileMoveCommandTest.java
+++ b/operation-project/directio/src/test/java/com/asakusafw/operation/tools/directio/file/FileMoveCommandTest.java
@@ -243,4 +243,27 @@ public class FileMoveCommandTest extends DirectIoToolsTestRoot {
         touch(root, "dir/d");
         invoke("move", "d", "dir", "--overwrite");
     }
+
+    /**
+     * conflict source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void same_target() {
+        File root = add("root", "/");
+
+        touch(root, "d/a.txt");
+        invoke("move", "d", "d", "--overwrite");
+    }
+
+    /**
+     * conflict source.
+     */
+    @Test(expected = RuntimeException.class)
+    public void nested_target() {
+        File root = add("root", "/");
+
+        touch(root, "d/a.txt");
+        touch(root, "d/d/");
+        invoke("move", "d", "d/d", "--overwrite");
+    }
 }


### PR DESCRIPTION
## Summary

This PR adds commands `directio {copy, move}`, which enable copy/move resources on Direct I/O data sources.

## Background, Problem or Goal of the patch

`directio` command has been introduced #765, and it can copy files only between local file system and Direct I/O data sources by `put` and `get`.

## Design of the fix, or a new feature

Note that, `copy` accepts `--recursive` option but `move` does not. `move` originally can rename/move directories.

## Related Issue, Pull Request or Code

* #765 