### PR TITLE
add backward compatible flag of #835.

### DIFF
--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/hadoop/HadoopDataSourceProfile.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/hadoop/HadoopDataSourceProfile.java
@@ -144,6 +144,18 @@ public class HadoopDataSourceProfile {
     private final LocalFileSystem localFileSystem;
 
     /**
+     * the Hadoop configuration key of whether or not use the <em>minimum</em> value between
+     * {@link #getMinimumFragmentSize()} and {@link FragmentableDataFormat#getMinimumFragmentSize()}.
+     * After the <a href="https://github.com/asakusafw/asakusafw/pull/835"> issue </a> was fixed,
+     * we use the <em>maximum</em> value of them.
+     * @since 0.10.3
+     * @see <a href="https://github.com/asakusafw/asakusafw/pull/835"> GitHub issue page </a>
+     */
+    public static final String KEY_LEGACY_FRAGMENT_MIN = HadoopDataSourceUtil.PREFIX + "COMPAT835"; //$NON-NLS-1$
+
+    private final boolean legacyFragmentMin;
+
+    /**
      * Creates a new instance.
      * @param conf the current configuration
      * @param id the ID of this datasource
@@ -165,6 +177,7 @@ public class HadoopDataSourceProfile {
         this.temporaryPath = temporaryPath;
         this.fileSystem = fileSystemPath.getFileSystem(conf);
         this.localFileSystem = FileSystem.getLocal(conf);
+        this.legacyFragmentMin = conf.getBoolean(KEY_LEGACY_FRAGMENT_MIN, false);
     }
 
     /**
@@ -231,7 +244,11 @@ public class HadoopDataSourceProfile {
         if (formatMin < 0 || minimumFragmentSize < 0) {
             return -1;
         }
-        return Math.max(formatMin, minimumFragmentSize);
+        if (!legacyFragmentMin) {
+            return Math.max(formatMin, minimumFragmentSize);
+        } else {
+            return Math.min(formatMin, minimumFragmentSize);
+        }
     }
 
     /**

--- a/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/util/DelimiterRangeInputStream.java
+++ b/core-project/asakusa-runtime/src/main/java/com/asakusafw/runtime/directio/util/DelimiterRangeInputStream.java
@@ -1,0 +1,254 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.runtime.directio.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.asakusafw.runtime.io.util.LineFeedDelimitedInputStream;
+
+/**
+ * {@link InputStream} for fragments with delimiter.
+ * @since 0.2.5
+ * @deprecated use {@link LineFeedDelimitedInputStream} instead
+ */
+@Deprecated
+public class DelimiterRangeInputStream extends InputStream {
+
+    private final InputStream origin;
+
+    private final char delimiter;
+
+    private long remaining;
+
+    private boolean endOfRange;
+
+    private final byte[] buffer;
+
+    private int bufferOffset;
+
+    private int bufferLimit;
+
+    /**
+     * Creates a new instance.
+     * @param stream original input
+     * @param delimiter delimiter character
+     * @param length soft limit in bytes
+     * @param skipFirst whether skip until first delimiter
+     * @throws IOException if failed to create instance by I/O error
+     * @throws IllegalArgumentException if some parameters were {@code null}
+     */
+    public DelimiterRangeInputStream(
+            InputStream stream,
+            char delimiter,
+            long length,
+            boolean skipFirst) throws IOException {
+        if (stream == null) {
+            throw new IllegalArgumentException("stream must not be null"); //$NON-NLS-1$
+        }
+        this.origin = stream;
+        this.delimiter = delimiter;
+        this.remaining = length;
+        this.endOfRange = false;
+        this.buffer = new byte[1024];
+        this.bufferOffset = 0;
+        this.bufferLimit = 0;
+        if (remaining == 0) {
+            endOfRange = true;
+        } else if (skipFirst) {
+            discardHead();
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (isBufferRemaining()) {
+            return buffer[bufferOffset++];
+        }
+        if (endOfRange) {
+            return -1;
+        }
+        if (isSoftLimitExceeded()) {
+            int c = origin.read();
+            if (c < 0) {
+                endOfRange = true;
+                return -1;
+            }
+            if (isDelimiter(c)) {
+                endOfRange = true;
+            }
+            return c;
+        } else {
+            int c = origin.read();
+            if (c < 0) {
+                endOfRange = true;
+                return -1;
+            }
+            remaining -= 1;
+            return c;
+        }
+    }
+
+    @Override
+    public int read(byte[] b) throws IOException {
+        return read(b, 0, b.length);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        int bufferedSize = fillFromBuffer(b, off, len);
+        if (bufferedSize > 0) {
+            return bufferedSize;
+        }
+        if (endOfRange) {
+            return -1;
+        }
+        if (isSoftLimitExceeded()) {
+            int read = origin.read(b, off, len);
+            if (read < 0) {
+                endOfRange = true;
+                return -1;
+            }
+            int index = findDelimiter(b, off, read);
+            if (index < 0) {
+                return read;
+            } else {
+                endOfRange = true;
+                return index - off + 1;
+            }
+        } else {
+            assert remaining > 0;
+            int rest = (int) Math.min(len, remaining);
+            int read = origin.read(b, off, rest);
+            if (read < 0) {
+                endOfRange = true;
+                return -1;
+            }
+            remaining -= read;
+            return read;
+        }
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        if (n <= 0) {
+            return 0;
+        }
+        if (isBufferRemaining()) {
+            long bufferRest = bufferLimit - bufferOffset;
+            long skipped = Math.min(n, bufferRest);
+            bufferOffset += skipped;
+            return skipped;
+        }
+        if (endOfRange) {
+            return 0;
+        }
+        if (isSoftLimitExceeded()) {
+            assert isBufferRemaining() == false;
+            int read = read(buffer);
+            if (read < 0) {
+                return 0;
+            }
+            return read;
+        } else {
+            assert remaining > 0;
+            long skipped = origin.skip(Math.min(n, remaining));
+            remaining -= skipped;
+            return skipped;
+        }
+    }
+
+    @Override
+    public int available() throws IOException {
+        return origin.available();
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+
+    @Override
+    public void close() throws IOException {
+        origin.close();
+    }
+
+    private void discardHead() throws IOException {
+        while (remaining > 0) {
+            int limit = (int) Math.min(buffer.length, remaining);
+            int read = origin.read(buffer, 0, limit);
+            if (read < 0) {
+                endOfRange = true;
+                break;
+            }
+            remaining -= read;
+            int index = findDelimiter(buffer, 0, read);
+            if (index >= 0) {
+                this.bufferOffset = index + 1;
+                this.bufferLimit = read;
+                return;
+            }
+        }
+        // delimiter not found
+        endOfRange = true;
+    }
+
+    private int fillFromBuffer(byte[] b, int off, int len) {
+        assert b != null;
+        if (isBufferRemaining()) {
+            int bufferLen = bufferLimit - bufferOffset;
+            assert bufferLen > 0;
+            int size = Math.min(len, bufferLen);
+            System.arraycopy(buffer, bufferOffset, b, off, size);
+            bufferOffset += size;
+            return size;
+        }
+        return 0;
+    }
+
+    private int findDelimiter(byte[] bytes, int offset, int length) {
+        assert bytes != null;
+        assert length >= 0;
+        for (int i = offset, n = offset + length; i < n; i++) {
+            if (isDelimiter(bytes[i])) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private boolean isBufferRemaining() {
+        return bufferOffset < bufferLimit;
+    }
+
+    private boolean isSoftLimitExceeded() {
+        return remaining == 0;
+    }
+
+    private boolean isDelimiter(int c) {
+        return c == delimiter;
+    }
+}


### PR DESCRIPTION
## Summary

This PR enables to revert the breaking compatible change of #835.

## Background, Problem or Goal of the patch

Since #835, `FragmentableDataFormat.getMinimumFragmentSize()` **MUST** return smaller value than the required minimum fragment size.

To revert this behavior, please set the following configuration to your **Hadoop configuration (like `asakusa-resources.xml`)**:

* `com.asakusafw.directio.COMPAT835` : `true`

Note that, this commit includes a copy of `com.asakusafw.runtime.directio.util.DelimiterRangeInputStream` as deprecated class, which was moved in #835. Note that, we recommended replace that class with `com.asakusafw.runtime.io.util.LineFeedDelimitedInputStream`.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #835
