### PR TITLE
Fix Direct I/O text parsers.

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/line/BasicLineInput.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/line/BasicLineInput.java
@@ -206,7 +206,7 @@ public class BasicLineInput extends LineInput {
         cs.limit(cs.position() + len);
         while (true) {
             bs.clear();
-            CoderResult result = encoder.encode(cs, bs, true);
+            CoderResult result = encoder.encode(cs, bs, false);
             if (result.isError() == false) {
                 bs.flip();
                 entity.append(bs.array(), bs.position(), bs.limit());

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/value/StringOptionFieldAdapter.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/io/text/value/StringOptionFieldAdapter.java
@@ -17,8 +17,10 @@ package com.asakusafw.runtime.io.text.value;
 
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 
@@ -31,10 +33,13 @@ import com.asakusafw.runtime.value.StringOption;
 /**
  * An implementation of {@link FieldAdapter} which accepts {@link StringOption}.
  * @since 0.9.1
+ * @version 0.10.2
  */
 public final class StringOptionFieldAdapter extends ValueOptionFieldAdapter<StringOption> {
 
-    private final CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
+    private final CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT);
 
     private final ByteBuffer encodeBuffer = ByteBuffer.allocate(256);
 
@@ -53,29 +58,63 @@ public final class StringOptionFieldAdapter extends ValueOptionFieldAdapter<Stri
     @Override
     protected void doParse(CharSequence contents, StringOption property) {
         property.reset();
-        Text text = property.get();
-        CharBuffer cbuf = CharBuffer.wrap(contents);
-        ByteBuffer bbuf = encodeBuffer;
-        CharsetEncoder enc = encoder;
-        enc.reset();
-        while (cbuf.hasRemaining()) {
-            bbuf.clear();
-            CoderResult result = enc.encode(cbuf, bbuf, true);
-            if (result.isError()) {
-                throw new IllegalArgumentException(MessageFormat.format(
-                        "cannot map input string to UTF-8: {0}",
-                        TextUtil.quote(contents)));
+        if (contents.length() == 0) {
+            return;
+        }
+        try {
+            append(CharBuffer.wrap(contents), property, encoder, encodeBuffer);
+        } catch (CharacterCodingException e) {
+            throw new IllegalArgumentException(MessageFormat.format(
+                    "cannot map input string to UTF-8: {0}",
+                    TextUtil.quote(contents)), e);
+        }
+    }
+
+    /**
+     * Appends source contents into the destination string.
+     * @param source the source buffer
+     * @param destination the target StringOption
+     * @param encoder the encoder
+     * @param buffer the working buffer
+     * @throws CharacterCodingException if error occurred while encoding source input
+     */
+    public static void append(
+            CharBuffer source, StringOption destination,
+            CharsetEncoder encoder, ByteBuffer buffer) throws CharacterCodingException {
+        if (source.hasRemaining() == false) {
+            return;
+        }
+        Text text = destination.get();
+        encoder.reset();
+        while (source.hasRemaining()) {
+            buffer.clear();
+            CoderResult r1 = encoder.encode(source, buffer, false);
+            if (r1.isError()) {
+                r1.throwException();
             }
-            bbuf.flip();
-            if (bbuf.hasRemaining()) {
-                text.append(bbuf.array(), bbuf.arrayOffset() + bbuf.position(), bbuf.remaining());
+            append0(buffer, text);
+            if (r1.isUnderflow()) {
+                buffer.clear();
+                CoderResult r2 = encoder.encode(source, buffer, true);
+                if (r2.isError()) {
+                    r2.throwException();
+                }
+                append0(buffer, text);
+                break;
             }
-            bbuf.clear();
-            enc.flush(bbuf);
-            bbuf.flip();
-            if (bbuf.hasRemaining()) {
-                text.append(bbuf.array(), bbuf.arrayOffset() + bbuf.position(), bbuf.remaining());
-            }
+        }
+        buffer.clear();
+        CoderResult r3 = encoder.flush(buffer);
+        if (r3.isError()) {
+            r3.throwException();
+        }
+        append0(buffer, text);
+    }
+
+    private static void append0(ByteBuffer buffer, Text text) {
+        buffer.flip();
+        if (buffer.hasRemaining()) {
+            text.append(buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
         }
     }
 

--- a/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/value/StringOptionFieldAdapterTest.java
+++ b/core-project/asakusa-runtime/src/test/java/com/asakusafw/runtime/io/text/value/StringOptionFieldAdapterTest.java
@@ -65,6 +65,19 @@ public class StringOptionFieldAdapterTest {
     }
 
     /**
+     * parse - overflow.
+     */
+    @Test
+    public void parse_overflow() {
+        StringOptionFieldAdapter adapter = StringOptionFieldAdapter.builder().build();
+        StringBuilder buf = new StringBuilder();
+        for (int i = 0; i < 257; i++) {
+            buf.append('a');
+        }
+        checkParse(adapter, buf.toString(), new StringOption(buf.toString()));
+    }
+
+    /**
      * parse - broken UTF-16.
      */
     @Test


### PR DESCRIPTION
## Summary

This PR fixes Direct I/O parsers of line, formatted text, and legacy TSV.

## Background, Problem or Goal of the patch

The latest implementation, Direct I/O parsers sometimes will be failed when reading large fields.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.