### PR TITLE
Fix Direct I/O Line for small files.

### DIFF
--- a/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/line/driver/LineFormatEmitter.java
+++ b/directio-project/asakusa-directio-dmdl/src/main/java/com/asakusafw/dmdl/directio/line/driver/LineFormatEmitter.java
@@ -398,7 +398,15 @@ public class LineFormatEmitter extends JavaDataModelDriver {
                         .newObject(
                                 blessInputStream(stream),
                                 Models.toLiteral(f, '\n'),
-                                fragmentSize,
+                                f.newConditionalExpression(
+                                        f.newInfixExpression(
+                                                fragmentSize,
+                                                InfixOperator.GREATER_EQUALS,
+                                                Models.toLiteral(f, 0L)),
+                                        fragmentSize,
+                                        new TypeBuilder(f, context.resolve(Long.class))
+                                            .field("MAX_VALUE") //$NON-NLS-1$
+                                            .toExpression()),
                                 isNotHead)
                         .toExpression())
                     .toStatement());

--- a/directio-project/asakusa-directio-dmdl/src/test/java/com/asakusafw/dmdl/directio/line/driver/LineFormatEmitterTest.java
+++ b/directio-project/asakusa-directio-dmdl/src/test/java/com/asakusafw/dmdl/directio/line/driver/LineFormatEmitterTest.java
@@ -64,7 +64,6 @@ public class LineFormatEmitterTest extends GeneratorTesterRoot {
      */
     @Test
     public void simple() throws Exception {
-        dump(true);
         ModelLoader loader = generateJavaFromLines(new String[] {
                 "@directio.line",
                 "simple = { value : TEXT; };",

--- a/directio-project/asakusa-directio-dmdl/src/test/java/com/asakusafw/dmdl/directio/line/driver/LineFormatEmitterTest.java
+++ b/directio-project/asakusa-directio-dmdl/src/test/java/com/asakusafw/dmdl/directio/line/driver/LineFormatEmitterTest.java
@@ -64,6 +64,7 @@ public class LineFormatEmitterTest extends GeneratorTesterRoot {
      */
     @Test
     public void simple() throws Exception {
+        dump(true);
         ModelLoader loader = generateJavaFromLines(new String[] {
                 "@directio.line",
                 "simple = { value : TEXT; };",
@@ -313,7 +314,7 @@ public class LineFormatEmitterTest extends GeneratorTesterRoot {
                 "Hello1",
                 "Hello2",
                 "Hello3",
-        }).getBytes("UTF-8"));
+        }).getBytes("UTF-8"), -1L);
 
         ModelWrapper model = loader.newModel("Simple");
         assertThat(reader.readTo(model.unwrap()), is(true));
@@ -368,7 +369,7 @@ public class LineFormatEmitterTest extends GeneratorTesterRoot {
                 HELLO_JP + "1",
                 HELLO_JP + "2",
                 HELLO_JP + "3",
-        }).getBytes("MS932"));
+        }).getBytes("MS932"), -1L);
 
         ModelWrapper model = loader.newModel("Simple");
         assertThat(reader.readTo(model.unwrap()), is(true));
@@ -563,6 +564,13 @@ public class LineFormatEmitterTest extends GeneratorTesterRoot {
     private void check(
             ModelLoader loader, String name,
             BinaryStreamFormat<Object> format) throws IOException, InterruptedException {
+        check(loader, name, format, -1L);
+    }
+
+    private void check(
+            ModelLoader loader, String name,
+            BinaryStreamFormat<Object> format,
+            long fragmentSize) throws IOException, InterruptedException {
         ModelWrapper model = loader.newModel(name);
         assertThat(format.getSupportedType(), equalTo((Object) model.getModelClass()));
 
@@ -573,7 +581,7 @@ public class LineFormatEmitterTest extends GeneratorTesterRoot {
             writer.write(model.unwrap());
         }
         Object buffer = loader.newModel(name).unwrap();
-        try (ModelInput<Object> reader = reader(format, output.toByteArray())) {
+        try (ModelInput<Object> reader = reader(format, output.toByteArray(), fragmentSize)) {
             assertThat(reader.readTo(buffer), is(true));
             assertThat(buffer, is(model.unwrap()));
             assertThat(reader.readTo(buffer), is(false));
@@ -583,10 +591,11 @@ public class LineFormatEmitterTest extends GeneratorTesterRoot {
 
     private ModelInput<Object> reader(
             BinaryStreamFormat<Object> format,
-            byte[] contents) throws IOException, InterruptedException {
+            byte[] contents,
+            long fragmentSize) throws IOException, InterruptedException {
         return format.createInput(
                 format.getSupportedType(), "testinig", new ByteArrayInputStream(contents),
-                0, contents.length);
+                0, fragmentSize);
     }
 
     private ModelOutput<Object> writer(


### PR DESCRIPTION
## Summary

This PR fixes Direct I/O Line support, that may crash for reading small files.

## Background, Problem or Goal of the patch

In the latest implementation, Direct I/O line does not read smaller files than the split size.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.