### PR TITLE
Revise error messages of `directio`.

### DIFF
--- a/operation-project/command-portal/src/main/java/com/asakusafw/operation/tools/portal/AsakusaPortal.java
+++ b/operation-project/command-portal/src/main/java/com/asakusafw/operation/tools/portal/AsakusaPortal.java
@@ -16,10 +16,8 @@
 package com.asakusafw.operation.tools.portal;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import java.util.ServiceLoader;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +27,6 @@ import com.asakusafw.utils.jcommander.CommandExecutionException;
 import com.asakusafw.utils.jcommander.JCommanderWrapper;
 import com.asakusafw.utils.jcommander.common.CommandProvider;
 import com.asakusafw.utils.jcommander.common.GroupUsageCommand;
-import com.beust.jcommander.MissingCommandException;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
 
@@ -68,10 +65,6 @@ public final class AsakusaPortal extends GroupUsageCommand {
             handle(e);
             LOG.debug("configuration error detail: {}", Arrays.toString(args), e);
             System.exit(2);
-        } catch (MissingCommandException e) {
-            handle(e);
-            LOG.debug("parameter error detail: {}", Arrays.toString(args), e);
-            System.exit(3);
         } catch (ParameterException e) {
             handle(e);
             LOG.debug("parameter error detail: {}", Arrays.toString(args), e);
@@ -99,22 +92,6 @@ public final class AsakusaPortal extends GroupUsageCommand {
     }
 
     private static void handle(ParameterException e) {
-        LOG.error("{} ({})",
-                e.getMessage(),
-                e.getJCommander().getProgramName());
-    }
-
-    private static void handle(MissingCommandException e) {
-        LOG.error("{} \"{}\" is not defined.",
-                e.getJCommander().getProgramName(),
-                e.getUnknownCommand());
-        List<String> candidates = e.getJCommander().getCommands().keySet().stream()
-                .sorted()
-                .collect(Collectors.toList());
-        if (candidates.isEmpty() == false) {
-            LOG.error("Available commands are: {}", candidates.stream()
-                    .map(it -> String.format("\"%s\"", it))
-                    .collect(Collectors.joining(", ")));
-        }
+        JCommanderWrapper.handle(e, s -> LOG.error("{}", s)); //$NON-NLS-1$
     }
 }

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/DirectIo.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/DirectIo.java
@@ -61,7 +61,7 @@ public class DirectIo extends GroupUsageCommand {
             LOG.debug("configuration error detail: {}", Arrays.toString(args), e);
             System.exit(2);
         } catch (ParameterException e) {
-            LOG.error("cannot recognize arguments: {}", Arrays.toString(args), e);
+            JCommanderWrapper.handle(e, s -> LOG.error("{}", s)); //$NON-NLS-1$
             System.exit(3);
         }
     }

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/DirectIo.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/DirectIo.java
@@ -37,6 +37,7 @@ import com.beust.jcommander.ParameterException;
 public class DirectIo extends GroupUsageCommand {
 
     static {
+        SimpleLoggerUtil.configure();
         WindowsConfigurator.install();
     }
 

--- a/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/SimpleLoggerUtil.java
+++ b/operation-project/directio/src/main/java/com/asakusafw/operation/tools/directio/SimpleLoggerUtil.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.operation.tools.directio;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+final class SimpleLoggerUtil {
+
+    static final String NAME_RESOURCE_FILE = "simplelogger.properties";
+
+    static final String OPT_PREFIX = "org.slf4j.simpleLogger.";
+
+    static final String OPT_DEFAULT_LOG_LEVEL = OPT_PREFIX + "defaultLogLevel";
+
+    static final String OPT_LOG_LEVEL_PREFIX = OPT_PREFIX + "log.";
+
+    static final String OPT_SHOW_DATE_TIME = OPT_PREFIX + "showDateTime";
+
+    static final String OPT_SHOW_THREAD_NAME = OPT_PREFIX + "showThreadName";
+
+    static final String OPT_SHOW_LOG_NAME = OPT_PREFIX + "showLogName";
+
+    static final String OPT_LEVEL_IN_BRACKETS = OPT_PREFIX + "levelInBrackets";
+
+    static final String DEFAULT_DEFAULT_LOG_LEVEL = "warn";
+
+    static final String DEFAULT_WORKFLOW_EXECUTOR_LOG_LEVEL = "info";
+
+    static final String DEFAULT_SHOW_DATE_TIME = String.valueOf(false);
+
+    static final String DEFAULT_SHOW_THREAD_NAME = String.valueOf(false);
+
+    static final String DEFAULT_SHOW_LOG_NAME = String.valueOf(false);
+
+    static final String DEFAULT_LEVEL_IN_BRACKETS = String.valueOf(true);
+
+    static final Map<String, String> OPT_DEFAULTS;
+    static {
+        Map<String, String> map = new HashMap<>();
+        map.put(OPT_DEFAULT_LOG_LEVEL, DEFAULT_DEFAULT_LOG_LEVEL);
+        map.put(OPT_SHOW_DATE_TIME, DEFAULT_SHOW_DATE_TIME);
+        map.put(OPT_SHOW_THREAD_NAME, DEFAULT_SHOW_THREAD_NAME);
+        map.put(OPT_SHOW_LOG_NAME, DEFAULT_SHOW_LOG_NAME);
+        map.put(OPT_LEVEL_IN_BRACKETS, DEFAULT_LEVEL_IN_BRACKETS);
+        OPT_DEFAULTS = map;
+    }
+
+    private SimpleLoggerUtil() {
+        return;
+    }
+
+    static void configure() {
+        if (SimpleLoggerUtil.class.getClassLoader().getResource(NAME_RESOURCE_FILE) != null) {
+            return;
+        }
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            Properties props = System.getProperties();
+            OPT_DEFAULTS.forEach((k, v) -> props.putIfAbsent(k, v));
+            System.setProperties(props);
+            return null;
+        });
+    }
+}

--- a/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/JCommanderWrapper.java
+++ b/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/JCommanderWrapper.java
@@ -142,14 +142,14 @@ public class JCommanderWrapper<T> implements CommandBuilder<T> {
                 .flatMap(it -> Arrays.stream(it.getParameter().names()))
                 .collect(Collectors.toSet());
         for (String arg : args) {
-            if (arg.equals("--")) {
+            if (arg.equals("--")) { //$NON-NLS-1$
                 break;
             }
-            if (arg.startsWith("-")) {
+            if (arg.startsWith("-")) { //$NON-NLS-1$
                 if (statics.contains(arg) == false
                         && dynamics.stream().anyMatch(arg::startsWith) == false) {
                     ParameterException exc = new ParameterException(MessageFormat.format(
-                            "unknown option: {0}",
+                            Messages.getString("JCommanderWrapper.errorUnknownOption"), //$NON-NLS-1$
                             arg));
                     exc.setJCommander(commander);
                     throw exc;
@@ -180,19 +180,19 @@ public class JCommanderWrapper<T> implements CommandBuilder<T> {
                 if (isShortNameOption(arg)
                         && arg.length() > 2
                         && dynamics.stream().anyMatch(arg::startsWith) == false) {
-                    LOG.debug("expand option: {}", arg);
+                    LOG.debug("expand option: {}", arg); //$NON-NLS-1$
                     for (int i = 1, n = arg.length(); i < n; i++) {
                         sawExpand = true;
-                        results.add("-" + arg.charAt(i));
+                        results.add("-" + arg.charAt(i)); //$NON-NLS-1$
                     }
                 } else {
-                    sawEscape |= arg.equals("--");
+                    sawEscape |= arg.equals("--"); //$NON-NLS-1$
                     results.add(arg);
                 }
             }
         }
         if (sawExpand) {
-            LOG.debug("expanded command line: {}", results);
+            LOG.debug("expanded command line: {}", results); //$NON-NLS-1$
             return results.toArray(new String[results.size()]);
         }
         return args;
@@ -226,7 +226,7 @@ public class JCommanderWrapper<T> implements CommandBuilder<T> {
     }
 
     private static boolean isShortNameOption(String arg) {
-        return arg.startsWith("-") && arg.startsWith("--") == false;
+        return arg.startsWith("-") && arg.startsWith("--") == false; //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     private static Object getActiveCommand(JCommander commander) {
@@ -265,7 +265,7 @@ public class JCommanderWrapper<T> implements CommandBuilder<T> {
                         }
                     }
                 } catch (ReflectiveOperationException e) {
-                    LOG.warn("error occurred while searching for help option: {}", object, e);
+                    LOG.warn("error occurred while searching for help option: {}", object, e); //$NON-NLS-1$
                     return false;
                 }
             }
@@ -290,8 +290,8 @@ public class JCommanderWrapper<T> implements CommandBuilder<T> {
                         inject(delegate, commander);
                     }
                 } catch (ReflectiveOperationException e) {
-                    throw new CommandConfigurationException(MessageFormat.format(
-                            "error occurred while injecting JCommander object: {0}#{1}",
+                    throw new IllegalStateException(MessageFormat.format(
+                            "error occurred while injecting JCommander object: {0}#{1}", //$NON-NLS-1$
                             object.getClass().getName(),
                             f.getName()), e);
                 }
@@ -319,7 +319,7 @@ public class JCommanderWrapper<T> implements CommandBuilder<T> {
                         collectParams(results, delegate);
                     }
                 } catch (ReflectiveOperationException e) {
-                    LOG.warn("error occurred while analyzing arguments: {}", object, e);
+                    LOG.warn("error occurred while analyzing arguments: {}", object, e); //$NON-NLS-1$
                 }
             }
         }
@@ -334,10 +334,10 @@ public class JCommanderWrapper<T> implements CommandBuilder<T> {
     public static void handle(ParameterException exception, Consumer<? super String> sink) {
         String programName = Optional.ofNullable(exception.getJCommander())
                 .map(JCommander::getProgramName)
-                .orElse("N/A");
+                .orElse("N/A"); //$NON-NLS-1$
         if (exception instanceof MissingCommandException) {
             sink.accept(MessageFormat.format(
-                    "{0} \"{1}\" is not defined.",
+                    Messages.getString("JCommanderWrapper.errorUnknownCommand"), //$NON-NLS-1$
                     programName,
                     ((MissingCommandException) exception).getUnknownCommand()));
             Set<String> candidates = Optional.ofNullable(exception.getJCommander())
@@ -345,15 +345,15 @@ public class JCommanderWrapper<T> implements CommandBuilder<T> {
                     .orElse(Collections.emptySet());
             if (candidates.isEmpty() == false) {
                 sink.accept(MessageFormat.format(
-                        "Available commands are: {0}",
+                        Messages.getString("JCommanderWrapper.hintAvailableCommands"), //$NON-NLS-1$
                         candidates.stream()
                                 .sorted()
-                                .map(it -> String.format("\"%s\"", it))
-                                .collect(Collectors.joining(", "))));
+                                .map(it -> String.format("\"%s\"", it)) //$NON-NLS-1$
+                                .collect(Collectors.joining(", ")))); //$NON-NLS-1$
             }
         } else {
             sink.accept(MessageFormat.format(
-                    "{0} ({1})",
+                    Messages.getString("JCommanderWrapper.errorCommandParameter"), //$NON-NLS-1$
                     Optional.ofNullable(exception.getMessage())
                             .orElseGet(exception::toString),
                     programName));
@@ -420,7 +420,7 @@ public class JCommanderWrapper<T> implements CommandBuilder<T> {
             JCommander next = commander.getCommands().get(name);
             next.setProgramName(Stream.concat(
                     Arrays.stream(nameSequence),
-                    Stream.of(name)).collect(Collectors.joining(" ")));
+                    Stream.of(name)).collect(Collectors.joining(" "))); //$NON-NLS-1$
             return next;
         }
     }

--- a/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/Messages.java
+++ b/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/Messages.java
@@ -15,23 +15,23 @@
  */
 package com.asakusafw.utils.jcommander;
 
-import java.text.MessageFormat;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
 
-import com.beust.jcommander.Parameters;
+final class Messages {
 
-final class Util {
+    private static final String BUNDLE_NAME = "com.asakusafw.utils.jcommander.messages"; //$NON-NLS-1$
 
-    private Util() {
-        return;
+    private static final ResourceBundle RESOURCE_BUNDLE = ResourceBundle.getBundle(BUNDLE_NAME);
+
+    private Messages() {
     }
 
-    static String getCommandName(Object command) {
-        Parameters parameters = command.getClass().getAnnotation(Parameters.class);
-        if (parameters == null || parameters.commandNames().length != 1) {
-            throw new IllegalStateException(MessageFormat.format(
-                    "there are no valid command name information: {0}", //$NON-NLS-1$
-                    command.getClass().getName()));
+    public static String getString(String key) {
+        try {
+            return RESOURCE_BUNDLE.getString(key);
+        } catch (MissingResourceException e) {
+            return '!' + key + '!';
         }
-        return parameters.commandNames()[0];
     }
 }

--- a/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/common/LocalPath.java
+++ b/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/common/LocalPath.java
@@ -33,9 +33,9 @@ public final class LocalPath {
 
     static final Logger LOG = LoggerFactory.getLogger(LocalPath.class);
 
-    static final String KEY_WORKING_DIRECTORY = "cli.cwd";
+    static final String KEY_WORKING_DIRECTORY = "cli.cwd"; //$NON-NLS-1$
 
-    static final String ENV_WORKING_DIRECTORY = "CALLER_CWD";
+    static final String ENV_WORKING_DIRECTORY = "CALLER_CWD"; //$NON-NLS-1$
 
     private static final Path WORKING_DIRECTORY;
 
@@ -67,7 +67,7 @@ public final class LocalPath {
      * @throws CommandConfigurationException if the path cannot be resolved
      */
     public static Path of(String path) {
-        return of(path, Paths.get("."));
+        return of(path, Paths.get(".")); //$NON-NLS-1$
     }
 
     /**
@@ -88,7 +88,7 @@ public final class LocalPath {
                         WORKING_DIRECTORY));
             }
             Path result = WORKING_DIRECTORY.resolve(path);
-            LOG.debug("resolve local path: {} -> {}", path, result);
+            LOG.debug("resolve local path: {} -> {}", path, result); //$NON-NLS-1$
             return result;
         } else if (defaultWorkingDirectory != null) {
             return defaultWorkingDirectory.resolve(path).toAbsolutePath();

--- a/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/common/OutputParameter.java
+++ b/utils-project/jcommander-wrapper/src/main/java/com/asakusafw/utils/jcommander/common/OutputParameter.java
@@ -38,7 +38,7 @@ public class OutputParameter {
     /**
      * The default output name (standard output).
      */
-    public static final String DEFAULT_OUTPUT = "-";
+    public static final String DEFAULT_OUTPUT = "-"; //$NON-NLS-1$
 
     /**
      * The output target file, or {@link #DEFAULT_OUTPUT}.

--- a/utils-project/jcommander-wrapper/src/main/resources/com/asakusafw/utils/jcommander/messages.properties
+++ b/utils-project/jcommander-wrapper/src/main/resources/com/asakusafw/utils/jcommander/messages.properties
@@ -1,0 +1,4 @@
+JCommanderWrapper.errorCommandParameter={0} (command: {1})
+JCommanderWrapper.errorUnknownCommand={0} "{1}" is not defined.
+JCommanderWrapper.errorUnknownOption=unknown option: {0}
+JCommanderWrapper.hintAvailableCommands=Available commands are: {0}

--- a/utils-project/jcommander-wrapper/src/main/resources/com/asakusafw/utils/jcommander/messages_ja.properties
+++ b/utils-project/jcommander-wrapper/src/main/resources/com/asakusafw/utils/jcommander/messages_ja.properties
@@ -1,0 +1,4 @@
+JCommanderWrapper.errorCommandParameter={0} (\u30b3\u30de\u30f3\u30c9\u300c{1}\u300d)
+JCommanderWrapper.errorUnknownCommand=\u30b3\u30de\u30f3\u30c9\u300c{0} "{1}"\u300d\u304c\u898b\u3064\u304b\u308a\u307e\u305b\u3093\u3002
+JCommanderWrapper.errorUnknownOption=\u4e0d\u660e\u306a\u30aa\u30d7\u30b7\u30e7\u30f3: {0}
+JCommanderWrapper.hintAvailableCommands=\u5229\u7528\u53ef\u80fd\u306a\u30b3\u30de\u30f3\u30c9: {0}

--- a/utils-project/jcommander-wrapper/src/test/java/com/asakusafw/utils/jcommander/JCommanderWrapperTest.java
+++ b/utils-project/jcommander-wrapper/src/test/java/com/asakusafw/utils/jcommander/JCommanderWrapperTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import com.asakusafw.utils.jcommander.JCommanderWrapper;
 import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.MissingCommandException;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.beust.jcommander.Parameters;
@@ -160,19 +161,46 @@ public class JCommanderWrapperTest {
     /**
      * w/ unknown command.
      */
-    @Test(expected = ParameterException.class)
+    @Test
     public void unknown_command() {
         JCommanderWrapper<Supplier<String>> commander = new JCommanderWrapper<>("PG", new Cmd("R"));
-        commander.parse("UNKNOWN").map(Supplier::get);
+        try {
+            commander.parse("UNKNOWN").map(Supplier::get);
+            fail();
+        } catch (ParameterException e) {
+            JCommanderWrapper.handle(e, System.out::println);
+        }
+    }
+
+    /**
+     * w/ unknown command.
+     */
+    @Test
+    public void unknown_command_with_subs() {
+        JCommanderWrapper<Supplier<String>> commander = new JCommanderWrapper<>("PG", new Cmd("R"));
+        commander.addCommand("a", new Cmd("OK"));
+        try {
+            commander.parse("UNKNOWN").map(Supplier::get);
+            fail();
+        } catch (MissingCommandException e) {
+            JCommanderWrapper.handle(e, System.out::println);
+        }
     }
 
     /**
      * w/ unknown option.
      */
-    @Test(expected = ParameterException.class)
+    @Test
     public void unknown_option() {
         JCommanderWrapper<Supplier<String>> commander = new JCommanderWrapper<>("PG", new Cmd("R"));
-        commander.parse("--unknown").map(Supplier::get);
+        try {
+            commander.parse("--unknown").map(Supplier::get);
+            fail();
+        } catch (MissingCommandException e) {
+            throw e;
+        } catch (ParameterException e) {
+            JCommanderWrapper.handle(e, System.out::println);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR revises error messages of `directio` command.

## Background, Problem or Goal of the patch

`directio` command sometimes provides poorer messages than `asakusa` command. This PR improves the following features.

* shared error messages about missing commands (e.g. `directio x`) with `asakusa` command, and added Japanese resource
* shared SLF4J simple logger settings with `asakusa` command, but it is enabled only if `asakusafwOrganizer.hadoop.embed` is `true`

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #765 