### PR TITLE
Use Consumer instead of ModelTransformer.

### DIFF
--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/DriverElementBase.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/DriverElementBase.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
 import org.apache.hadoop.conf.Configuration;
@@ -37,7 +38,6 @@ import com.asakusafw.testdriver.core.DataModelSourceFactory;
 import com.asakusafw.testdriver.core.DataModelSourceFilter;
 import com.asakusafw.testdriver.core.Difference;
 import com.asakusafw.testdriver.core.IteratorDataModelSource;
-import com.asakusafw.testdriver.core.ModelTransformer;
 import com.asakusafw.testdriver.core.SourceDataModelSource;
 import com.asakusafw.testdriver.core.TestContext;
 import com.asakusafw.testdriver.core.TestDataToolProvider;
@@ -230,7 +230,7 @@ public abstract class DriverElementBase {
      */
     protected final <T> DataModelSourceFilter toDataModelSourceFilter(
             DataModelDefinition<T> definition,
-            ModelTransformer<? super T> transformer) {
+            Consumer<? super T> transformer) {
         return new DataModelSourceFilter() {
             @Override
             public DataModelSource apply(DataModelSource source) {
@@ -242,7 +242,7 @@ public abstract class DriverElementBase {
                             return null;
                         }
                         T object = definition.toObject(next);
-                        transformer.transform(object);
+                        transformer.accept(object);
                         return definition.toReflection(object);
                     }
                     @Override

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/DriverInputBase.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/DriverInputBase.java
@@ -17,6 +17,7 @@ package com.asakusafw.testdriver;
 
 import java.io.IOException;
 import java.text.MessageFormat;
+import java.util.function.Consumer;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +26,6 @@ import com.asakusafw.testdriver.core.DataModelDefinition;
 import com.asakusafw.testdriver.core.DataModelReflection;
 import com.asakusafw.testdriver.core.DataModelSourceFactory;
 import com.asakusafw.testdriver.core.DataModelSourceFilter;
-import com.asakusafw.testdriver.core.ModelTransformer;
 import com.asakusafw.testdriver.core.TestDataToolProvider;
 
 /**
@@ -163,7 +163,7 @@ public abstract class DriverInputBase<T> extends DriverElementBase {
      * @return the filter which transforms each data model objects using the transformer
      * @since 0.10.2
      */
-    protected final DataModelSourceFilter toDataModelSourceFilter(ModelTransformer<? super T> transformer) {
+    protected final DataModelSourceFilter toDataModelSourceFilter(Consumer<? super T> transformer) {
         DataModelDefinition<T> definition = getDataModelDefinition();
         return toDataModelSourceFilter(definition, transformer);
     }

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/FlowDriverOutput.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/FlowDriverOutput.java
@@ -636,4 +636,17 @@ public abstract class FlowDriverOutput<T, S extends FlowDriverOutput<T, S>> exte
         }
         return dumpDifference(toDifferenceSinkFactory(outputPath));
     }
+
+    /**
+     * Configures this object.
+     * @param configurator the configurator
+     * @return this
+     * @since 0.10.2
+     */
+    public S with(Consumer<? super S> configurator) {
+        if (configurator != null) {
+            configurator.accept(getThis());
+        }
+        return getThis();
+    }
 }

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/FlowDriverOutput.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/FlowDriverOutput.java
@@ -18,13 +18,18 @@ package com.asakusafw.testdriver;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.asakusafw.runtime.directio.DataFormat;
 import com.asakusafw.testdriver.core.DataModelDefinition;
 import com.asakusafw.testdriver.core.DataModelSinkFactory;
 import com.asakusafw.testdriver.core.DataModelSource;
 import com.asakusafw.testdriver.core.DataModelSourceFactory;
+import com.asakusafw.testdriver.core.DataModelSourceFilter;
 import com.asakusafw.testdriver.core.DifferenceSinkFactory;
 import com.asakusafw.testdriver.core.ModelTester;
 import com.asakusafw.testdriver.core.ModelTransformer;
@@ -43,6 +48,8 @@ import com.asakusafw.utils.io.Source;
  * @version 0.9.1
  */
 public abstract class FlowDriverOutput<T, S extends FlowDriverOutput<T, S>> extends DriverOutputBase<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FlowDriverOutput.class);
 
     /**
      * Creates a new instance.
@@ -70,10 +77,27 @@ public abstract class FlowDriverOutput<T, S extends FlowDriverOutput<T, S>> exte
      * @since 0.6.0
      */
     public S prepare(DataModelSourceFactory factory) {
+        return prepare(factory, null);
+    }
+
+    /**
+     * Sets the test data set for this output.
+     * @param factory factory which provides test data set
+     * @param transformer the input source transformer
+     * @return this
+     * @since 0.10.2
+     */
+    public S prepare(DataModelSourceFactory factory, Consumer<? super T> transformer) {
         if (factory == null) {
             throw new IllegalArgumentException("factory must not be null"); //$NON-NLS-1$
         }
-        setSource(factory);
+        LOG.debug("prepare - ModelType: {}", getModelType()); //$NON-NLS-1$
+        if (transformer == null) {
+            setSource(factory);
+        } else {
+            DataModelSourceFilter filter = toDataModelSourceFilter(transformer);
+            setSource(filter.apply(factory));
+        }
         return getThis();
     }
 
@@ -530,13 +554,23 @@ public abstract class FlowDriverOutput<T, S extends FlowDriverOutput<T, S>> exte
      * Enables to transform the result data before verifying the results of this output.
      * @param transformer the data model object transformer
      * @return this
-     * @since 0.7.0
+     * @since 0.10.2
      */
-    public S transform(ModelTransformer<? super T> transformer) {
+    public S transform(Consumer<? super T> transformer) {
         if (transformer == null) {
             throw new IllegalArgumentException("transformer must not be null"); //$NON-NLS-1$
         }
         return filter(toDataModelSourceFilter(transformer));
+    }
+
+    /**
+     * Enables to transform the result data before verifying the results of this output.
+     * @param transformer the data model object transformer
+     * @return this
+     * @since 0.7.0
+     */
+    public S transform(ModelTransformer<? super T> transformer) {
+        return transform((Consumer<? super T>) transformer);
     }
 
     /**

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/FlowDriverOutputTest.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/FlowDriverOutputTest.java
@@ -454,6 +454,17 @@ public class FlowDriverOutputTest {
     }
 
     /**
+     * Test method for {@link FlowDriverOutput#transform(ModelTransformer)}.
+     */
+    @Test
+    public void transform_lambda() {
+        MockFlowDriverOutput<Text> mock = MockFlowDriverOutput.text(getClass(), tool_rule("Hello3!"));
+        mock.transform(s -> s.set(s.toString() + "!"));
+        mock.verify(list("Hello1!", "Hello2!", "Hello3!"), "data/dummy");
+        assertThat(test(mock.getVerifier(), "Hello1", "Hello2", "Hello3"), hasSize(1));
+    }
+
+    /**
      * Test method for {@link FlowDriverOutput#dumpActual(String)}.
      */
     @Test

--- a/testing-project/asakusa-test-moderator/src/main/java/com/asakusafw/testdriver/core/ModelTransformer.java
+++ b/testing-project/asakusa-test-moderator/src/main/java/com/asakusafw/testdriver/core/ModelTransformer.java
@@ -15,13 +15,21 @@
  */
 package com.asakusafw.testdriver.core;
 
+import java.util.function.Consumer;
+
 /**
  * Transforms data model objects.
  * @param <T> the data model type
  * @since 0.7.0
+ * @version 0.10.2
  */
 @FunctionalInterface
-public interface ModelTransformer<T> {
+public interface ModelTransformer<T> extends Consumer<T> {
+
+    @Override
+    default void accept(T t) {
+        transform(t);
+    }
 
     /**
      * Transforms the target data model object.


### PR DESCRIPTION
## Summary

This PR is revision of #820, replaced `ModelTransformer` with `Consumer`.

## Background, Problem or Goal of the patch

We have introduced `prepare(String, ModelTransformer)` since #820, but the `ModelTransformer` only has functionally equivalent to `Consumer`. To gain portability, this PR replaces `ModelTransformer` with `Consumer`.

## Design of the fix, or a new feature

This PR additionally enables to transform test inputs from other data set kinds, for example, we introduced `transformer` parameters to Direct I/O test inputs, like `prepare(Class<? extends DataFormat<...>>, String, Consumer<...>)`.

## Related Issue, Pull Request or Code

* #820 