### PR TITLE
Accept `asakusa run -v`.

### DIFF
--- a/workflow/cli/src/main/java/com/asakusafw/workflow/cli/run/RunCommand.java
+++ b/workflow/cli/src/main/java/com/asakusafw/workflow/cli/run/RunCommand.java
@@ -27,6 +27,7 @@ import com.asakusafw.utils.jcommander.CommandConfigurationException;
 import com.asakusafw.utils.jcommander.CommandExecutionException;
 import com.asakusafw.utils.jcommander.common.CommandProvider;
 import com.asakusafw.utils.jcommander.common.HelpParameter;
+import com.asakusafw.utils.jcommander.common.VerboseParameter;
 import com.asakusafw.workflow.cli.common.ExecutionContextParameter;
 import com.asakusafw.workflow.cli.common.WorkflowParameter;
 import com.asakusafw.workflow.executor.BatchExecutor;
@@ -50,6 +51,9 @@ public class RunCommand implements Runnable, CommandProvider {
 
     @ParametersDelegate
     final HelpParameter helpParameter = new HelpParameter();
+
+    @ParametersDelegate
+    final VerboseParameter verboseParameter = new VerboseParameter();
 
     @ParametersDelegate
     final ExecutionContextParameter contextParameter = new ExecutionContextParameter();


### PR DESCRIPTION
## Summary

This PR enables `asakusa run` to recognize `-v` option, but it does nothing.

## Background, Problem or Goal of the patch

Almost commands in `asakusa` can accept `-v, --verbose` option except `asakusa run`. To pull up `-v` to a common option of `asakusa`, this enables to recognize `-v` without any effects.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #750