### PR TITLE
Inherit indirect projective models.

### DIFF
--- a/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/analyzer/ModelDeclarationProcessor.java
+++ b/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/analyzer/ModelDeclarationProcessor.java
@@ -54,6 +54,7 @@ import com.asakusafw.dmdl.semantics.trait.JoinTrait;
 import com.asakusafw.dmdl.semantics.trait.MappingFactor;
 import com.asakusafw.dmdl.semantics.trait.ProjectionsTrait;
 import com.asakusafw.dmdl.semantics.trait.ReduceTerm;
+import com.asakusafw.dmdl.semantics.trait.ReferencesTrait;
 import com.asakusafw.dmdl.semantics.trait.SummarizeTrait;
 
 final class ModelDeclarationProcessor {
@@ -99,9 +100,11 @@ final class ModelDeclarationProcessor {
         assert model != null;
         assert node != null;
         LOG.debug("resolving record: {}", model.getName()); //$NON-NLS-1$
-        List<ModelSymbol> projections = PropertyDeclarationProcessor.resolve(context, model, node.expression);
-        LOG.debug("record {} has projections: {}", model.getName(), projections); //$NON-NLS-1$
-        model.putTrait(ProjectionsTrait.class, new ProjectionsTrait(node.expression, projections));
+        PropertyDeclarationProcessor refs = PropertyDeclarationProcessor.resolve(context, model, node.expression);
+        LOG.debug("record {} has references: {}", model.getName(), refs.references); //$NON-NLS-1$
+        LOG.debug("record {} has projections: {}", model.getName(), refs.projections); //$NON-NLS-1$
+        model.putTrait(ReferencesTrait.class, new ReferencesTrait(node.expression, refs.references));
+        model.putTrait(ProjectionsTrait.class, new ProjectionsTrait(node.expression, refs.projections));
 
         if (context.hasError()) {
             return;

--- a/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/analyzer/PropertyDeclarationProcessor.java
+++ b/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/analyzer/PropertyDeclarationProcessor.java
@@ -39,16 +39,19 @@ final class PropertyDeclarationProcessor extends AbstractVisitor<ModelDeclaratio
 
     private final Context context;
 
-    private final List<ModelSymbol> projections = new ArrayList<>();
+    final List<ModelSymbol> references = new ArrayList<>();
+
+    final List<ModelSymbol> projections = new ArrayList<>();
 
     private PropertyDeclarationProcessor(Context context) {
         this.context = context;
     }
 
-    static List<ModelSymbol> resolve(Context context, ModelDeclaration model, AstExpression<AstRecord> node) {
+    static PropertyDeclarationProcessor resolve(
+            Context context, ModelDeclaration model, AstExpression<AstRecord> node) {
         PropertyDeclarationProcessor resolver = new PropertyDeclarationProcessor(context);
         node.accept(model, resolver);
-        return resolver.projections;
+        return resolver;
     }
 
     @Override
@@ -94,8 +97,10 @@ final class PropertyDeclarationProcessor extends AbstractVisitor<ModelDeclaratio
                     property.getDescription(),
                     property.getAttributes());
         }
+        ModelSymbol ref = context.getWorld().createModelSymbol(node.name);
+        references.add(ref);
         if (decl.getOriginalAst().kind == ModelDefinitionKind.PROJECTIVE) {
-            projections.add(context.getWorld().createModelSymbol(node.name));
+            projections.add(ref);
         }
         return null;
     }

--- a/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/semantics/Declaration.java
+++ b/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/semantics/Declaration.java
@@ -16,6 +16,7 @@
 package com.asakusafw.dmdl.semantics;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.asakusafw.dmdl.model.AstAttribute;
 import com.asakusafw.dmdl.model.AstDescription;
@@ -23,6 +24,8 @@ import com.asakusafw.dmdl.model.AstSimpleName;
 
 /**
  * Super interface of the all declarations.
+ * @since 0.1.0
+ * @version 0.10.2
  */
 public interface Declaration extends Element {
 
@@ -55,6 +58,18 @@ public interface Declaration extends Element {
      * @throws IllegalArgumentException if some parameters were {@code null}
      */
     <T extends Trait<T>> T getTrait(Class<T> kind);
+
+    /**
+     * Returns the specified trait of this declaration.
+     * @param <T> type of trait
+     * @param kind the kind of trait
+     * @return the trait, or empty if not put
+     * @throws IllegalArgumentException if some parameters were {@code null}
+     * @since 0.10.2
+     */
+    default <T extends Trait<T>> Optional<T> findTrait(Class<T> kind) {
+        return Optional.ofNullable(getTrait(kind));
+    }
 
     /**
      * Puts a trait into this declaration.

--- a/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/semantics/trait/ReferencesTrait.java
+++ b/dmdl-project/asakusa-dmdl-core/src/main/java/com/asakusafw/dmdl/semantics/trait/ReferencesTrait.java
@@ -22,26 +22,26 @@ import com.asakusafw.dmdl.semantics.ModelSymbol;
 import com.asakusafw.dmdl.semantics.Trait;
 
 /**
- * Projections in use.
+ * Referred models.
  */
-public class ProjectionsTrait implements Trait<ProjectionsTrait> {
+public class ReferencesTrait implements Trait<ReferencesTrait> {
 
     private final AstNode originalAst;
 
-    private final List<ModelSymbol> projections;
+    private final List<ModelSymbol> references;
 
     /**
      * Creates and returns a new instance.
      * @param originalAst the original AST, or {@code null} if this is an ad-hoc element
-     * @param projections each projective model in references
+     * @param references each referred model
      * @throws IllegalArgumentException if some parameters were {@code null}
      */
-    public ProjectionsTrait(AstNode originalAst, List<ModelSymbol> projections) {
-        if (projections == null) {
-            throw new IllegalArgumentException("projectives must not be null"); //$NON-NLS-1$
+    public ReferencesTrait(AstNode originalAst, List<ModelSymbol> references) {
+        if (references == null) {
+            throw new IllegalArgumentException("references must not be null"); //$NON-NLS-1$
         }
         this.originalAst = originalAst;
-        this.projections = projections;
+        this.references = references;
     }
 
     @Override
@@ -50,10 +50,10 @@ public class ProjectionsTrait implements Trait<ProjectionsTrait> {
     }
 
     /**
-     * Returns owned projective models.
-     * @return the projections
+     * Returns referred models.
+     * @return the referred models
      */
-    public List<ModelSymbol> getProjections() {
-        return projections;
+    public List<ModelSymbol> getReferences() {
+        return references;
     }
 }


### PR DESCRIPTION
## Summary

This enables data model classes inherit deep projective models as Java interfaces, and their projective models can behave as projection of the target data model.

## Background, Problem or Goal of the patch

The latest implementation, projections must be appear in the right hand side of record model definitions.

For example, in the following DMDL snippet,  the declared model `x` composites another model `base`. and `base` has `p` as its projection. In this case, the model `x` does not have `p` as its projection even if `x` has all properties declared in `p`.

```
projective p = ...;
base = p + ...;
x = base + ...;
```

This PR enables `p` also become `x`'s projection via `base`. In other words, "`x` **inherits** all projections of `base`". 

Similarly, in the following case, `y` becomes a sub projection of `p`.

```
projective p = ...;
base = p + ...;
projective y = base + ...;
```

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.