### PR TITLE
Remove testcase in AsakusaUpgradeTest for v1.12

### DIFF
--- a/gradle/src/test/groovy/com/asakusafw/gradle/plugins/AsakusaUpgradeTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/gradle/plugins/AsakusaUpgradeTest.groovy
@@ -118,14 +118,6 @@ class AsakusaUpgradeTest {
         doUpgradeFromTestName()
     }
 
-    /**
-     * Test for {@code 1.12} (Asakusa {@code 0.6.0}).
-     */
-    @Test
-    void 'v1.12'() {
-        doUpgradeFromTestName()
-    }
-
     private void doUpgradeFromTestName() {
         doUpgrade(testName.methodName.replaceFirst('v', ''))
     }


### PR DESCRIPTION
## Summary
This PR removes testcase `AsakusaUpgradeTest` -> `v1.12`.

## Background, Problem or Goal of the patch
Gradle version 1.12 (tooling API) uses HTTP protocol for dependency resolution, but Maven Central already disable HTTP and now only HTTPS enabled.

## Design of the fix, or a new feature
Remove this testcase.  `AsakusaUpgradeTest` -> `v1.12` is almost unnecessary at the moment, as it's for migration from a very old version (Asakusa 0.6.0). 

## Related Issue, Pull Request or Code
