### PR TITLE
Add `FlowDriverInput.prepare(String, ModelTransformer)`.

### DIFF
--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/DriverInputBase.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/DriverInputBase.java
@@ -24,12 +24,14 @@ import org.slf4j.LoggerFactory;
 import com.asakusafw.testdriver.core.DataModelDefinition;
 import com.asakusafw.testdriver.core.DataModelReflection;
 import com.asakusafw.testdriver.core.DataModelSourceFactory;
+import com.asakusafw.testdriver.core.DataModelSourceFilter;
+import com.asakusafw.testdriver.core.ModelTransformer;
 import com.asakusafw.testdriver.core.TestDataToolProvider;
 
 /**
  * An abstract super class of test driver inputs.
  * @since 0.2.0
- * @version 0.6.0
+ * @version 0.10.2
  * @param <T> the data model type
  */
 public abstract class DriverInputBase<T> extends DriverElementBase {
@@ -153,5 +155,16 @@ public abstract class DriverInputBase<T> extends DriverElementBase {
                     name,
                     modelType.getName()), e);
         }
+    }
+
+    /**
+     * Converts an model transformer into {@link DataModelSourceFilter}.
+     * @param transformer the data model transformer
+     * @return the filter which transforms each data model objects using the transformer
+     * @since 0.10.2
+     */
+    protected final DataModelSourceFilter toDataModelSourceFilter(ModelTransformer<? super T> transformer) {
+        DataModelDefinition<T> definition = getDataModelDefinition();
+        return toDataModelSourceFilter(definition, transformer);
     }
 }

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/DriverOutputBase.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/DriverOutputBase.java
@@ -25,14 +25,11 @@ import java.util.function.UnaryOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.asakusafw.testdriver.core.DataModelDefinition;
 import com.asakusafw.testdriver.core.DataModelSinkFactory;
 import com.asakusafw.testdriver.core.DataModelSource;
 import com.asakusafw.testdriver.core.DataModelSourceFactory;
-import com.asakusafw.testdriver.core.DataModelSourceFilter;
 import com.asakusafw.testdriver.core.DifferenceSinkFactory;
 import com.asakusafw.testdriver.core.ModelTester;
-import com.asakusafw.testdriver.core.ModelTransformer;
 import com.asakusafw.testdriver.core.ModelVerifier;
 import com.asakusafw.testdriver.core.TestDataToolProvider;
 import com.asakusafw.testdriver.core.TestRule;
@@ -199,17 +196,6 @@ public class DriverOutputBase<T> extends DriverInputBase<T> {
      */
     protected final DifferenceSinkFactory toDifferenceSinkFactory(File path) {
         return getTestTools().getDifferenceSinkFactory(path.toURI());
-    }
-
-    /**
-     * Converts an model transformer into {@link DataModelSourceFilter}.
-     * @param transformer the data model transformer
-     * @return the filter which transforms each data model objects using the transformer
-     * @since 0.7.0
-     */
-    protected final DataModelSourceFilter toDataModelSourceFilter(ModelTransformer<? super T> transformer) {
-        DataModelDefinition<T> definition = getDataModelDefinition();
-        return toDataModelSourceFilter(definition, transformer);
     }
 
     /**

--- a/testing-project/asakusa-test-moderator/src/main/java/com/asakusafw/testdriver/core/DataModelSourceFilter.java
+++ b/testing-project/asakusa-test-moderator/src/main/java/com/asakusafw/testdriver/core/DataModelSourceFilter.java
@@ -15,11 +15,13 @@
  */
 package com.asakusafw.testdriver.core;
 
+import java.io.IOException;
 import java.util.function.UnaryOperator;
 
 /**
  * Filters {@link DataModelSource}s.
  * @since 0.7.0
+ * @version 0.10.2
  */
 @FunctionalInterface
 public interface DataModelSourceFilter extends UnaryOperator<DataModelSource> {
@@ -31,4 +33,21 @@ public interface DataModelSourceFilter extends UnaryOperator<DataModelSource> {
      */
     @Override
     DataModelSource apply(DataModelSource source);
+
+    /**
+     * Applies this filter into the factory.
+     * @param factory the target factory
+     * @return the applied factory
+     * @since 0.10.2
+     */
+    default DataModelSourceFactory apply(DataModelSourceFactory factory) {
+        return new DataModelSourceFactory() {
+            @Override
+            public <T> DataModelSource createSource(
+                    DataModelDefinition<T> definition,
+                    TestContext context) throws IOException {
+                return DataModelSourceFilter.this.apply(factory.createSource(definition, context));
+            }
+        };
+    }
 }


### PR DESCRIPTION
## Summary

This PR introduces `FlowDriverInput.prepare(String, ModelTransformer)` to test facility that enables transforms test inputs.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.