### PR TITLE
Remove use of deprecated annotaions in Gradle plug-ins.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/tasks/GenerateHiveDdlTask.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/tasks/GenerateHiveDdlTask.groovy
@@ -17,7 +17,6 @@ package com.asakusafw.gradle.tasks
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
-import org.gradle.api.Nullable
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.tasks.options.Option
 import org.gradle.api.tasks.Input
@@ -39,13 +38,11 @@ class GenerateHiveDdlTask extends DefaultTask {
     /**
      * The logback configuration for the tool.
      */
-    @Nullable
     File logbackConf
 
     /**
      * The max heap size for the tool.
      */
-    @Nullable
     String maxHeapSize
 
     /**

--- a/gradle/src/main/groovy/com/asakusafw/gradle/tasks/internal/AbstractAsakusaToolTask.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/tasks/internal/AbstractAsakusaToolTask.groovy
@@ -16,7 +16,6 @@
 package com.asakusafw.gradle.tasks.internal
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.Nullable
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -32,13 +31,11 @@ abstract class AbstractAsakusaToolTask extends DefaultTask {
     /**
      * The logback configuration for the tool.
      */
-    @Nullable
     File logbackConf
 
     /**
      * The max heap size for the tool.
      */
-    @Nullable
     String maxHeapSize
 
     /**

--- a/gradle/src/main/groovy/com/asakusafw/gradle/tasks/internal/AbstractTestToolTask.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/tasks/internal/AbstractTestToolTask.groovy
@@ -17,7 +17,6 @@ package com.asakusafw.gradle.tasks.internal
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
-import org.gradle.api.Nullable
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.tasks.options.Option
 import org.gradle.api.tasks.Input
@@ -38,13 +37,11 @@ abstract class AbstractTestToolTask extends DefaultTask {
     /**
      * The logback configuration for the tool.
      */
-    @Nullable
     File logbackConf
 
     /**
      * The max heap size for the tool.
      */
-    @Nullable
     String maxHeapSize
 
     /**


### PR DESCRIPTION
## Summary

This PR removes use of `org.gradle.api.Nullable` which has been deprecated since the latest version of Gradle, and it replaced with `javax.annotation.Nullable`

## Background, Problem or Goal of the patch

`org.gradle.api.Nullable` has been replaced with `javax.annotation.Nullable` since Gradle `4.1` and the old one will be removed in Gradle `5.0`. This PR just removed use of them because Gradle `< 4.1` API does not provide the new one.

The `@Nullable` annotation actually does not have effect on runtime, on the one hand `@Optional` accepts `null` values for task input fields.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.
