### PR TITLE
Change maven repository URL to use https in build configurations

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Bug reports, Patch contribution
 * Please report any issues to [repository for issue tracking](https://github.com/asakusafw/asakusafw-issues/issues)
-* Please contribute with patches according to our [contribution guide (Japanese only, English version to be added)](http://docs.asakusafw.com/latest/release/ja/html/contribution.html)
+* Please contribute with patches according to our [contribution guide (Japanese only, English version to be added)](https://docs.asakusafw.com/latest/release/ja/html/contribution.html)
 
 ## Template of Issues or Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Asakusa Framework
 
-Asakusa is a full stack framework for distributed/parallel computing, which provides with a development platform and runtime libraries supporting various distributed/parallel computing environments such as [Hadoop](http://hadoop.apache.org), [Spark](http://spark.apache.org), [M<sup>3</sup> for Batch Processing](https://github.com/fixstars/m3bp), and so on. Users can enjoy the best performance on distributed/parallel computing transparently changing execution engines among MapReduce, SparkRDD, and C++ native based on their data size.
+Asakusa is a full stack framework for distributed/parallel computing, which provides with a development platform and runtime libraries supporting various distributed/parallel computing environments such as [Hadoop](https://hadoop.apache.org), [Spark](https://spark.apache.org), [M<sup>3</sup> for Batch Processing](https://github.com/fixstars/m3bp), and so on. Users can enjoy the best performance on distributed/parallel computing transparently changing execution engines among MapReduce, SparkRDD, and C++ native based on their data size.
 
 Other than query-based languages, Asakusa helps to develop more complicated data flow programs more easily, efficiently, and comprehensively due to following components.
 
@@ -91,12 +91,12 @@ And then import existing projects from Eclipse.
 * [Shafu](https://github.com/asakusafw/asakusafw-shafu)
 
 ## Resources
-* [Asakusa Framework Documentation (ja)](http://docs.asakusafw.com/)
-* [Asakusa Framework Community Site (ja)](http://asakusafw.com)
+* [Asakusa Framework Documentation (ja)](https://docs.asakusafw.com/)
+* [Asakusa Framework Community Site (ja)](https://asakusafw.com)
 
 ## Bug reports, Patch contribution
 * Please report any issues to [repository for issue tracking](https://github.com/asakusafw/asakusafw-issues/issues)
-* Please contribute with patches according to our [contribution guide (Japanese only, English version to be added)](http://docs.asakusafw.com/latest/release/ja/html/contribution.html)
+* Please contribute with patches according to our [contribution guide (Japanese only, English version to be added)](https://docs.asakusafw.com/latest/release/ja/html/contribution.html)
 
 ## License
 * [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -7,7 +7,7 @@
   <version>0.10.4-SNAPSHOT</version>
 
   <description>Asakusa Framework Build Tools</description>
-  <url>http://asakusafw.com</url>
+  <url>https://asakusafw.com</url>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -23,7 +23,7 @@
   <inceptionYear>2011</inceptionYear>
   <organization>
     <name>Asakusa Framework Team</name>
-    <url>http://asakusafw.com</url>
+    <url>https://asakusafw.com</url>
   </organization>
 
   <distributionManagement>

--- a/build-tools/src/main/javadoc/overview-summary.html
+++ b/build-tools/src/main/javadoc/overview-summary.html
@@ -8,6 +8,6 @@ Asakusa is a Hadoop-based Enterprise Batch Processing Framework, to improve the 
 <p>
 Asakusa consists of the following components: (1) Asakusa DSL compiler, (2) a data model generator for Hadoop data format, and (3) integrated test suites tools. Asakusa DSL compiler compiles the DSLs (multi-layered DSLs, business workflow DSL, logic flow DSL, and data operator DSL) into MapReduce programs. The data model generator takes a simple DSL script (data model definition language: DMDL) or RDBMS schema as an input, and generates the Hadoop I/O classes and the corresponding test templates. For the ease of the development, the test suite tools integrate the Asakusa DSL compiler and data model generator.
 </p>
-@see <a href="http://docs.asakusafw.com/latest/release/ja/html/index.html">Asakusa Framework Documentaion (ja)</a>
-@see <a href="http://asakusafw.com">Asakusa Framework Community Site (ja)</a>
+@see <a href="https://docs.asakusafw.com/latest/release/ja/html/index.html">Asakusa Framework Documentaion (ja)</a>
+@see <a href="https://asakusafw.com">Asakusa Framework Community Site (ja)</a>
 </body>

--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -62,8 +62,8 @@ repositories {
         mavenLocal()
     }
     mavenCentral()
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
 }
 
 dependencies {

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -41,8 +41,8 @@ repositories {
         mavenLocal()
     }
     mavenCentral()
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }
 

--- a/integration/src/integration-test/data/directio-tools/build.gradle
+++ b/integration/src/integration-test/data/directio-tools/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         if (System.getProperty("maven.local", "true") == "true") {
             mavenLocal()
         }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw', name: 'asakusa-gradle-plugins', version: System.getProperty("asakusafw.version")

--- a/integration/src/integration-test/data/organizer-simple/build.gradle
+++ b/integration/src/integration-test/data/organizer-simple/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         if (System.getProperty("maven.local", "true") == "true") {
             mavenLocal()
         }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw', name: 'asakusa-gradle-plugins', version: System.getProperty("asakusafw.version")

--- a/integration/src/integration-test/data/sdk-eclipse/build.gradle
+++ b/integration/src/integration-test/data/sdk-eclipse/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         if (System.getProperty("maven.local", "true") == "true") {
             mavenLocal()
         }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw', name: 'asakusa-gradle-plugins', version: System.getProperty("asakusafw.version")

--- a/integration/src/integration-test/data/sdk-simple/build.gradle
+++ b/integration/src/integration-test/data/sdk-simple/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         if (System.getProperty("maven.local", "true") == "true") {
             mavenLocal()
         }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw', name: 'asakusa-gradle-plugins', version: System.getProperty("asakusafw.version")

--- a/integration/src/integration-test/data/simple/build.gradle
+++ b/integration/src/integration-test/data/simple/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         if (System.getProperty("maven.local", "true") == "true") {
             mavenLocal()
         }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw', name: 'asakusa-gradle-plugins', version: System.getProperty("asakusafw.version")

--- a/integration/src/integration-test/data/windgate/build.gradle
+++ b/integration/src/integration-test/data/windgate/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         if (System.getProperty("maven.local", "true") == "true") {
             mavenLocal()
         }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw', name: 'asakusa-gradle-plugins', version: System.getProperty("asakusafw.version")

--- a/integration/src/integration-test/data/yaess/build.gradle
+++ b/integration/src/integration-test/data/yaess/build.gradle
@@ -5,8 +5,8 @@ buildscript {
         if (System.getProperty("maven.local", "true") == "true") {
             mavenLocal()
         }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-        maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+        maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     }
     dependencies {
         classpath group: 'com.asakusafw', name: 'asakusa-gradle-plugins', version: System.getProperty("asakusafw.version")

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <packaging>pom</packaging>
 
   <description>Asakusa Framework Parent POM</description>
-  <url>http://asakusafw.com</url>
+  <url>https://asakusafw.com</url>
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
@@ -20,7 +20,7 @@
   <inceptionYear>2011</inceptionYear>
   <organization>
     <name>Asakusa Framework Team</name>
-    <url>http://asakusafw.com</url>
+    <url>https://asakusafw.com</url>
   </organization>
 
   <scm>
@@ -169,7 +169,7 @@
     <repository>
       <id>central</id>
       <name>Central Repository</name>
-      <url>http://repo.maven.apache.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
       <layout>default</layout>
       <snapshots>
         <enabled>false</enabled>
@@ -178,7 +178,7 @@
     <repository>
       <id>com.asakusafw.releases</id>
       <name>Asakusa Framework Repository</name>
-      <url>http://asakusafw.s3.amazonaws.com/maven/releases</url>
+      <url>https://asakusafw.s3.amazonaws.com/maven/releases</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -186,7 +186,7 @@
     <repository>
       <id>com.asakusafw.snapshots</id>
       <name>Asakusa Framework Snapshot Repository</name>
-      <url>http://asakusafw.s3.amazonaws.com/maven/snapshots</url>
+      <url>https://asakusafw.s3.amazonaws.com/maven/snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>
@@ -213,7 +213,7 @@
     <pluginRepository>
       <id>central</id>
       <name>Central Repository</name>
-      <url>http://repo.maven.apache.org/maven2</url>
+      <url>https://repo.maven.apache.org/maven2</url>
       <layout>default</layout>
       <snapshots>
         <enabled>false</enabled>
@@ -225,7 +225,7 @@
     <pluginRepository>
       <id>com.asakusafw.releases</id>
       <name>Asakusa Framework Repository</name>
-      <url>http://asakusafw.s3.amazonaws.com/maven/releases</url>
+      <url>https://asakusafw.s3.amazonaws.com/maven/releases</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -233,7 +233,7 @@
     <pluginRepository>
       <id>com.asakusafw.snapshots</id>
       <name>Asakusa Framework Snapshot Repository</name>
-      <url>http://asakusafw.s3.amazonaws.com/maven/snapshots</url>
+      <url>https://asakusafw.s3.amazonaws.com/maven/snapshots</url>
       <releases>
         <enabled>false</enabled>
       </releases>

--- a/utils-project/gradle-launcher/README.md
+++ b/utils-project/gradle-launcher/README.md
@@ -27,8 +27,8 @@ This artifact provides an easy way of Gradle access to your program.
 ```gradle
 repositories {
     mavenCentral()
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
-    maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/releases' }
+    maven { url 'https://asakusafw.s3.amazonaws.com/maven/snapshots' }
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }
 


### PR DESCRIPTION
## Summary
This PR changes maven repository URL protocol from http to https in `pom.xml` and `build.gradle` for framework build configurations.
This also changes link URL to https in documentation files.

## Background, Problem or Goal of the patch
Follow-up asakusafw/asakusafw#845

## Design of the fix, or a new feature
The same as asakusafw/asakusafw#845

## Related Issue, Pull Request or Code
N/A.
