### PR TITLE
Remove duplicated operators in `asakusa list operator`.

### DIFF
--- a/info/cli/src/main/java/com/asakusafw/info/cli/list/ListOperatorCommand.java
+++ b/info/cli/src/main/java/com/asakusafw/info/cli/list/ListOperatorCommand.java
@@ -126,7 +126,13 @@ public class ListOperatorCommand implements Runnable {
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(entity);
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + Objects.hashCode(entity.getSpec());
+            if (verbose) {
+                result = prime * result + Objects.hashCode(entity.getParameters());
+            }
+            return result;
         }
 
         @Override


### PR DESCRIPTION
## Summary

This PR fixes `asakusa list operator` (without `-v`) to remove duplicated operators.

## Background, Problem or Goal of the patch

The latest implementation, `asakusa list operator` without `-v` sometimes shows the same operators twice or more. It because the `hashCode` operator is not consistent with `equals` method.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.