### PR TITLE
Introduce `*Tester.loader()`.

### DIFF
--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/BasicDataLoader.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/BasicDataLoader.java
@@ -21,6 +21,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.asakusafw.runtime.core.View;
 import com.asakusafw.testdriver.core.DataModelDefinition;
@@ -87,7 +88,7 @@ public class BasicDataLoader<T> implements DataLoader<T> {
     }
 
     @Override
-    public List<T> asList() {
+    public Stream<T> asStream() {
         List<DataModelReflection> refs = new ArrayList<>();
         try (DataModelSource source = factory.createSource(definition, context)) {
             while (true) {
@@ -105,8 +106,12 @@ public class BasicDataLoader<T> implements DataLoader<T> {
         }
         return refs.stream()
                 .sequential()
-                .map(definition::toObject)
-                .collect(Collectors.toList());
+                .map(definition::toObject);
+    }
+
+    @Override
+    public List<T> asList() {
+        return asStream().collect(Collectors.toList());
     }
 
     @Override

--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/DataLoader.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/loader/DataLoader.java
@@ -17,6 +17,7 @@ package com.asakusafw.testdriver.loader;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Stream;
 
 import com.asakusafw.runtime.core.View;
 import com.asakusafw.vocabulary.model.Key;
@@ -25,6 +26,7 @@ import com.asakusafw.vocabulary.model.Key;
  * Loads a dataset and organize it for operator inputs.
  * @param <T> the data type
  * @since 0.9.1
+ * @version 0.10.2
  */
 public interface DataLoader<T> {
 
@@ -54,6 +56,15 @@ public interface DataLoader<T> {
      * @throws IllegalStateException if sort order is already configured
      */
     DataLoader<T> order(Comparator<? super T> comparator);
+
+    /**
+     * Returns the loaded data as a stream.
+     * @return the organized stream
+     * @since 0.10.2
+     */
+    default Stream<T> asStream() {
+        return asList().stream();
+    }
 
     /**
      * Returns the loaded data as a list.


### PR DESCRIPTION
## Summary

This PR introduces `{Batch,Jobflow,FlowPart}Tester.loader()` like `OperatorTestEnvironment.loader()`.

## Background, Problem or Goal of the patch

In #820 and #821, we have enabled to transform test input dataset. This PR additionally enables load test input datasets manually, and then can drive them to each flow input.

## Design of the fix, or a new feature

This PR also introduces `DataLoader.asStream()` to manipulate input dataset on the stream.

## Related Issue, Pull Request or Code

* #820 
* #821
