### PR TITLE
Introduce `OperatorTestEnvironment.newInstance()`.

### DIFF
--- a/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/OperatorTestEnvironment.java
+++ b/testing-project/asakusa-test-driver/src/main/java/com/asakusafw/testdriver/OperatorTestEnvironment.java
@@ -202,14 +202,10 @@ public class OperatorTestEnvironment extends DriverElementBase implements TestRu
      */
     protected void before() {
         Configuration conf = createConfig();
-        for (Map.Entry<String, String> entry : extraConfigurations.entrySet()) {
-            conf.set(entry.getKey(), entry.getValue());
-        }
+        extraConfigurations.forEach(conf::set);
         if (batchArguments.isEmpty() == false) {
             VariableTable variables = new VariableTable(RedefineStrategy.OVERWRITE);
-            for (Map.Entry<String, String> entry : batchArguments.entrySet()) {
-                variables.defineVariable(entry.getKey(), entry.getValue());
-            }
+            variables.defineVariables(batchArguments);
             conf.set(StageConstants.PROP_ASAKUSA_BATCH_ARGS, variables.toSerialString());
         }
 
@@ -230,6 +226,9 @@ public class OperatorTestEnvironment extends DriverElementBase implements TestRu
      * @since 0.10.2
      */
     public <T> T newInstance(Class<T> operatorClass) {
+        if (operatorClass == null) {
+            throw new IllegalArgumentException("operatorClass must not be null"); //$NON-NLS-1$
+        }
         Class<? extends T> implementationClass = findImplementation(operatorClass);
         try {
             Constructor<? extends T> ctor = implementationClass.getConstructor();
@@ -334,9 +333,7 @@ public class OperatorTestEnvironment extends DriverElementBase implements TestRu
                     Messages.getString("OperatorTestEnvironment.errorMissingConfigurationFile"), //$NON-NLS-1$
                     configurationPath));
         }
-        for (Map.Entry<String, String> entry : extraConfigurations.entrySet()) {
-            conf.set(entry.getKey(), entry.getValue());
-        }
+        extraConfigurations.forEach(conf::set);
         conf.addResource(resource);
         return conf;
     }

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/OperatorTestEnvironmentTest.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/OperatorTestEnvironmentTest.java
@@ -290,16 +290,15 @@ public class OperatorTestEnvironmentTest {
 
     <T extends Throwable> void exec(Action<T> action) throws T {
         OperatorTestEnvironment env = new OperatorTestEnvironment().reset(getClass());
-        env.before();
-        try {
-            action.perform(env);
-        } finally {
-            env.after();
-        }
+        exec0(env, action);
     }
 
     <T extends Throwable> void exec(String configPath, Action<T> action) throws T {
         OperatorTestEnvironment env = new OperatorTestEnvironment(configPath).reset(getClass());
+        exec0(env, action);
+    }
+
+    private static <T extends Throwable> void exec0(OperatorTestEnvironment env, Action<T> action) throws T {
         env.before();
         try {
             action.perform(env);

--- a/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/testing/dsl/SimpleOperatorImpl.java
+++ b/testing-project/asakusa-test-driver/src/test/java/com/asakusafw/testdriver/testing/dsl/SimpleOperatorImpl.java
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2011-2018 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.testdriver.testing.dsl;
+
+/**
+ * An implementation of {@link SimpleOperator}.
+ */
+public class SimpleOperatorImpl extends SimpleOperator {
+    // no special members
+}


### PR DESCRIPTION
## Summary

This PR introduces `OperatorTestEnvironment.newInstance()` which provides operator implementation class instance from the corresponded operator class.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.