### PR TITLE
`Convert.original` output now can leave disconnected.

### DIFF
--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/ConvertOperatorDriver.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/ConvertOperatorDriver.java
@@ -57,7 +57,8 @@ public class ConvertOperatorDriver implements OperatorDriver {
                             Document.text(Messages.getString("ConvertOperatorDriver.javadocOriginalOutput")), //$NON-NLS-1$
                             dsl.annotation().string(ORIGINAL_PORT),
                             p.type().mirror(),
-                            p.reference());
+                            p.reference(),
+                            DslBuilder.ENUM_CONNECTIVITY_OPTIONAL);
                 } else {
                     p.error(Messages.getString("ConvertOperatorDriver.errorInputTooMany")); //$NON-NLS-1$
                 }

--- a/operator/builtin/src/test/java/com/asakusafw/operator/builtin/ConvertOperatorDriverTest.java
+++ b/operator/builtin/src/test/java/com/asakusafw/operator/builtin/ConvertOperatorDriverTest.java
@@ -29,6 +29,7 @@ import com.asakusafw.operator.model.OperatorDescription;
 import com.asakusafw.operator.model.OperatorDescription.Node;
 import com.asakusafw.operator.model.OperatorDescription.Reference;
 import com.asakusafw.operator.model.OperatorElement;
+import com.asakusafw.vocabulary.flow.graph.Connectivity;
 import com.asakusafw.vocabulary.operator.Convert;
 
 /**
@@ -73,12 +74,14 @@ public class ConvertOperatorDriverTest extends OperatorDriverTestRoot {
                 assertThat(orig.getName(), is(defaultName(Convert.class, "originalPort")));
                 assertThat(orig.getType(), is(sameType("com.example.Model")));
                 assertThat(orig.getReference(), is((Reference) Reference.parameter(0)));
+                assertThat(orig.getAttributes(), hasItem(Descriptions.valueOf(Connectivity.OPTIONAL)));
 
                 Node out = description.getOutputs().get(Convert.ID_OUTPUT_CONVERTED);
                 assertThat(out, is(notNullValue()));
                 assertThat(out.getName(), is(defaultName(Convert.class, "convertedPort")));
                 assertThat(out.getType(), is(sameType("com.example.Proceeded")));
                 assertThat(out.getReference(), is(Reference.returns()));
+                assertThat(out.getAttributes(), not(hasItem(Descriptions.valueOf(Connectivity.OPTIONAL))));
             }
         });
     }


### PR DESCRIPTION
## Summary

This PR enables to suppress `stop()` operators for `@Convert.original` outputs.

## Background, Problem or Goal of the patch

This enhancement requires that the consequent DSL compiler also supports `Connectivity` attribute for individual output ports. Please use this enhancement with asakusafw/asakusafw-compiler#177.

Note that, legacy compilers may not support this feature.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-compiler#177