### PR TITLE
Allow enum constants for operator methods.

### DIFF
--- a/operator/builtin/src/main/java/com/asakusafw/operator/builtin/DslBuilder.java
+++ b/operator/builtin/src/main/java/com/asakusafw/operator/builtin/DslBuilder.java
@@ -771,7 +771,7 @@ final class DslBuilder {
         }
 
         public boolean isExtra() {
-            return isPrimitive() || isString() || isViewLike();
+            return isBasic() || isViewLike();
         }
 
         public boolean isViewLike() {
@@ -787,7 +787,7 @@ final class DslBuilder {
         }
 
         public boolean isBasic() {
-            return isPrimitive() || isString();
+            return isPrimitive() || isString() || (environment.isEnumConstantParameter() && isEnum());
         }
 
         public boolean isBoolean() {

--- a/operator/builtin/src/test/java/com/asakusafw/operator/builtin/ExtractOperatorDriverTest.java
+++ b/operator/builtin/src/test/java/com/asakusafw/operator/builtin/ExtractOperatorDriverTest.java
@@ -167,6 +167,35 @@ public class ExtractOperatorDriverTest extends OperatorDriverTestRoot {
     }
 
     /**
+     * w/ enum constant arguments.
+     */
+    @Test
+    public void with_argument_enum() {
+        edits.add(it -> it.withEnumConstantParameter(true));
+        compile(new Action("com.example.WithEnumArgument") {
+            @Override
+            protected void perform(OperatorElement target) {
+                OperatorDescription description = target.getDescription();
+                assertThat(description.getInputs().size(), is(1));
+                assertThat(description.getOutputs().size(), is(1));
+                assertThat(description.getArguments().size(), is(1));
+
+                Node input = description.getInputs().get(0);
+                assertThat(input.getName(), is("in"));
+                assertThat(input.getType(), is(sameType("com.example.Model")));
+
+                Node output = description.getOutputs().get(0);
+                assertThat(output.getName(), is("out"));
+                assertThat(output.getType(), is(sameType("com.example.Proceeded")));
+
+                Node argument = description.getArguments().get(0);
+                assertThat(argument.getName(), is("select"));
+                assertThat(argument.getType(), is(sameType("com.example.WithEnumArgument.Select")));
+            }
+        });
+    }
+
+    /**
      * violates method is not abstract.
      */
     @Test
@@ -228,5 +257,14 @@ public class ExtractOperatorDriverTest extends OperatorDriverTestRoot {
     @Test
     public void violate_output_inferable() {
         violate("com.example.ViolateOutputInferable");
+    }
+
+    /**
+     * w/ enum constant arguments.
+     */
+    @Test
+    public void violate_argument_enum() {
+        edits.add(it -> it.withEnumConstantParameter(false));
+        violate("com.example.WithEnumArgument");
     }
 }

--- a/operator/builtin/src/test/java/com/asakusafw/operator/builtin/OperatorDriverTestRoot.java
+++ b/operator/builtin/src/test/java/com/asakusafw/operator/builtin/OperatorDriverTestRoot.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import javax.annotation.processing.ProcessingEnvironment;
@@ -64,6 +65,11 @@ public class OperatorDriverTestRoot extends OperatorCompilerTestRoot {
      * Target operator driver.
      */
     protected final OperatorDriver driver;
+
+    /**
+     * Edits {@link CompileEnvironment}.
+     */
+    protected final List<Consumer<? super CompileEnvironment>> edits = new ArrayList<>();
 
     final List<String> dataModelNames;
 
@@ -236,6 +242,7 @@ public class OperatorDriverTestRoot extends OperatorCompilerTestRoot {
 
         @Override
         protected void test() {
+            edits.forEach(it -> it.accept(env));
             TypeElement element = env.findTypeElement(new ClassDescription(className));
             assertThat(className, element, is(notNullValue()));
             while (element.getEnclosingElement().getKind() != ElementKind.PACKAGE) {

--- a/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/ExtractOperatorDriverTest.files/com/example/WithEnumArgument.java.txt
+++ b/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/ExtractOperatorDriverTest.files/com/example/WithEnumArgument.java.txt
@@ -1,0 +1,16 @@
+package com.example;
+
+import java.util.List;
+import com.asakusafw.runtime.core.Result;
+import com.asakusafw.vocabulary.operator.*;
+
+public abstract class $s {
+
+    @Extract
+    public void method(Model in, Result<Proceeded> out, Select select) {
+    }
+
+    public enum Select {
+        A, B, C,
+    }
+}

--- a/operator/core/src/main/java/com/asakusafw/operator/CompileEnvironment.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/CompileEnvironment.java
@@ -47,7 +47,7 @@ import com.asakusafw.utils.java.model.util.Models;
 /**
  * Represents operator compiler environment.
  * @since 0.9.0
- * @version 0.10.1
+ * @version 0.10.2
  */
 public class CompileEnvironment {
 
@@ -74,6 +74,8 @@ public class CompileEnvironment {
     private volatile boolean strictOperatorParameterOrder = false;
 
     private volatile boolean strictOptionalOutputConnectivity = true;
+
+    private volatile boolean enumConstantParameter = false;
 
     /**
      * Creates a new instance.
@@ -465,6 +467,26 @@ public class CompileEnvironment {
     }
 
     /**
+     * Returns whether or not the operators can accept enum constants as value parameter.
+     * @return {@code true} if operators can accept enum constants, otherwise {@code false}
+     * @since 0.10.2
+     */
+    public boolean isEnumConstantParameter() {
+        return enumConstantParameter;
+    }
+
+    /**
+     * Sets whether or not the operators can accept enum constants as value parameter.
+     * @param newValue {@code true} to accept enum constants, otherwise {@code false}
+     * @return this
+     * @since 0.10.2
+     */
+    public CompileEnvironment withEnumConstantParameter(boolean newValue) {
+        this.enumConstantParameter = newValue;
+        return this;
+    }
+
+    /**
      * Represents kind of supported features in {@link CompileEnvironment}.
      */
     public enum Support {
@@ -504,6 +526,12 @@ public class CompileEnvironment {
          * Always uses the normalized member name for operator factory methods.
          */
         FORCE_NORMALIZE_MEMBER_NAME(CompileEnvironment::withForceNormalizeMemberName),
+
+        /**
+         * Accepts enum constant as operator parameter.
+         * @since 0.10.2
+         */
+        ENUM_CONSTANT_PARAMETER(CompileEnvironment::withEnumConstantParameter),
 
         /**
          * Supports external I/O ports in flow parts.

--- a/operator/core/src/main/java/com/asakusafw/operator/method/OperatorAnnotationProcessor.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/method/OperatorAnnotationProcessor.java
@@ -50,7 +50,8 @@ public class OperatorAnnotationProcessor extends AbstractOperatorAnnotationProce
             CompileEnvironment.Support.STRICT_OPTIONAL_OUTPUT_CONNECTIVITY,
             CompileEnvironment.Support.FORCE_REGENERATE_RESOURCES,
             CompileEnvironment.Support.FORCE_GENERATE_IMPLEMENTATION,
-            CompileEnvironment.Support.FORCE_NORMALIZE_MEMBER_NAME));
+            CompileEnvironment.Support.FORCE_NORMALIZE_MEMBER_NAME,
+            CompileEnvironment.Support.ENUM_CONSTANT_PARAMETER));
 
     @Override
     protected CompileEnvironment createCompileEnvironment(ProcessingEnvironment processingEnv) {


### PR DESCRIPTION
## Summary

This enables operator methods to declare enum constant parameters.

## Background, Problem or Goal of the patch

The latest implementation, the operator compiler only had accepted primitive types and strings as extra parameters of operator methods. This PR additionally allows enum constants.

## Design of the fix, or a new feature

This feature is disabled in default. To enable this, please insert the following in your `build.gradle`.

```
asakusafw.javac.processorOption 'com.asakusafw.operator.ENUM_CONSTANT_PARAMETER', 'true'
```

Note that, this feature may not be available for legacy implementations of DSL compiler, and Asakusa on Spark will require extra patches.

## Related Issue, Pull Request or Code

N/A.