### PR TITLE
Enable unbound projective models.

### DIFF
--- a/operator/builtin/src/test/java/com/asakusafw/operator/builtin/LoggingOperatorDriverTest.java
+++ b/operator/builtin/src/test/java/com/asakusafw/operator/builtin/LoggingOperatorDriverTest.java
@@ -18,11 +18,13 @@ package com.asakusafw.operator.builtin;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeVariable;
 
 import org.junit.Test;
 
+import com.asakusafw.operator.CompileEnvironment;
 import com.asakusafw.operator.description.Descriptions;
 import com.asakusafw.operator.model.OperatorDescription;
 import com.asakusafw.operator.model.OperatorDescription.Node;
@@ -120,6 +122,37 @@ public class LoggingOperatorDriverTest extends OperatorDriverTestRoot {
                 Node output = description.getOutputs().get(0);
                 assertThat(output.getName(), is("out"));
                 assertThat(output.getType(), is(sameType(t)));
+            }
+        });
+    }
+
+    /**
+     * type parameter w/o bound.
+     */
+    @Test
+    public void unbound_projection() {
+        compile(new Action("com.example.UnboundProjection") {
+            @Override
+            protected void perform(OperatorElement target) {
+                OperatorDescription description = target.getDescription();
+                assertThat(description.getInputs().size(), is(1));
+                assertThat(description.getOutputs().size(), is(1));
+                assertThat(description.getArguments().size(), is(0));
+
+                TypeVariable t = getTypeVariable(target.getDeclaration(), "T");
+
+                Node input = description.getInputs().get(0);
+                assertThat(input.getName(), is("in"));
+                assertThat(input.getType(), is(sameType(t)));
+
+                Node output = description.getOutputs().get(0);
+                assertThat(output.getName(), is("out"));
+                assertThat(output.getType(), is(sameType(t)));
+            }
+            @Override
+            protected CompileEnvironment createCompileEnvironment(ProcessingEnvironment processingEnv) {
+                return super.createCompileEnvironment(processingEnv)
+                        .withUnboundProjection(true);
             }
         });
     }

--- a/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/LoggingOperatorDriverTest.files/com/example/UnboundProjection.java.txt
+++ b/operator/builtin/src/test/resources/com/asakusafw/operator/builtin/LoggingOperatorDriverTest.files/com/example/UnboundProjection.java.txt
@@ -1,0 +1,11 @@
+package com.example;
+
+import com.asakusafw.vocabulary.operator.*;
+
+public abstract class $s {
+
+    @Logging
+    public <T> String method(T in) {
+        return null;
+    }
+}

--- a/operator/core/src/main/java/com/asakusafw/operator/CompileEnvironment.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/CompileEnvironment.java
@@ -77,6 +77,8 @@ public class CompileEnvironment {
 
     private volatile boolean enumConstantParameter = false;
 
+    private volatile boolean unboundProjection = false;
+
     /**
      * Creates a new instance.
      * @param processingEnvironment current annotation processing environment
@@ -487,6 +489,26 @@ public class CompileEnvironment {
     }
 
     /**
+     * Returns whether or not the operators can accept unbound projective models.
+     * @return {@code true} if operators can accept unbound projective models, otherwise {@code false}
+     * @since 0.10.3
+     */
+    public boolean isUnboundProjection() {
+        return unboundProjection;
+    }
+
+    /**
+     * Sets whether or not the operators can accept unbound projective models.
+     * @param newValue {@code true} to accept unbound projective models, otherwise {@code false}
+     * @return this
+     * @since 0.10.3
+     */
+    public CompileEnvironment withUnboundProjection(boolean newValue) {
+        this.unboundProjection = newValue;
+        return this;
+    }
+
+    /**
      * Represents kind of supported features in {@link CompileEnvironment}.
      */
     public enum Support {
@@ -532,6 +554,12 @@ public class CompileEnvironment {
          * @since 0.10.2
          */
         ENUM_CONSTANT_PARAMETER(CompileEnvironment::withEnumConstantParameter),
+
+        /**
+         * Accepts unbound projective models.
+         * @since 0.10.3
+         */
+        UNBOUND_PROJECTION(CompileEnvironment::withUnboundProjection),
 
         /**
          * Supports external I/O ports in flow parts.

--- a/operator/core/src/main/java/com/asakusafw/operator/CompileEnvironment.java
+++ b/operator/core/src/main/java/com/asakusafw/operator/CompileEnvironment.java
@@ -47,7 +47,7 @@ import com.asakusafw.utils.java.model.util.Models;
 /**
  * Represents operator compiler environment.
  * @since 0.9.0
- * @version 0.10.2
+ * @version 0.10.3
  */
 public class CompileEnvironment {
 
@@ -77,7 +77,7 @@ public class CompileEnvironment {
 
     private volatile boolean enumConstantParameter = false;
 
-    private volatile boolean unboundProjection = false;
+    private volatile boolean unboundProjection = true;
 
     /**
      * Creates a new instance.

--- a/operator/dmdl/src/test/java/com/asakusafw/operator/dmdl/DmdlDataModelMirrorRepositoryTest.java
+++ b/operator/dmdl/src/test/java/com/asakusafw/operator/dmdl/DmdlDataModelMirrorRepositoryTest.java
@@ -49,6 +49,8 @@ public class DmdlDataModelMirrorRepositoryTest {
             runner.add("TOther", String.format("public abstract class TOther<T extends %s> extends %s {}",
                     MockFloatProjection.class.getName(),
                     Constants.TYPE_FLOW_DESCRIPTION.getClassName()));
+            runner.add("TBare", String.format("public abstract class TBare<T> extends %s {}",
+                    Constants.TYPE_FLOW_DESCRIPTION.getClassName()));
         }
     };
 
@@ -88,6 +90,18 @@ public class DmdlDataModelMirrorRepositoryTest {
         PropertyMirror pInt = mirror.findProperty("int");
         assertThat(pInt, is(notNullValue()));
         assertThat(pInt.getType(), is(apt.sameType(apt.getType(IntOption.class))));
+    }
+
+    /**
+     * Loads a partial DMDL data model.
+     */
+    @Test
+    public void load_bare() {
+        apt.env.withUnboundProjection(true);
+        DataModelMirror mirror = apt.env.findDataModel(apt.getTypeVariable("TBare", "T"));
+        assertThat(mirror, is(notNullValue()));
+
+        assertThat(mirror.getKind(), is(DataModelMirror.Kind.PARTIAL));
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR enables operator methods to declare unbound projective models.

## Background, Problem or Goal of the patch

The latest implementation, the operator compiler rejects unbound type parameters like `public <T> void operator(T ...)`. This PR additionally allows them as "unbound projection" which means empty projection for all data models.

## Design of the fix, or a new feature

This feature is **enabled** in default. To disable this, please insert the following in your `build.gradle`.

```
asakusafw.javac.processorOption 'com.asakusafw.operator. UNBOUND_PROJECTION', 'false'
```

## Related Issue, Pull Request or Code

N/A.