### PR TITLE
Enable config to ignore environment hadoop conf

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/util/hadoop/ConfigurationProvider.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/util/hadoop/ConfigurationProvider.java
@@ -75,6 +75,8 @@ public class ConfigurationProvider {
 
     private static final String PATH_CONF_DIR_PACKAGE = "etc/hadoop"; //$NON-NLS-1$
 
+    private static final String PATH_CONF_DIR_IGNORE = "-"; //$NON-NLS-1$
+
     private static final String CLASS_EXTENSION = ".class"; //$NON-NLS-1$
 
     private static final String PATH_SUBPROC_OUTPUT = "result"; //$NON-NLS-1$
@@ -125,6 +127,12 @@ public class ConfigurationProvider {
             if (SAW_HADOOP_CONF_MISSING.compareAndSet(false, true)) {
                 LOG.info("Hadoop configuration path is not found");
             }
+            return null;
+        }
+        if (conf.getPath().equals(PATH_CONF_DIR_IGNORE)) {
+            LOG.debug(MessageFormat.format(
+                    "Special character [{0}] for ignoring environment Hadoop configuration was set", //$NON-NLS-1$
+                    PATH_CONF_DIR_IGNORE));
             return null;
         }
         if (conf.isDirectory() == false) {


### PR DESCRIPTION
## Summary
This PR enables config to ignore environment hadoop configuration.

## Background, Problem or Goal of the patch
When executing TestDriver on the general Hadoop distribution environment where Hadoop client is installed with `PATH` to `hadoop` command, and that Hadoop configuration `fs.defaultFS` is for HDFS ( `hdfs://...` ) , that test fails with following logs:
```
./gradlew -i test
...
com.example.flowpart.CategorySummaryFlowPartTest > summarize FAILED
    java.lang.IllegalStateException: java.io.IOException: No FileSystem for scheme: hdfs
        at com.asakusafw.testdriver.FlowPartTester.runTest(FlowPartTester.java:128)
...
```

This is caused that TestDriver resolves Hadoop configuration from `PATH` of `hadoop` command but don't use the corresponding hadoop classpath.

## Design of the fix, or a new feature
Sometimes we would like to ignore the environment Hadoop settings, especially when running `test` task with TestDriver. Therefore this patch introduce a special character `-` for ignoring environment Hadoop settings to `HADOOP_CONF`.

This usage is as follows:
```
HADOOP_CONF=- ./gradlew test
```

## Related Issue, Pull Request or Code
N/A.