### PR TITLE
Fix `hadoop` command detection in `asakusa version -v`.

### DIFF
--- a/operation-project/command-portal/src/main/java/com/asakusafw/operation/tools/portal/VersionCommand.java
+++ b/operation-project/command-portal/src/main/java/com/asakusafw/operation/tools/portal/VersionCommand.java
@@ -64,7 +64,9 @@ public class VersionCommand implements Runnable {
 
     static final String PATH_VERSION = "VERSION";
 
-    static final String PATH_HADOOP_CMD = "bin/hadoop";
+    static final String PATH_HADOOP_CMD_NAME = "hadoop";
+
+    static final String PATH_HADOOP_CMD = "bin/" + PATH_HADOOP_CMD_NAME;
 
     static final String PATH_EMBED_HADOOP = "hadoop/lib";
 
@@ -158,10 +160,10 @@ public class VersionCommand implements Runnable {
                 .map(it -> Arrays.stream(it.split(Pattern.quote(File.pathSeparator))))
                 .orElse(Stream.empty())
                 .map(String::trim)
-                .filter(s -> s.isEmpty())
+                .filter(s -> s.isEmpty() == false)
                 .map(Paths::get)
                 .filter(Files::isDirectory)
-                .map(it -> it.resolve(PATH_HADOOP_CMD))
+                .map(it -> it.resolve(PATH_HADOOP_CMD_NAME))
                 .filter(Files::isRegularFile)
                 .filter(Files::isExecutable)
                 .findFirst();


### PR DESCRIPTION
## Summary

This PR fixes `asakusa version -v` to show `hadoop` command location on `PATH` environment.

## Background, Problem or Goal of the patch

`asakusa version -v` has been show `hadoop` command location since #789, but it cannot show the command location on `PATH` environment variable.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #789 