### PR TITLE
Fix logging operator.

### DIFF
--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/DslBuilder.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/DslBuilder.java
@@ -137,6 +137,8 @@ final class DslBuilder {
 
     private final ElementRef unknownRef;
 
+    private boolean defaultSticky;
+
     DslBuilder(OperatorDriver.Context context) {
         Objects.requireNonNull(context, "context must not be null"); //$NON-NLS-1$
         this.environment = context.getEnvironment();
@@ -211,6 +213,10 @@ final class DslBuilder {
 
     public void setSupport(ExecutableElement newValue) {
         this.support = newValue;
+    }
+
+    public void setSticky(boolean newValue) {
+        this.defaultSticky = newValue;
     }
 
     public void addAttribute(ValueDescription attribute) {
@@ -372,7 +378,7 @@ final class DslBuilder {
 
     private EnumConstantDescription computeObservationCount() {
         boolean isVolatile = false;
-        boolean isSticky = false;
+        boolean isSticky = defaultSticky;
         DeclaredType volatileType = environment.findDeclaredType(TYPE_VOLATILE);
         DeclaredType stickyType = environment.findDeclaredType(TYPE_STICKY);
         Types types = environment.getProcessingEnvironment().getTypeUtils();

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/DslBuilder.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/DslBuilder.java
@@ -92,12 +92,20 @@ final class DslBuilder {
     static final ClassDescription TYPE_OBSERVATION_COUNT =
             new ClassDescription("com.asakusafw.vocabulary.flow.graph.ObservationCount"); //$NON-NLS-1$
 
+    static final ClassDescription TYPE_CONNECTIVITY =
+            new ClassDescription("com.asakusafw.vocabulary.flow.graph.Connectivity"); //$NON-NLS-1$
+
     static final ClassDescription TYPE_VIEW_INFO =
             new ClassDescription("com.asakusafw.vocabulary.attribute.ViewInfo"); //$NON-NLS-1$
 
     static final String NAME_FLAT_VIEW_INFO_FACTORY = "flat"; //$NON-NLS-1$
 
     static final String NAME_GROUP_VIEW_INFO_FACTORY = "groupOf"; //$NON-NLS-1$
+
+    static final String NAME_CONNECTIVITY_OPTIONAL = "OPTIONAL";
+
+    static final EnumConstantDescription ENUM_CONNECTIVITY_OPTIONAL =
+            new EnumConstantDescription(TYPE_CONNECTIVITY, NAME_CONNECTIVITY_OPTIONAL);
 
     private final List<Node> parameters = new ArrayList<>();
 

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/LoggingOperatorDriver.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/LoggingOperatorDriver.java
@@ -69,6 +69,7 @@ public class LoggingOperatorDriver implements OperatorDriver {
             }
         }
         dsl.addAttribute(dsl.annotation().constant(LOG_LEVEL));
+        dsl.setSticky(true);
         return dsl.toDescription();
     }
 }

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/LoggingOperatorDriver.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/LoggingOperatorDriver.java
@@ -57,7 +57,8 @@ public class LoggingOperatorDriver implements OperatorDriver {
                             Document.text(Messages.getString("LoggingOperatorDriver.javadocOutput")), //$NON-NLS-1$
                             dsl.annotation().string(OUTPUT_PORT),
                             p.type().mirror(),
-                            p.reference());
+                            p.reference(),
+                            DslBuilder.ENUM_CONNECTIVITY_OPTIONAL);
                 } else {
                     p.error(Messages.getString("LoggingOperatorDriver.errorInputTooMany")); //$NON-NLS-1$
                 }

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/LoggingOperatorDriver.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/LoggingOperatorDriver.java
@@ -69,6 +69,7 @@ public class LoggingOperatorDriver implements OperatorDriver {
             }
         }
         dsl.addAttribute(dsl.annotation().constant(LOG_LEVEL));
+        dsl.addAttribute(DslBuilder.ENUM_CONNECTIVITY_OPTIONAL);
         dsl.setSticky(true);
         return dsl.toDescription();
     }

--- a/operator/builtin/src/test/java/com/asakusafw/operator/builtin/LoggingOperatorDriverTest.java
+++ b/operator/builtin/src/test/java/com/asakusafw/operator/builtin/LoggingOperatorDriverTest.java
@@ -28,6 +28,7 @@ import com.asakusafw.operator.model.OperatorDescription;
 import com.asakusafw.operator.model.OperatorDescription.Node;
 import com.asakusafw.operator.model.OperatorElement;
 import com.asakusafw.vocabulary.flow.graph.Connectivity;
+import com.asakusafw.vocabulary.flow.graph.ObservationCount;
 import com.asakusafw.vocabulary.operator.Logging;
 
 /**
@@ -62,6 +63,7 @@ public class LoggingOperatorDriverTest extends OperatorDriverTestRoot {
                 assertThat(description.getInputs().size(), is(1));
                 assertThat(description.getOutputs().size(), is(1));
                 assertThat(description.getArguments().size(), is(0));
+                assertThat(description.getAttributes(), hasItem(Descriptions.valueOf(ObservationCount.AT_LEAST_ONCE)));
 
                 Node input = description.getInputs().get(0);
                 assertThat(input.getName(), is("model"));

--- a/operator/builtin/src/test/java/com/asakusafw/operator/builtin/LoggingOperatorDriverTest.java
+++ b/operator/builtin/src/test/java/com/asakusafw/operator/builtin/LoggingOperatorDriverTest.java
@@ -63,6 +63,7 @@ public class LoggingOperatorDriverTest extends OperatorDriverTestRoot {
                 assertThat(description.getInputs().size(), is(1));
                 assertThat(description.getOutputs().size(), is(1));
                 assertThat(description.getArguments().size(), is(0));
+                assertThat(description.getAttributes(), hasItem(Descriptions.valueOf(Connectivity.OPTIONAL)));
                 assertThat(description.getAttributes(), hasItem(Descriptions.valueOf(ObservationCount.AT_LEAST_ONCE)));
 
                 Node input = description.getInputs().get(0);

--- a/operator/builtin/src/test/java/com/asakusafw/operator/builtin/LoggingOperatorDriverTest.java
+++ b/operator/builtin/src/test/java/com/asakusafw/operator/builtin/LoggingOperatorDriverTest.java
@@ -27,6 +27,7 @@ import com.asakusafw.operator.description.Descriptions;
 import com.asakusafw.operator.model.OperatorDescription;
 import com.asakusafw.operator.model.OperatorDescription.Node;
 import com.asakusafw.operator.model.OperatorElement;
+import com.asakusafw.vocabulary.flow.graph.Connectivity;
 import com.asakusafw.vocabulary.operator.Logging;
 
 /**
@@ -69,6 +70,7 @@ public class LoggingOperatorDriverTest extends OperatorDriverTestRoot {
                 Node output = description.getOutputs().get(0);
                 assertThat(output.getName(), is(defaultName(Logging.class, "outputPort")));
                 assertThat(output.getType(), is(sameType("com.example.Model")));
+                assertThat(output.getAttributes(), hasItem(Descriptions.valueOf(Connectivity.OPTIONAL)));
             }
         });
     }


### PR DESCRIPTION
## Summary

This PR fixes operator DSL compiler to make `@Logging` operator works correct.

## Background, Problem or Goal of the patch

In the latest implementation, the following `@Logging` operator's properties did not work correct:

* `@Logging` operator allows disconnected output port
* `@Logging` operator works as if is it is annotated by `@Sticky`

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.
