### PR TITLE
Enable optional operator output ports leave opened.

### DIFF
--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/DslBuilder.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/DslBuilder.java
@@ -65,7 +65,7 @@ import com.asakusafw.operator.util.AnnotationHelper;
 /**
  * Helper for built-in operators.
  * @since 0.9.0
- * @version 0.9.1
+ * @version 0.10.1
  */
 final class DslBuilder {
 
@@ -217,6 +217,12 @@ final class DslBuilder {
 
     public void setSticky(boolean newValue) {
         this.defaultSticky = newValue;
+    }
+
+    public void processOptionalOutput(Node node) {
+        if (environment.isStrictOptionalOutputConnectivity() == false) {
+            node.withAttribute(ENUM_CONNECTIVITY_OPTIONAL);
+        }
     }
 
     public void addAttribute(ValueDescription attribute) {

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/MasterCheckOperatorDriver.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/MasterCheckOperatorDriver.java
@@ -74,7 +74,7 @@ public class MasterCheckOperatorDriver implements OperatorDriver {
                     Document.text(Messages.getString("MasterCheckOperatorDriver.javadocMissOutput")), //$NON-NLS-1$
                     dsl.annotation().string(MISSED_PORT),
                     txInput.getType(),
-                    Reference.special(String.valueOf(false)));
+                    Reference.special(String.valueOf(false))).with(dsl::processOptionalOutput);
         }
         dsl.setSupport(selector);
         dsl.requireShuffle();

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/MasterJoinOperatorDriver.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/MasterJoinOperatorDriver.java
@@ -126,7 +126,7 @@ public class MasterJoinOperatorDriver implements OperatorDriver {
                     Document.text(Messages.getString("MasterJoinOperatorDriver.javadocMissOutput")), //$NON-NLS-1$
                     dsl.annotation().string(MISSED_PORT),
                     txInput.getType(),
-                    txInput.getReference());
+                    txInput.getReference()).with(dsl::processOptionalOutput);
         } else {
             if (dsl.sawError() == false) {
                 List<TypeRef> types = new ArrayList<>();

--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/MasterJoinUpdateOperatorDriver.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/MasterJoinUpdateOperatorDriver.java
@@ -69,7 +69,7 @@ public class MasterJoinUpdateOperatorDriver implements OperatorDriver {
                     Document.text(Messages.getString("MasterJoinUpdateOperatorDriver.javadocMissOutput")), //$NON-NLS-1$
                     dsl.annotation().string(MISSED_PORT),
                     txInput.getType(),
-                    Reference.special(String.valueOf(false)));
+                    Reference.special(String.valueOf(false))).with(dsl::processOptionalOutput);
         }
         dsl.setSupport(MasterKindOperatorHelper.extractMasterSelection(dsl));
         dsl.requireShuffle();

--- a/operator/core/src/main/java/com/asakusafw/operator/CompileEnvironment.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/CompileEnvironment.java
@@ -46,6 +46,8 @@ import com.asakusafw.utils.java.model.util.Models;
 
 /**
  * Represents operator compiler environment.
+ * @since 0.9.0
+ * @version 0.10.1
  */
 public class CompileEnvironment {
 
@@ -70,6 +72,8 @@ public class CompileEnvironment {
     private volatile boolean forceNormalizeMemberName = true;
 
     private volatile boolean strictOperatorParameterOrder = false;
+
+    private volatile boolean strictOptionalOutputConnectivity = true;
 
     /**
      * Creates a new instance.
@@ -423,6 +427,26 @@ public class CompileEnvironment {
     }
 
     /**
+     * Returns whether or not the operator outputs must not be opened even if they are optional.
+     * @return {@code true} if it is strict, otherwise {@code false}
+     * @since 0.10.1
+     */
+    public boolean isStrictOptionalOutputConnectivity() {
+        return strictOptionalOutputConnectivity;
+    }
+
+    /**
+     * Sets whether or not the operator outputs must not be opened even if they are optional.
+     * @param newValue {@code true} if it must be strict, otherwise {@code false}
+     * @return this
+     * @since 0.10.1
+     */
+    public CompileEnvironment withStrictOptionalOutputConnectivity(boolean newValue) {
+        this.strictOptionalOutputConnectivity = newValue;
+        return this;
+    }
+
+    /**
      * Returns whether or not the member names must be normalized.
      * @return {@code true} is normalized, otherwise {@code false}
      */
@@ -459,6 +483,12 @@ public class CompileEnvironment {
          * Operator method parameters must be strict ordered.
          */
         STRICT_PARAMETER_ORDER(CompileEnvironment::withStrictOperatorParameterOrder),
+
+        /**
+         * Operator outputs must not be opened even if they are optional.
+         * @since 0.10.1
+         */
+        STRICT_OPTIONAL_OUTPUT_CONNECTIVITY(CompileEnvironment::withStrictOptionalOutputConnectivity),
 
         /**
          * Forcibly regenerates resources.

--- a/operator/core/src/main/java/com/asakusafw/operator/flowpart/FlowPartAnnotationProcessor.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/flowpart/FlowPartAnnotationProcessor.java
@@ -39,7 +39,6 @@ public class FlowPartAnnotationProcessor extends AbstractOperatorAnnotationProce
     static final Logger LOG = Logger.get(FlowPartAnnotationProcessor.class);
 
     static final Collection<CompileEnvironment.Support> FEATURES = Collections.unmodifiableSet(EnumSet.of(
-            CompileEnvironment.Support.STRICT_PARAMETER_ORDER,
             CompileEnvironment.Support.FORCE_REGENERATE_RESOURCES,
             CompileEnvironment.Support.FLOWPART_EXTERNAL_IO));
 

--- a/operator/core/src/main/java/com/asakusafw/operator/method/OperatorAnnotationProcessor.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/method/OperatorAnnotationProcessor.java
@@ -47,7 +47,7 @@ public class OperatorAnnotationProcessor extends AbstractOperatorAnnotationProce
     static final Logger LOG = Logger.get(OperatorAnnotationProcessor.class);
 
     static final Collection<CompileEnvironment.Support> FEATURES = Collections.unmodifiableSet(EnumSet.of(
-            CompileEnvironment.Support.STRICT_PARAMETER_ORDER,
+            CompileEnvironment.Support.STRICT_OPTIONAL_OUTPUT_CONNECTIVITY,
             CompileEnvironment.Support.FORCE_REGENERATE_RESOURCES,
             CompileEnvironment.Support.FORCE_GENERATE_IMPLEMENTATION,
             CompileEnvironment.Support.FORCE_NORMALIZE_MEMBER_NAME));

--- a/operator/core/src/main/java/com/asakusafw/operator/model/OperatorDescription.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/model/OperatorDescription.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
@@ -547,7 +548,7 @@ public class OperatorDescription implements AttributeContainer {
     /**
      * Represents input/output/argument.
      * @since 0.9.0
-     * @version 0.9.1
+     * @version 0.10.1
      */
     public static final class Node implements AttributeContainer {
 
@@ -582,6 +583,17 @@ public class OperatorDescription implements AttributeContainer {
             this.document = Objects.requireNonNull(document, "document must not be null"); //$NON-NLS-1$
             this.type = Objects.requireNonNull(type, "type must not be null"); //$NON-NLS-1$
             this.reference = Objects.requireNonNull(reference, "reference must not be null"); //$NON-NLS-1$
+        }
+
+        /**
+         * Processes this node.
+         * @param action the action
+         * @return this
+         * @since 0.10.1
+         */
+        public Node with(Consumer<? super Node> action) {
+            action.accept(this);
+            return this;
         }
 
         /**


### PR DESCRIPTION
## Summary

This PR enables operators' optional output ports leave opened.

## Background, Problem or Goal of the patch

`@Master{Join,Check,JoinUpdate}.missed` output ports are now optional, so that DSL compiler will not raise errors even if these output ports would not be connected to any opposites.

## Design of the fix, or a new feature

This feature is disabled in default. To enable this, please insert the following in your `build.gradle`.
```
asakusafw.javac.processorOption 'com.asakusafw.operator.STRICT_OPTIONAL_OUTPUT_CONNECTIVITY', 'false'
```

Note that, this feature may not be available for legacy implementations of DSL compiler.

## Related Issue, Pull Request or Code

* #802
