### PR TITLE
better Hive version detection.

### DIFF
--- a/hive-project/core-stub/src/main/java/com/asakusafw/directio/hive/util/CompatibilityUtil.java
+++ b/hive-project/core-stub/src/main/java/com/asakusafw/directio/hive/util/CompatibilityUtil.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2011-2019 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.directio.hive.util;
+
+import java.text.MessageFormat;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hive.common.HiveVersionAnnotation;
+
+/**
+ * utilities about Hive v1/v2 compatibilities.
+ * @since 0.10.3
+ */
+public final class CompatibilityUtil {
+
+    static final Log LOG = LogFactory.getLog(CompatibilityUtil.class);
+
+    private static HiveVersionAnnotation version;
+    static {
+        version = Optional.ofNullable(HiveVersionAnnotation.class.getPackage())
+                .flatMap(it -> Optional.ofNullable(it.getAnnotation(HiveVersionAnnotation.class)))
+                .orElse(null);
+    }
+
+    private CompatibilityUtil() {
+        return;
+    }
+
+    /**
+     * returns the major version number of Hive.
+     * @return the major version, or {@code empty} if it is not sure
+     */
+    public static OptionalInt getHiveMajorVersion() {
+        if (version == null) {
+            if (LOG.isTraceEnabled()) {
+                LOG.trace("missing Hive version info");
+            }
+            return OptionalInt.empty();
+        }
+        // x.y.z
+        String shortVersion = version.shortVersion();
+        if (LOG.isTraceEnabled()) {
+            LOG.trace(MessageFormat.format("Hive version: {0}", shortVersion));
+        }
+        int firstDot = shortVersion.indexOf('.');
+        if (firstDot < 0) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(MessageFormat.format("cannot extract Hive major version: {0}", shortVersion));
+            }
+            return OptionalInt.empty();
+        }
+        try {
+            return OptionalInt.of(Integer.parseInt(shortVersion.substring(0, firstDot).trim()));
+        } catch (NumberFormatException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(MessageFormat.format("cannot extract Hive major version: {0}", shortVersion), e);
+            }
+            return OptionalInt.empty();
+        }
+    }
+}

--- a/hive-project/core-v1/src/main/java/com/asakusafw/directio/hive/orc/v1/CompatibilityV1.java
+++ b/hive-project/core-v1/src/main/java/com/asakusafw/directio/hive/orc/v1/CompatibilityV1.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -41,6 +42,7 @@ import com.asakusafw.directio.hive.orc.OrcFileOutput;
 import com.asakusafw.directio.hive.orc.OrcFormatConfiguration;
 import com.asakusafw.directio.hive.serde.DataModelInspector;
 import com.asakusafw.directio.hive.serde.DataModelMapping;
+import com.asakusafw.directio.hive.util.CompatibilityUtil;
 import com.asakusafw.runtime.directio.Counter;
 import com.asakusafw.runtime.directio.DirectInputFragment;
 import com.asakusafw.runtime.directio.hadoop.BlockMap;
@@ -58,6 +60,11 @@ public class CompatibilityV1 extends Compatibility {
 
     @Override
     protected int getPriority() {
+        OptionalInt version = CompatibilityUtil.getHiveMajorVersion();
+        if (version.isPresent()) {
+            int v = version.getAsInt();
+            return v == 0 || v == 1 ? 1 : -1;
+        }
         try {
             Class.forName("org.apache.hadoop.hive.ql.io.orc.OrcFile$OrcTableProperties"); //$NON-NLS-1$
             return 1;

--- a/hive-project/core-v1/src/main/java/com/asakusafw/directio/hive/parquet/v1/CompatibilityV1.java
+++ b/hive-project/core-v1/src/main/java/com/asakusafw/directio/hive/parquet/v1/CompatibilityV1.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -34,6 +35,7 @@ import com.asakusafw.directio.hive.parquet.AbstractParquetFileFormat;
 import com.asakusafw.directio.hive.parquet.Compatibility;
 import com.asakusafw.directio.hive.parquet.ParquetFormatConfiguration;
 import com.asakusafw.directio.hive.serde.DataModelMapping;
+import com.asakusafw.directio.hive.util.CompatibilityUtil;
 import com.asakusafw.runtime.directio.Counter;
 import com.asakusafw.runtime.directio.DirectInputFragment;
 import com.asakusafw.runtime.directio.hadoop.BlockMap;
@@ -58,6 +60,11 @@ public class CompatibilityV1 extends Compatibility {
 
     @Override
     protected int getPriority() {
+        OptionalInt version = CompatibilityUtil.getHiveMajorVersion();
+        if (version.isPresent()) {
+            int v = version.getAsInt();
+            return v == 0 || v == 1 ? 1 : -1;
+        }
         try {
             Class.forName("parquet.column.ParquetProperties"); //$NON-NLS-1$
             return 1;

--- a/hive-project/core-v2/src/main/java/com/asakusafw/directio/hive/orc/v2/CompatibilityV2.java
+++ b/hive-project/core-v2/src/main/java/com/asakusafw/directio/hive/orc/v2/CompatibilityV2.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -41,6 +42,7 @@ import com.asakusafw.directio.hive.orc.OrcFileOutput;
 import com.asakusafw.directio.hive.orc.OrcFormatConfiguration;
 import com.asakusafw.directio.hive.serde.DataModelInspector;
 import com.asakusafw.directio.hive.serde.DataModelMapping;
+import com.asakusafw.directio.hive.util.CompatibilityUtil;
 import com.asakusafw.runtime.directio.Counter;
 import com.asakusafw.runtime.directio.DirectInputFragment;
 import com.asakusafw.runtime.directio.hadoop.BlockMap;
@@ -58,6 +60,11 @@ public class CompatibilityV2 extends Compatibility {
 
     @Override
     protected int getPriority() {
+        OptionalInt version = CompatibilityUtil.getHiveMajorVersion();
+        if (version.isPresent()) {
+            int v = version.getAsInt();
+            return v == 2 ? 2 : -1;
+        }
         try {
             Class.forName("org.apache.orc.OrcConf"); //$NON-NLS-1$
             return 2;

--- a/hive-project/core-v2/src/main/java/com/asakusafw/directio/hive/parquet/v2/CompatibilityV2.java
+++ b/hive-project/core-v2/src/main/java/com/asakusafw/directio/hive/parquet/v2/CompatibilityV2.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -40,6 +41,7 @@ import com.asakusafw.directio.hive.parquet.AbstractParquetFileFormat;
 import com.asakusafw.directio.hive.parquet.Compatibility;
 import com.asakusafw.directio.hive.parquet.ParquetFormatConfiguration;
 import com.asakusafw.directio.hive.serde.DataModelMapping;
+import com.asakusafw.directio.hive.util.CompatibilityUtil;
 import com.asakusafw.runtime.directio.Counter;
 import com.asakusafw.runtime.directio.DirectInputFragment;
 import com.asakusafw.runtime.directio.hadoop.BlockMap;
@@ -57,6 +59,11 @@ public class CompatibilityV2 extends Compatibility {
 
     @Override
     protected int getPriority() {
+        OptionalInt version = CompatibilityUtil.getHiveMajorVersion();
+        if (version.isPresent()) {
+            int v = version.getAsInt();
+            return v == 2 ? 2 : -1;
+        }
         try {
             Class.forName("org.apache.parquet.column.ParquetProperties"); //$NON-NLS-1$
             return 2;


### PR DESCRIPTION
## Summary

This PR improves how detect version detection for #834.

## Background, Problem or Goal of the patch

#834 does not work correct for Asakusa on Spark.

## Design of the fix, or a new feature

This commit introduces `CompatibilityUtil`, which provides installed Hive version information via `HiveVersionAnnotation`.

## Related Issue, Pull Request or Code

* #834