### PR TITLE
Fix to work asakusafw.maxHeapSize in *compileBatchapps

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/tasks/AsakusaCompileTask.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/tasks/AsakusaCompileTask.groovy
@@ -424,12 +424,13 @@ class AsakusaCompileTask extends DefaultTask {
             project.mkdir getOutputDirectory()
         }
 
+        String javaMaxHeapSize = getMaxHeapSize()
         project.javaexec { JavaExecSpec spec ->
             spec.main = javaMain
             spec.classpath = javaClasspath
             spec.jvmArgs = getResolvedJvmArgs()
-            if (getMaxHeapSize() != null) {
-                spec.maxHeapSize = getMaxHeapSize()
+            if (javaMaxHeapSize != null) {
+                spec.maxHeapSize = javaMaxHeapSize
             }
             spec.systemProperties getResolvedSystemProperties()
             spec.systemProperties getExtraSystemProperties()


### PR DESCRIPTION
## Summary
This PR fixes `asakusafw.maxHeapSize` in `*compileBatchapps` task does not work.

## Background, Problem or Goal of the patch
 `asakusafw.maxHeapSize` works.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.