### PR TITLE
Fix inconsistency of eclipse classpath and project directory

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
@@ -110,17 +110,27 @@ class EclipsePluginEnhancement {
                 noExportConfigurations += [project.configurations.provided, project.configurations.embedded]
             }
         }
-        project.eclipseClasspath.doFirst {
-            makeGeneratedSourceDir()
-        }
-    }
-
-    private void makeGeneratedSourceDir() {
-        if (!project.file(project.asakusafw.modelgen.modelgenSourceDirectory).exists()) {
-            project.mkdir(project.asakusafw.modelgen.modelgenSourceDirectory)
-        }
-        if (!project.file(project.asakusafw.javac.annotationSourceDirectory).exists()) {
-            project.mkdir(project.asakusafw.javac.annotationSourceDirectory)
+        PluginUtils.afterEvaluate(project) {
+            AsakusafwPluginConvention sdk =  project.asakusafw
+            if (sdk.sdk.dmdl) {
+                project.tasks.eclipseClasspath {
+                    shouldRunAfter(project.tasks.compileDMDL)
+                    doFirst {
+                        if (!project.file(sdk.modelgen.modelgenSourceDirectory).exists()) {
+                            project.mkdir(sdk.modelgen.modelgenSourceDirectory)
+                        }
+                    }
+                }
+            }
+            if (sdk.sdk.operator) {
+                project.tasks.eclipseClasspath {
+                    doFirst {
+                        if (!project.file(sdk.javac.annotationSourceDirectory).exists()) {
+                            project.mkdir(sdk.javac.annotationSourceDirectory)
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
@@ -96,6 +96,16 @@ class EclipsePluginEnhancement {
     }
 
     private void extendEclipseClasspath() {
+        AsakusafwPluginConvention sdk =  project.asakusafw
+        def modelgenSrc = project.relativePath(sdk.modelgen.modelgenSourceDirectory ?: '').replace('\\', '/')
+        def annotationSrc = project.relativePath(sdk.javac.annotationSourceDirectory ?: '').replace('\\', '/')
+        def putAttribute = { attrs, name, value ->
+            attrs.collect {
+                it.children().find { it.name() == 'attribute' && it.@name == name } ?: it.appendNode('attribute', [name: name])
+            }.each {
+                it.@value = value
+            }
+        }
         project.eclipse.classpath {
             file {
                 whenMerged { classpath ->
@@ -104,6 +114,17 @@ class EclipsePluginEnhancement {
                     }
                     classpath.entries.unique()
                 }
+                withXml { provider ->
+                    def genSrcAttributes = provider.asNode().children().findAll {
+                        it.name() == 'classpathentry' && it.@kind == 'src' \
+                        && it.@path \
+                        && ( it.@path == modelgenSrc ||it.@path == annotationSrc )
+                    }.collect {
+                        it.children().find { it.name() == 'attributes' } ?: it.appendNode('attributes')
+                    }
+                    putAttribute(genSrcAttributes, 'optional', 'true')
+                    putAttribute(genSrcAttributes, 'ignore_optional_problems', 'true')
+                }
             }
             plusConfigurations += [project.configurations.provided, project.configurations.embedded]
             if (PluginUtils.compareGradleVersion('2.5-rc-1') < 0) {
@@ -111,7 +132,6 @@ class EclipsePluginEnhancement {
             }
         }
         PluginUtils.afterEvaluate(project) {
-            AsakusafwPluginConvention sdk =  project.asakusafw
             if (sdk.sdk.dmdl) {
                 project.tasks.eclipseClasspath {
                     shouldRunAfter(project.tasks.compileDMDL)


### PR DESCRIPTION
## Summary
This PR fixes some inconsistency of eclipse classpath and project directory configuration which occurs by `eclipse` and other tasks with Asakusa Gradle Plugin.

## Background, Problem or Goal of the patch
For example, the following commands on a project that has no dmdl scripts occurs build error on Eclipse:
```
./gradlew eclipse compileDMDL
```

This is caused that Gradle deletes task output resource when no task input ( NO-SORUCE ).
In this case, `eclipse` task generates eclipse classpath and directory for generated model classes but `compileDMDL` task deletes that directory so build error occurs on Eclipse. This problem is likely to occur in multi-project.

## Design of the fix, or a new feature
* Generates classpath and directory only `asakusafw.sdk.[dmdl|operator]` enable
* Set task orders of `compileClasspath` and `compileDMDL` by `shouldRunAfter`
* Set `optional` and `ignore_optional_problems` to generated sources classpath entries of `.classpath`

## Related Issue, Pull Request or Code
N/A.
