### PR TITLE
Change configure maven repository URL to use https

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
@@ -163,9 +163,9 @@ class AsakusafwBasePlugin implements Plugin<Project> {
 
     private void configureRepositories() {
         project.repositories {
-            maven { url "http://repo1.maven.org/maven2/" }
-            maven { url "http://asakusafw.s3.amazonaws.com/maven/releases" }
-            maven { url "http://asakusafw.s3.amazonaws.com/maven/snapshots" }
+            maven { url "https://repo.maven.apache.org/maven2/" }
+            maven { url "https://asakusafw.s3.amazonaws.com/maven/releases" }
+            maven { url "https://asakusafw.s3.amazonaws.com/maven/snapshots" }
         }
     }
 


### PR DESCRIPTION
## Summary
This PR changes maven repository URL protocol from `http` to `https` in Asakusa Gradle Plugin for batch application project configurations.

## Background, Problem or Goal of the patch
This prepares Maven Central plans to stop support communication over HTTP.

* https://central.sonatype.org/articles/2019/Apr/30/http-access-to-repo1mavenorg-and-repomavenapacheorg-is-being-deprecated/

## Design of the fix, or a new feature
This changes to use https for Maven Central, and this changes for Asakusa Framework maven repository on S3 as well.

Also, this changes Maven Central repository URL from `repo1.maven.org/maven2` to `repo.maven.apache.org/maven2` due to the Gradle current configurations as follows:

* https://github.com/gradle/gradle/pull/3464

## Related Issue, Pull Request or Code
N/A.