### PR TITLE
`asakusa run -O logging` should show messages in default.

### DIFF
--- a/operation-project/command-portal/src/main/java/com/asakusafw/operation/tools/portal/SimpleLoggerUtil.java
+++ b/operation-project/command-portal/src/main/java/com/asakusafw/operation/tools/portal/SimpleLoggerUtil.java
@@ -21,13 +21,17 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import com.asakusafw.workflow.cli.run.ExecutorLogger;
+
 final class SimpleLoggerUtil {
 
     static final String NAME_RESOURCE_FILE = "simplelogger.properties";
 
     static final String OPT_PREFIX = "org.slf4j.simpleLogger.";
 
-    static final String OPT_LOG_LEVEL = OPT_PREFIX + "defaultLogLevel";
+    static final String OPT_DEFAULT_LOG_LEVEL = OPT_PREFIX + "defaultLogLevel";
+
+    static final String OPT_LOG_LEVEL_PREFIX = OPT_PREFIX + "log.";
 
     static final String OPT_SHOW_DATE_TIME = OPT_PREFIX + "showDateTime";
 
@@ -37,7 +41,9 @@ final class SimpleLoggerUtil {
 
     static final String OPT_LEVEL_IN_BRACKETS = OPT_PREFIX + "levelInBrackets";
 
-    static final String DEFAULT_LOG_LEVEL = "warn";
+    static final String DEFAULT_DEFAULT_LOG_LEVEL = "warn";
+
+    static final String DEFAULT_WORKFLOW_EXECUTOR_LOG_LEVEL = "info";
 
     static final String DEFAULT_SHOW_DATE_TIME = String.valueOf(false);
 
@@ -50,11 +56,12 @@ final class SimpleLoggerUtil {
     static final Map<String, String> OPT_DEFAULTS;
     static {
         Map<String, String> map = new HashMap<>();
-        map.put(OPT_LOG_LEVEL, DEFAULT_LOG_LEVEL);
+        map.put(OPT_DEFAULT_LOG_LEVEL, DEFAULT_DEFAULT_LOG_LEVEL);
         map.put(OPT_SHOW_DATE_TIME, DEFAULT_SHOW_DATE_TIME);
         map.put(OPT_SHOW_THREAD_NAME, DEFAULT_SHOW_THREAD_NAME);
         map.put(OPT_SHOW_LOG_NAME, DEFAULT_SHOW_LOG_NAME);
         map.put(OPT_LEVEL_IN_BRACKETS, DEFAULT_LEVEL_IN_BRACKETS);
+        map.put(OPT_LOG_LEVEL_PREFIX + ExecutorLogger.LOGGER_NAME, DEFAULT_WORKFLOW_EXECUTOR_LOG_LEVEL);
         OPT_DEFAULTS = map;
     }
 

--- a/workflow/cli/src/main/java/com/asakusafw/workflow/cli/run/ExecutorLogger.java
+++ b/workflow/cli/src/main/java/com/asakusafw/workflow/cli/run/ExecutorLogger.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.workflow.cli.run;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.workflow.executor.basic.BasicCommandLauncher;
+import com.asakusafw.workflow.executor.basic.BasicCommandLauncher.OutputChannel;
+
+/**
+ * An command output consumer for workflow executions.
+ * @see #LOGGER_NAME
+ * @since 0.10.0
+ */
+public class ExecutorLogger implements BasicCommandLauncher.OutputConsumer {
+
+    /**
+     * The logger name.
+     */
+    public static final String LOGGER_NAME = "com.asakusafw.cli.workflow.executor";
+
+    @Override
+    public void accept(OutputChannel channel, String label, CharSequence line) {
+        Lazy.LOG.info("({}:{}) {}", label, channel, line);
+    }
+
+    private static final class Lazy {
+
+        static final Logger LOG = LoggerFactory.getLogger(LOGGER_NAME);
+
+        private Lazy() {
+            return;
+        }
+    }
+}

--- a/workflow/cli/src/main/java/com/asakusafw/workflow/cli/run/ExecutorParameter.java
+++ b/workflow/cli/src/main/java/com/asakusafw/workflow/cli/run/ExecutorParameter.java
@@ -69,7 +69,15 @@ public class ExecutorParameter {
     }
 
     private CommandLauncher getCommandLauncher(TaskExecutionContext it) {
-        return BasicCommandTaskExecutor.getCommandLauncher(it, outputStyle);
+        return BasicCommandTaskExecutor.getCommandLauncher(it, getOutputStyle());
+    }
+
+    BasicCommandLauncher.OutputConsumer getOutputStyle() {
+        if (outputStyle == BasicCommandLauncher.Output.LOGGING) {
+            return new ExecutorLogger();
+        } else {
+            return outputStyle;
+        }
     }
 
     /**

--- a/workflow/executor/src/main/java/com/asakusafw/workflow/executor/basic/BasicCommandTaskExecutor.java
+++ b/workflow/executor/src/main/java/com/asakusafw/workflow/executor/basic/BasicCommandTaskExecutor.java
@@ -115,7 +115,7 @@ public class BasicCommandTaskExecutor implements TaskExecutor {
      */
     public static CommandLauncher getCommandLauncher(
             ExecutionContext context,
-            BasicCommandLauncher.Output output) {
+            BasicCommandLauncher.OutputConsumer output) {
         return new BasicCommandLauncher(
                 output,
                 TaskExecutors.getUserHome(context),


### PR DESCRIPTION
## Summary

This PR enables `asakusa run -O logging` to show sub-command output messages in default.

## Background, Problem or Goal of the patch

The latest implementation, `asakusa run -O logging` has not been shown any messages in default, because the default log level of `asakusa` command is `warn` even if level of the messages is `info`.

## Design of the fix, or a new feature

This PR first allocate log name `com.asakusafw.cli.workflow.executor` to SLF4J logger of execution output, and then set log level of that log to `info` in default.

Note that, the default log level of `asakusa` command is still `warn`. To change the log level of execution output. Please set system property `-Dorg.slf4j.simpleLogger.log.com.asakusafw.cli.workflow.executor=...` instead of `-Dorg.slf4j.simpleLogger.defaultLogLevel=...` via environment variable `ASAKUSA_CLIENT_OPTS`.

## Related Issue, Pull Request or Code

* #784