### PR TITLE
Fix to assemble when enabling yaess.jobqueueEnabled

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -29,6 +29,7 @@ ext.parentPom = { f ->
         'jsch-version' : props['jsch.version'].text(),
         'gson-version' : props['gson.version'].text(),
         'http-client-version' : props['httpclient.version'].text(),
+        'http-core-version' : props['httpcore.version'].text(),
         'commons-cli-version' : props['commons.cli.version'].text(),
         'commons-codec-version' : props['commons.codec.version'].text(),
         'commons-io-version' : props['commons.io.version'].text(),

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBaseExtension.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBaseExtension.groovy
@@ -74,6 +74,11 @@ class AsakusafwBaseExtension {
     String httpClientVersion
 
     /**
+     * The default HTTP Core version.
+     */
+    String httpCoreVersion
+
+    /**
      * The default Commons CLI version.
      */
     String commonsCliVersion

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
@@ -95,6 +95,7 @@ class AsakusafwBasePlugin implements Plugin<Project> {
             'jsch-version': 'JSch',
             'gson-version': 'GSON',
             'http-client-version': 'Commons HTTP Client',
+            'http-core-version': 'Commons HTTP Core',
             'commons-cli-version': 'Commons CLI',
             'commons-io-version': 'Commons IO',
             'commons-lang-version': 'Commons Lang',

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusafwOrganizer.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusafwOrganizer.groovy
@@ -146,7 +146,7 @@ class AsakusafwOrganizer extends AbstractOrganizer {
                 ],
                 YaessJobQueueLib : [
                     "com.asakusafw:asakusa-yaess-jobqueue:${base.frameworkVersion}@jar",
-                    "org.apache.httpcomponents:httpcore:${base.httpClientVersion}@jar",
+                    "org.apache.httpcomponents:httpcore:${base.httpCoreVersion}@jar",
                     "org.apache.httpcomponents:httpclient:${base.httpClientVersion}@jar",
                     "com.google.code.gson:gson:${base.gsonVersion}@jar",
                     "commons-codec:commons-codec:${base.commonsCodecVersion}@jar",

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
 
     <!-- fragile artifacts -->
     <httpclient.version>4.2.6</httpclient.version>
+    <httpcore.version>4.2.5</httpcore.version>
     <commons.cli.version>1.2</commons.cli.version>
     <commons.io.version>2.4</commons.io.version>
     <commons.lang.version>2.6</commons.lang.version>


### PR DESCRIPTION
## Summary
This PR fix to fail on assemble task when specifing `asakusafwOrganizer.yaess.jobqueueEnabled` in `build.gradle` 

## Background, Problem or Goal of the patch
Asakusa Gradle Plugin specifies `org.apache.httpcomponents:httpcore:4.2.6` as dependencies for `YaessJobQueueLib` but that version does not exist. The correct version is `4.2.5`.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.
