### PR TITLE
Add extension-less file mappings for Maven license plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -461,11 +461,18 @@ encoding/<project>=UTF-8
               <include>src/**/*.jj</include>
               <include>src/**/*.sh</include>
               <include>src/**/*.cmd</include>
+              <include>src/main/dist/**/bin/*</include>
+              <include>src/main/dist/**/libexec/**/*</include>
             </includes>
             <encoding>UTF-8</encoding>
             <mapping>
               <flex>JAVADOC_STYLE</flex>
               <jj>JAVADOC_STYLE</jj>
+              <asakusa>SCRIPT_STYLE</asakusa>
+              <directio>SCRIPT_STYLE</directio>
+              <finalize>SCRIPT_STYLE</finalize>
+              <process>SCRIPT_STYLE</process>
+              <hadoop-bridge>SCRIPT_STYLE</hadoop-bridge>
             </mapping>
           </configuration>
         </plugin>


### PR DESCRIPTION
## Summary
This PR adds extension-less file mappings for Maven license plugin

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.
